### PR TITLE
feat: escalation: loop limit + human notification

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,16 +10,14 @@ Update this file when opening, completing, or blocking an issue.
 ---
 
 ## Ready to Start
-- #32 judges/quality: e2e + intent check vs original task
-- #34 escalation: loop limit + human notification
 - #38 github/verdict: post structured judge verdict as PR comment
+- #33 phases/quality: quality phase orchestration
 
 ## In Progress
 - none
 
 ## Blocked
-- #33 phases/quality: quality phase orchestration (blocked on #32)
-- #35 cmd: wire quality phase + escalation into vairdict run (blocked on #33, #34)
+- #35 cmd: wire quality phase + escalation into vairdict run (blocked on #33)
 - #36 dogfood: first full three-phase task on vairdict (blocked on #35)
 - #39 cmd/auto-vairdict: auto-merge on passing verdict (blocked on M3 complete)
 
@@ -39,6 +37,8 @@ Update this file when opening, completing, or blocking an issue.
 - #21 phases/code: code phase orchestration
 - #23 dogfood: plan + code phases e2e
 - #29 auth: ~/.config/vairdict/ API key configuration
+- #32 judges/quality: e2e + intent check vs original task
+- #34 escalation: loop limit + human notification
 
 ---
 
@@ -132,6 +132,6 @@ reviewed by the agent judge, only then created in GitHub.
 | M0        | done        | 1/1         |
 | M1        | done        | 9/9         |
 | M2        | done        | 6/6         |
-| M3        | in progress | 0/6         |
+| M3        | in progress | 2/6         |
 | M4        | not started | 0/6         |
 | M5+       | not started | —           |

--- a/internal/escalation/escalation.go
+++ b/internal/escalation/escalation.go
@@ -1,0 +1,142 @@
+// Package escalation handles loop-limit exhaustion: when a phase fails after
+// max attempts, this package transitions the task to the escalated state and
+// notifies a human via the configured channel (stdout or GitHub PR comment).
+//
+// This package intentionally does not import internal/github to avoid coupling.
+// Callers pass a PRCommenter (which *github.Client satisfies) when notifying
+// via the github channel.
+package escalation
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// PRCommenter is the minimal interface required to post a comment on a PR.
+// *github.Client satisfies this; tests provide a fake implementation.
+type PRCommenter interface {
+	AddComment(ctx context.Context, prNumber int, body string) error
+}
+
+// Result is the data the escalator needs from a failing phase.
+type Result struct {
+	Phase     state.Phase
+	Loops     int
+	LastScore float64
+	Gaps      []state.Gap
+	// PRNumber is optional. When zero and NotifyVia is "github", the
+	// escalator falls back to stdout so the message is never lost.
+	PRNumber int
+}
+
+// Escalate transitions the task to the escalated state, formats a summary,
+// and dispatches it via the configured channel.
+//
+// out is used for stdout-channel writes (and as the github-channel fallback
+// when no PR exists). gh is required only when NotifyVia is "github" and
+// PRNumber is non-zero; it may otherwise be nil.
+func Escalate(
+	ctx context.Context,
+	task *state.Task,
+	result Result,
+	cfg config.EscalationConfig,
+	out io.Writer,
+	gh PRCommenter,
+) error {
+	if task == nil {
+		return fmt.Errorf("escalate: task is nil")
+	}
+	if out == nil {
+		return fmt.Errorf("escalate: out writer is nil")
+	}
+
+	if task.State != state.StateEscalated {
+		if err := task.Transition(state.StateEscalated); err != nil {
+			return fmt.Errorf("transitioning task %s to escalated: %w", task.ID, err)
+		}
+	}
+
+	summary := FormatSummary(task, result)
+
+	channel := cfg.NotifyVia
+	if channel == "" {
+		channel = "stdout"
+	}
+
+	switch channel {
+	case "stdout":
+		if _, err := fmt.Fprintln(out, summary); err != nil {
+			return fmt.Errorf("writing escalation to stdout: %w", err)
+		}
+	case "github":
+		if result.PRNumber == 0 {
+			slog.Warn("github escalation requested but no PR number — falling back to stdout",
+				"task", task.ID,
+			)
+			if _, err := fmt.Fprintln(out, summary); err != nil {
+				return fmt.Errorf("writing escalation fallback to stdout: %w", err)
+			}
+		} else {
+			if gh == nil {
+				return fmt.Errorf("github escalation requested but no PR commenter provided")
+			}
+			if err := gh.AddComment(ctx, result.PRNumber, summary); err != nil {
+				return fmt.Errorf("posting escalation comment to PR #%d: %w", result.PRNumber, err)
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported escalation channel %q (supported: stdout, github)", channel)
+	}
+
+	slog.Info("task escalated",
+		"task", task.ID,
+		"phase", result.Phase,
+		"loops", result.Loops,
+		"last_score", result.LastScore,
+		"channel", channel,
+	)
+	return nil
+}
+
+// FormatSummary builds a human-readable escalation message describing the
+// failure: which phase, how many loops, last score, and any blocking gaps.
+// Output is plain markdown so it renders nicely as a GitHub comment.
+func FormatSummary(task *state.Task, result Result) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "## ⚠️ VAIrdict Escalation\n\n")
+	fmt.Fprintf(&b, "**Task:** `%s`\n", task.ID)
+	if task.Intent != "" {
+		fmt.Fprintf(&b, "**Intent:** %s\n", task.Intent)
+	}
+	if result.Phase != "" {
+		fmt.Fprintf(&b, "**Failed phase:** %s\n", result.Phase)
+	}
+	fmt.Fprintf(&b, "**Loops used:** %d\n", result.Loops)
+	fmt.Fprintf(&b, "**Last score:** %.0f%%\n\n", result.LastScore)
+
+	blocking := make([]state.Gap, 0, len(result.Gaps))
+	for _, g := range result.Gaps {
+		if g.Blocking {
+			blocking = append(blocking, g)
+		}
+	}
+
+	if len(blocking) > 0 {
+		b.WriteString("### Blocking gaps\n")
+		for _, g := range blocking {
+			fmt.Fprintf(&b, "- **[%s]** %s\n", g.Severity, g.Description)
+		}
+	} else {
+		b.WriteString("_No blocking gaps recorded._\n")
+	}
+
+	b.WriteString("\nHuman intervention required.\n")
+	return b.String()
+}

--- a/internal/escalation/escalation_test.go
+++ b/internal/escalation/escalation_test.go
@@ -1,0 +1,406 @@
+package escalation
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// fakePRCommenter records calls and returns a configurable error.
+type fakePRCommenter struct {
+	calls []fakeCall
+	err   error
+}
+
+type fakeCall struct {
+	prNumber int
+	body     string
+}
+
+func (f *fakePRCommenter) AddComment(_ context.Context, prNumber int, body string) error {
+	f.calls = append(f.calls, fakeCall{prNumber: prNumber, body: body})
+	return f.err
+}
+
+// taskInReviewState builds a task that has reached plan_review (a valid
+// origin for transition to escalated).
+func taskInReviewState(t *testing.T) *state.Task {
+	t.Helper()
+	task := state.NewTask("abc12345", "build a thing")
+	if err := task.Transition(state.StatePlanning); err != nil {
+		t.Fatalf("transition to planning: %v", err)
+	}
+	if err := task.Transition(state.StatePlanReview); err != nil {
+		t.Fatalf("transition to plan_review: %v", err)
+	}
+	return task
+}
+
+func sampleResult() Result {
+	return Result{
+		Phase:     state.PhasePlan,
+		Loops:     3,
+		LastScore: 42,
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP0, Description: "missing auth requirement", Blocking: true},
+			{Severity: state.SeverityP2, Description: "minor doc nit", Blocking: false},
+			{Severity: state.SeverityP1, Description: "no error handling", Blocking: true},
+		},
+	}
+}
+
+func TestEscalate_StdoutDefault(t *testing.T) {
+	task := taskInReviewState(t)
+	var buf bytes.Buffer
+
+	err := Escalate(
+		context.Background(),
+		task,
+		sampleResult(),
+		config.EscalationConfig{}, // empty NotifyVia → stdout default
+		&buf,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("expected stdout output, got empty buffer")
+	}
+	if task.State != state.StateEscalated {
+		t.Errorf("expected task state escalated, got %s", task.State)
+	}
+}
+
+func TestEscalate_StdoutExplicit(t *testing.T) {
+	task := taskInReviewState(t)
+	var buf bytes.Buffer
+
+	err := Escalate(
+		context.Background(),
+		task,
+		sampleResult(),
+		config.EscalationConfig{NotifyVia: "stdout"},
+		&buf,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "VAIrdict Escalation") {
+		t.Errorf("expected escalation header in output: %s", out)
+	}
+	if !strings.Contains(out, "abc12345") {
+		t.Errorf("expected task id in output")
+	}
+	if !strings.Contains(out, "build a thing") {
+		t.Errorf("expected intent in output")
+	}
+}
+
+func TestEscalate_GitHubHappyPath(t *testing.T) {
+	task := taskInReviewState(t)
+	var buf bytes.Buffer
+	gh := &fakePRCommenter{}
+
+	result := sampleResult()
+	result.PRNumber = 42
+
+	err := Escalate(
+		context.Background(),
+		task,
+		result,
+		config.EscalationConfig{NotifyVia: "github"},
+		&buf,
+		gh,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gh.calls) != 1 {
+		t.Fatalf("expected 1 PR comment, got %d", len(gh.calls))
+	}
+	if gh.calls[0].prNumber != 42 {
+		t.Errorf("expected PR number 42, got %d", gh.calls[0].prNumber)
+	}
+	if !strings.Contains(gh.calls[0].body, "VAIrdict Escalation") {
+		t.Errorf("expected escalation body posted to PR")
+	}
+	// stdout should NOT be used in github happy path.
+	if buf.Len() != 0 {
+		t.Errorf("expected empty stdout, got %q", buf.String())
+	}
+}
+
+func TestEscalate_GitHubNoPRFallsBackToStdout(t *testing.T) {
+	task := taskInReviewState(t)
+	var buf bytes.Buffer
+	gh := &fakePRCommenter{}
+
+	result := sampleResult()
+	result.PRNumber = 0 // no PR yet
+
+	err := Escalate(
+		context.Background(),
+		task,
+		result,
+		config.EscalationConfig{NotifyVia: "github"},
+		&buf,
+		gh,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("expected no PR comments, got %d", len(gh.calls))
+	}
+	if buf.Len() == 0 {
+		t.Error("expected fallback stdout output")
+	}
+}
+
+func TestEscalate_GitHubMissingClient(t *testing.T) {
+	task := taskInReviewState(t)
+	var buf bytes.Buffer
+
+	result := sampleResult()
+	result.PRNumber = 99
+
+	err := Escalate(
+		context.Background(),
+		task,
+		result,
+		config.EscalationConfig{NotifyVia: "github"},
+		&buf,
+		nil, // PRNumber set but no client
+	)
+	if err == nil {
+		t.Fatal("expected error when github channel used without commenter")
+	}
+	if !strings.Contains(err.Error(), "no PR commenter") {
+		t.Errorf("error should mention missing commenter, got: %v", err)
+	}
+}
+
+func TestEscalate_GitHubClientError(t *testing.T) {
+	task := taskInReviewState(t)
+	var buf bytes.Buffer
+	gh := &fakePRCommenter{err: errors.New("api down")}
+
+	result := sampleResult()
+	result.PRNumber = 7
+
+	err := Escalate(
+		context.Background(),
+		task,
+		result,
+		config.EscalationConfig{NotifyVia: "github"},
+		&buf,
+		gh,
+	)
+	if err == nil {
+		t.Fatal("expected error when commenter fails")
+	}
+	if !strings.Contains(err.Error(), "api down") {
+		t.Errorf("expected wrapped client error, got: %v", err)
+	}
+}
+
+func TestEscalate_UnknownChannel(t *testing.T) {
+	task := taskInReviewState(t)
+	var buf bytes.Buffer
+
+	err := Escalate(
+		context.Background(),
+		task,
+		sampleResult(),
+		config.EscalationConfig{NotifyVia: "carrier-pigeon"},
+		&buf,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for unsupported channel")
+	}
+	if !strings.Contains(err.Error(), "carrier-pigeon") {
+		t.Errorf("expected error to mention bad channel, got: %v", err)
+	}
+}
+
+func TestEscalate_TransitionsToEscalated(t *testing.T) {
+	task := taskInReviewState(t)
+	if task.State == state.StateEscalated {
+		t.Fatal("precondition: task should not start escalated")
+	}
+	var buf bytes.Buffer
+
+	if err := Escalate(
+		context.Background(),
+		task,
+		sampleResult(),
+		config.EscalationConfig{NotifyVia: "stdout"},
+		&buf,
+		nil,
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if task.State != state.StateEscalated {
+		t.Errorf("expected escalated state, got %s", task.State)
+	}
+}
+
+func TestEscalate_AlreadyEscalatedNoOp(t *testing.T) {
+	task := taskInReviewState(t)
+	if err := task.Transition(state.StateEscalated); err != nil {
+		t.Fatalf("setup transition: %v", err)
+	}
+	var buf bytes.Buffer
+
+	// Should still notify even though state was already escalated.
+	if err := Escalate(
+		context.Background(),
+		task,
+		sampleResult(),
+		config.EscalationConfig{NotifyVia: "stdout"},
+		&buf,
+		nil,
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if task.State != state.StateEscalated {
+		t.Errorf("expected state to remain escalated")
+	}
+	if buf.Len() == 0 {
+		t.Error("expected notification even when already escalated")
+	}
+}
+
+func TestEscalate_InvalidStateReturnsError(t *testing.T) {
+	// Pending state cannot transition directly to escalated.
+	task := state.NewTask("xx", "test")
+	var buf bytes.Buffer
+
+	err := Escalate(
+		context.Background(),
+		task,
+		sampleResult(),
+		config.EscalationConfig{NotifyVia: "stdout"},
+		&buf,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error transitioning from pending to escalated")
+	}
+	if !strings.Contains(err.Error(), "transitioning") {
+		t.Errorf("expected transition error, got: %v", err)
+	}
+}
+
+func TestEscalate_NilTask(t *testing.T) {
+	var buf bytes.Buffer
+	err := Escalate(
+		context.Background(),
+		nil,
+		sampleResult(),
+		config.EscalationConfig{NotifyVia: "stdout"},
+		&buf,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for nil task")
+	}
+}
+
+func TestEscalate_NilWriter(t *testing.T) {
+	task := taskInReviewState(t)
+	err := Escalate(
+		context.Background(),
+		task,
+		sampleResult(),
+		config.EscalationConfig{NotifyVia: "stdout"},
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for nil writer")
+	}
+}
+
+func TestFormatSummary_ContainsAllFields(t *testing.T) {
+	task := state.NewTask("task-99", "implement quality phase")
+	result := Result{
+		Phase:     state.PhaseQuality,
+		Loops:     3,
+		LastScore: 55.7,
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP0, Description: "intent mismatch", Blocking: true},
+		},
+	}
+
+	got := FormatSummary(task, result)
+
+	cases := []string{
+		"VAIrdict Escalation",
+		"task-99",
+		"implement quality phase",
+		"quality",
+		"Loops used:** 3",
+		"56", // 55.7 rounds to 56 with %.0f
+		"Blocking gaps",
+		"P0",
+		"intent mismatch",
+		"Human intervention required",
+	}
+	for _, want := range cases {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q\n--- summary ---\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatSummary_OnlyBlockingGapsListed(t *testing.T) {
+	task := state.NewTask("t1", "intent")
+	result := Result{
+		Phase: state.PhaseCode,
+		Loops: 2,
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP0, Description: "blocking-one", Blocking: true},
+			{Severity: state.SeverityP2, Description: "non-blocking-nit", Blocking: false},
+			{Severity: state.SeverityP3, Description: "deferred-thing", Blocking: false},
+		},
+	}
+
+	got := FormatSummary(task, result)
+
+	if !strings.Contains(got, "blocking-one") {
+		t.Error("expected blocking gap in summary")
+	}
+	if strings.Contains(got, "non-blocking-nit") {
+		t.Error("non-blocking gaps must not appear in summary")
+	}
+	if strings.Contains(got, "deferred-thing") {
+		t.Error("deferred gaps must not appear in summary")
+	}
+}
+
+func TestFormatSummary_NoBlockingGapsPlaceholder(t *testing.T) {
+	task := state.NewTask("t1", "intent")
+	result := Result{
+		Phase: state.PhaseCode,
+		Loops: 1,
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP2, Description: "minor", Blocking: false},
+		},
+	}
+
+	got := FormatSummary(task, result)
+	if !strings.Contains(got, "No blocking gaps recorded") {
+		t.Errorf("expected placeholder when no blocking gaps, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Issue
Closes #34

## What was built
Adds `internal/escalation` package with `Escalate` function that handles phase loop-limit exhaustion:
- Transitions the task to `escalated` state
- Formats a structured markdown summary (task, intent, failed phase, loops, last score, blocking gaps)
- Dispatches via configured channel: `stdout` (default) or `github` (PR comment)
- Falls back to stdout when `github` is requested but no PR exists, so notifications are never lost

Decoupled from `internal/github` via a small `PRCommenter` interface — `*github.Client` satisfies it without the escalation package importing gh.

## Out of scope
- Wiring into `cmd/run.go` — that's #35
- Slack channel — that's M7

## Tests
15 tests covering: stdout default + explicit, github happy path, github→stdout fallback, missing client, client error, unknown channel, state transition, already-escalated no-op, invalid state, nil task/writer guards, summary content/blocking-only/placeholder.

## Note
This supersedes PR #37 (an earlier vairdict run on the same issue that was never merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)