### PR TITLE
feat: sectioned ui output, gh stderr capture, per-task log files

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,9 +10,6 @@ Update this file when opening, completing, or blocking an issue.
 ---
 
 ## Ready to Start
-- #43 ui: human-readable cli output mode + --output flag
-- #44 cmd: capture gh CLI stderr in error messages
-- #45 logs: write run logs to ~/.vairdict/logs/<task>.log
 - #47 agents/claudecli: completer that wraps `claude -p` (no API key needed locally)
 - #48 cmd: `vairdict review <pr>` — judge an existing PR
 - #49 config: ci-specific overlay (vairdict.ci.yaml)
@@ -20,7 +17,9 @@ Update this file when opening, completing, or blocking an issue.
 - #51 test: orchestration coverage for runTask + runQualityPhase (DI refactor)
 
 ## In Progress
-- none
+- #43 ui: human-readable cli output mode + --output flag
+- #44 cmd: capture gh CLI stderr in error messages
+- #45 logs: write run logs to ~/.vairdict/logs/<task>.log
 
 ## Blocked
 - #39 cmd/auto-vairdict: auto-merge on passing verdict (blocked on M3 complete)

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -24,6 +24,7 @@ import (
 	planphase "github.com/vairdict/vairdict/internal/phases/plan"
 	qualityphase "github.com/vairdict/vairdict/internal/phases/quality"
 	"github.com/vairdict/vairdict/internal/state"
+	"github.com/vairdict/vairdict/internal/ui"
 )
 
 const (
@@ -31,7 +32,12 @@ const (
 	exitEscalation = 2
 )
 
-var issueFlag int
+var (
+	issueFlag  int
+	outputFlag string
+	colorsFlag string
+	asciiFlag  bool
+)
 
 var runCmd = &cobra.Command{
 	Use:   "run [intent]",
@@ -45,25 +51,35 @@ Use --issue to fetch the intent from a GitHub issue:
   vairdict run --issue 32`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		mode, err := ui.ParseMode(outputFlag)
+		if err != nil {
+			return err
+		}
+		colors, err := ui.ParseColorScheme(colorsFlag)
+		if err != nil {
+			return err
+		}
+
 		var intent string
 		if issueFlag > 0 {
-			var err error
 			intent, err = fetchIssueIntent(issueFlag)
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Issue #%d: %s\n", issueFlag, intent)
 		} else if len(args) == 1 {
 			intent = args[0]
 		} else {
 			return fmt.Errorf("provide an intent argument or use --issue")
 		}
-		return runTask(intent)
+		return runTask(intent, mode, colors, asciiFlag)
 	},
 }
 
 func init() {
 	runCmd.Flags().IntVar(&issueFlag, "issue", 0, "GitHub issue number to use as intent")
+	runCmd.Flags().StringVar(&outputFlag, "output", "", "output mode: cli|ci|json (default: auto-detect)")
+	runCmd.Flags().StringVar(&colorsFlag, "colors", "", "color scheme: default|accessible|no-color (default: auto-detect)")
+	runCmd.Flags().BoolVar(&asciiFlag, "ascii", false, "use ASCII glyphs instead of unicode emoji")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -81,7 +97,7 @@ func execCommand(name string, args ...string) ([]byte, error) {
 	return cmd.Output()
 }
 
-func runTask(intent string) error {
+func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) error {
 	// Load config.
 	cfg, err := config.LoadConfig("vairdict.yaml")
 	if err != nil {
@@ -114,6 +130,36 @@ func runTask(intent string) error {
 		return fmt.Errorf("creating task: %w", err)
 	}
 
+	// Open per-task log file and route slog into it. Falls back to the
+	// existing handler if $HOME is unwritable so we never block a run on
+	// log-file creation.
+	logFile, logErr := ui.OpenLogFile(task.ID)
+	logPath := ""
+	if logErr == nil {
+		slog.SetDefault(slog.New(logFile.Handler()))
+		logPath = logFile.Path()
+		defer func() { _ = logFile.Close() }()
+	} else {
+		slog.Warn("falling back to default log handler", "error", logErr)
+	}
+
+	// Build renderer. Auto-detects mode/colors based on TTY when flags
+	// are empty; respects NO_COLOR per no-color.org.
+	r := ui.New(ui.Options{
+		Mode:       mode,
+		Colors:     colors,
+		ASCII:      ascii,
+		IsTTY:      ui.IsTerminal(os.Stdout),
+		NoColorEnv: ui.NoColorEnv(),
+		Out:        os.Stdout,
+	})
+	defer func() { _ = r.Close() }()
+
+	r.RunStart(task.ID, intent, logPath)
+	if issueFlag > 0 {
+		r.Note("issue", fmt.Sprintf("#%d", issueFlag))
+	}
+
 	slog.Info("task created", "id", task.ID, "intent", intent)
 
 	// Set up context with signal handling.
@@ -130,54 +176,59 @@ func runTask(intent string) error {
 	ghClient := github.New(ghRunner)
 
 	// --- Plan phase ---
-	planResult, err := runPlanPhase(ctx, cfg, client, store, task)
+	planResult, err := runPlanPhase(ctx, cfg, client, store, task, r)
 	if err != nil {
+		r.Error(err)
 		return err
 	}
 
 	if planResult.Escalate {
+		gaps := lastGapsForPhase(task, state.PhasePlan)
+		r.Escalation(task.ID, state.PhasePlan, planResult.Loops, planResult.LastScore, gaps)
 		return escalateAndExit(ctx, task, escalation.Result{
 			Phase:     state.PhasePlan,
 			Loops:     planResult.Loops,
 			LastScore: planResult.LastScore,
-			Gaps:      lastGapsForPhase(task, state.PhasePlan),
+			Gaps:      gaps,
 		}, cfg.Escalation, ghClient)
 	}
-
-	fmt.Printf("\nTask %s completed plan phase (score: %.0f%%, loops: %d)\n", task.ID, planResult.LastScore, planResult.Loops)
 
 	// --- Create branch before code phase so commits land on it ---
 	branch, err := ghClient.CreateBranch(ctx, task.ID)
 	if err != nil {
+		r.Error(err)
 		return fmt.Errorf("creating branch: %w", err)
 	}
-	fmt.Printf("-> Branch created: %s\n", branch)
+	r.Note("branch", branch)
 
 	// --- Code phase ---
-	codeResult, err := runCodePhase(ctx, cfg, store, task, planResult.Plan, workDir)
+	codeResult, err := runCodePhase(ctx, cfg, store, task, planResult.Plan, workDir, r)
 	if err != nil {
+		r.Error(err)
 		return err
 	}
 
 	if codeResult.Escalate {
+		gaps := lastGapsForPhase(task, state.PhaseCode)
+		r.Escalation(task.ID, state.PhaseCode, codeResult.Loops, codeResult.LastScore, gaps)
 		return escalateAndExit(ctx, task, escalation.Result{
 			Phase:     state.PhaseCode,
 			Loops:     codeResult.Loops,
 			LastScore: codeResult.LastScore,
-			Gaps:      lastGapsForPhase(task, state.PhaseCode),
+			Gaps:      gaps,
 		}, cfg.Escalation, ghClient)
 	}
 
-	fmt.Printf("\nTask %s completed code phase (score: %.0f%%, loops: %d)\n", task.ID, codeResult.LastScore, codeResult.Loops)
-
 	// --- Commit any changes the coder made ---
-	if err := commitChanges(ctx, task, workDir); err != nil {
+	if err := commitChanges(ctx, task, workDir, r); err != nil {
+		r.Error(err)
 		return err
 	}
 
 	// --- Quality phase (gates the PR) ---
-	qualityResult, err := runQualityPhase(ctx, cfg, client, store, task, planResult.Plan, workDir)
+	qualityResult, err := runQualityPhase(ctx, cfg, client, store, task, planResult.Plan, workDir, r)
 	if err != nil {
+		r.Error(err)
 		return err
 	}
 
@@ -187,19 +238,20 @@ func runTask(intent string) error {
 		// a follow-up issue (see PROGRESS.md). The escalation summary
 		// includes the blocking gaps so the human knows code rework is
 		// needed.
+		gaps := lastGapsForPhase(task, state.PhaseQuality)
+		r.Escalation(task.ID, state.PhaseQuality, qualityResult.Loops, qualityResult.LastScore, gaps)
 		return escalateAndExit(ctx, task, escalation.Result{
 			Phase:     state.PhaseQuality,
 			Loops:     qualityResult.Loops,
 			LastScore: qualityResult.LastScore,
-			Gaps:      lastGapsForPhase(task, state.PhaseQuality),
+			Gaps:      gaps,
 		}, cfg.Escalation, ghClient)
 	}
 
-	fmt.Printf("\nTask %s completed quality phase (score: %.0f%%, loops: %d)\n", task.ID, qualityResult.LastScore, qualityResult.Loops)
-
 	// --- Create GitHub PR (only after quality passes) ---
-	pr, err := createPR(ctx, task, workDir, branch)
+	pr, err := createPR(ctx, task, workDir, branch, r)
 	if err != nil {
+		r.Error(err)
 		return err
 	}
 
@@ -210,11 +262,13 @@ func runTask(intent string) error {
 			if err := ghClient.PostVerdict(ctx, pr.Number, lastVerdict, state.PhaseQuality, qualityResult.Loops); err != nil {
 				// Log but don't fail the whole run for a comment posting failure.
 				slog.Warn("failed to post verdict comment", "error", err)
+			} else {
+				r.VerdictPosted(lastVerdict.Score, lastVerdict.Pass)
 			}
 		}
 	}
 
-	fmt.Printf("\nTask %s completed successfully\n", task.ID)
+	r.RunComplete(task.ID)
 	return nil
 }
 
@@ -264,57 +318,31 @@ func lastGapsForPhase(task *state.Task, phase state.Phase) []state.Gap {
 	return nil
 }
 
-func runPlanPhase(ctx context.Context, cfg *config.Config, client *claude.Client, store *state.Store, task *state.Task) (*planphase.PhaseResult, error) {
-	fmt.Println("\n-> Plan phase starting...")
+func runPlanPhase(ctx context.Context, cfg *config.Config, client *claude.Client, store *state.Store, task *state.Task, r ui.Renderer) (*planphase.PhaseResult, error) {
+	r.PhaseStart(state.PhasePlan)
 
 	judge := planjudge.New(client, cfg.Phases.Plan)
 	phase := planphase.New(client, judge, cfg.Phases.Plan)
 
-	// Run the plan phase with streaming output.
-	// The plan phase handles its own loop internally, but we wrap it
-	// to provide user-facing output.
 	result, err := phase.Run(ctx, task)
 	if err != nil {
-		// Persist task state even on error.
 		if updateErr := store.UpdateTask(task); updateErr != nil {
 			slog.Error("failed to persist task state", "error", updateErr)
 		}
 		return nil, fmt.Errorf("running plan phase: %w", err)
 	}
 
-	// Persist final task state.
 	if err := store.UpdateTask(task); err != nil {
 		return nil, fmt.Errorf("persisting task state: %w", err)
 	}
 
-	// Print attempt results.
-	for _, attempt := range task.Attempts {
-		if attempt.Phase != state.PhasePlan {
-			continue
-		}
-		maxLoops := cfg.Phases.Plan.MaxLoops
-		passStr := "x"
-		if attempt.Verdict != nil && attempt.Verdict.Pass {
-			passStr = "ok"
-		}
-		score := 0.0
-		if attempt.Verdict != nil {
-			score = attempt.Verdict.Score
-		}
-		fmt.Printf("   Loop %d/%d: %.0f%% %s\n", attempt.Loop, maxLoops, score, passStr)
-	}
-
-	if result.Pass {
-		fmt.Println("-> Plan phase complete")
-	} else if result.Escalate {
-		fmt.Println("-> Plan phase escalated")
-	}
-
+	emitPhaseAttempts(r, task, state.PhasePlan, cfg.Phases.Plan.MaxLoops)
+	emitPhaseDone(r, task, state.PhasePlan, result.Pass, result.Escalate, false, result.LastScore, result.Loops)
 	return result, nil
 }
 
-func runCodePhase(ctx context.Context, cfg *config.Config, store *state.Store, task *state.Task, plan string, workDir string) (*codephase.PhaseResult, error) {
-	fmt.Println("\n-> Code phase starting...")
+func runCodePhase(ctx context.Context, cfg *config.Config, store *state.Store, task *state.Task, plan string, workDir string, r ui.Renderer) (*codephase.PhaseResult, error) {
+	r.PhaseStart(state.PhaseCode)
 
 	coder := claudecode.New()
 	judge := codejudge.New(&codejudge.ExecExecutor{}, *cfg)
@@ -328,38 +356,105 @@ func runCodePhase(ctx context.Context, cfg *config.Config, store *state.Store, t
 		return nil, fmt.Errorf("running code phase: %w", err)
 	}
 
-	// Persist final task state.
 	if err := store.UpdateTask(task); err != nil {
 		return nil, fmt.Errorf("persisting task state: %w", err)
 	}
 
-	// Print attempt results.
-	for _, attempt := range task.Attempts {
-		if attempt.Phase != state.PhaseCode {
-			continue
+	// The code phase judge emits a pass/fail verdict but no narrative
+	// summary. Synthesize one from `git diff --stat` against main so the
+	// user sees what the coder actually touched. We inject it into the
+	// last code verdict so emitPhaseDone picks it up uniformly.
+	if summary := codeDiffSummary(workDir); summary != "" {
+		if v := lastVerdictForPhase(task, state.PhaseCode); v != nil {
+			v.Summary = summary
 		}
-		maxLoops := cfg.Phases.Code.MaxLoops
-		passStr := "x"
-		if attempt.Verdict != nil && attempt.Verdict.Pass {
-			passStr = "ok"
-		}
-		score := 0.0
-		if attempt.Verdict != nil {
-			score = attempt.Verdict.Score
-		}
-		fmt.Printf("   Loop %d/%d: %.0f%% %s\n", attempt.Loop, maxLoops, score, passStr)
 	}
 
-	if result.Pass {
-		fmt.Println("-> Code phase complete")
-	} else if result.Escalate {
-		fmt.Println("-> Code phase escalated")
-	}
-
+	emitPhaseAttempts(r, task, state.PhaseCode, cfg.Phases.Code.MaxLoops)
+	emitPhaseDone(r, task, state.PhaseCode, result.Pass, result.Escalate, false, result.LastScore, result.Loops)
 	return result, nil
 }
 
-func commitChanges(_ context.Context, task *state.Task, workDir string) error {
+// codeDiffSummary builds a `## Files touched` section from `git diff --stat`
+// against origin/main (or main if origin is not present). Empty on error so
+// the caller gracefully falls back to no summary.
+func codeDiffSummary(workDir string) string {
+	base := "main"
+	if _, err := execCommandInDir(workDir, "git", "rev-parse", "--verify", "origin/main"); err == nil {
+		base = "origin/main"
+	}
+	out, err := execCommandInDir(workDir, "git", "diff", "--stat", base+"...HEAD")
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 0 || lines[0] == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Files touched\n")
+	// Drop the final "N files changed, ..." summary line from git's output
+	// so we emit one bullet per file.
+	fileLines := lines
+	if len(fileLines) > 1 {
+		last := fileLines[len(fileLines)-1]
+		if strings.Contains(last, "changed") {
+			fileLines = fileLines[:len(fileLines)-1]
+		}
+	}
+	for _, line := range fileLines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "- %s\n", line)
+	}
+	return b.String()
+}
+
+// emitPhaseAttempts replays every attempt for the given phase to the
+// renderer as PhaseLoop events. Called once after the phase finishes so
+// the renderer sees the same trace whether the phase passed, failed, or
+// escalated.
+func emitPhaseAttempts(r ui.Renderer, task *state.Task, phase state.Phase, maxLoops int) {
+	for _, attempt := range task.Attempts {
+		if attempt.Phase != phase {
+			continue
+		}
+		var score float64
+		pass := false
+		if attempt.Verdict != nil {
+			score = attempt.Verdict.Score
+			pass = attempt.Verdict.Pass
+		}
+		r.PhaseLoop(phase, attempt.Loop, maxLoops, score, pass)
+	}
+}
+
+// emitPhaseDone emits the closing block for a phase, pulling the summary
+// and gaps from the last verdict. Outcome is derived from the phase
+// result flags.
+func emitPhaseDone(r ui.Renderer, task *state.Task, phase state.Phase, pass, escalate, requeueToCode bool, score float64, loops int) {
+	outcome := ui.OutcomeFail
+	switch {
+	case pass:
+		outcome = ui.OutcomePass
+	case requeueToCode:
+		outcome = ui.OutcomeRequeueToCode
+	case escalate:
+		outcome = ui.OutcomeEscalate
+	}
+	v := lastVerdictForPhase(task, phase)
+	var summary string
+	var gaps []state.Gap
+	if v != nil {
+		summary = v.Summary
+		gaps = v.Gaps
+	}
+	r.PhaseDone(phase, outcome, score, loops, summary, gaps)
+}
+
+func commitChanges(_ context.Context, task *state.Task, workDir string, r ui.Renderer) error {
 	// Stage all new and modified files.
 	if out, err := execCommandInDir(workDir, "git", "add", "-A"); err != nil {
 		return fmt.Errorf("staging changes: %s: %w", out, err)
@@ -380,7 +475,7 @@ func commitChanges(_ context.Context, task *state.Task, workDir string) error {
 		return fmt.Errorf("committing changes: %w", err)
 	}
 
-	fmt.Println("-> Changes committed")
+	r.Note("commit", "changes committed")
 	return nil
 }
 
@@ -390,9 +485,7 @@ func execCommandInDir(dir string, name string, args ...string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-func createPR(ctx context.Context, task *state.Task, workDir string, branch string) (*github.PR, error) {
-	fmt.Println("\n-> Creating GitHub PR...")
-
+func createPR(ctx context.Context, task *state.Task, workDir string, branch string, r ui.Renderer) (*github.PR, error) {
 	ghRunner := &github.ExecRunner{Dir: workDir}
 	ghClient := github.New(ghRunner)
 
@@ -411,7 +504,7 @@ func createPR(ctx context.Context, task *state.Task, workDir string, branch stri
 		return nil, fmt.Errorf("creating PR: %w", err)
 	}
 
-	fmt.Printf("-> PR created: %s\n", pr.URL)
+	r.PRCreated(pr.URL)
 	return pr, nil
 }
 
@@ -425,8 +518,8 @@ func lastVerdictForPhase(task *state.Task, phase state.Phase) *state.Verdict {
 	return nil
 }
 
-// runQualityPhase runs the quality phase orchestration and prints
-// per-loop progress similar to runPlanPhase / runCodePhase.
+// runQualityPhase runs the quality phase orchestration and emits progress
+// to the renderer in the same shape as runPlanPhase / runCodePhase.
 func runQualityPhase(
 	ctx context.Context,
 	cfg *config.Config,
@@ -435,8 +528,9 @@ func runQualityPhase(
 	task *state.Task,
 	plan string,
 	workDir string,
+	r ui.Renderer,
 ) (*qualityphase.PhaseResult, error) {
-	fmt.Println("\n-> Quality phase starting...")
+	r.PhaseStart(state.PhaseQuality)
 
 	judge := qualityjudge.New(client, &qualityjudge.ExecRunner{}, *cfg)
 	phase := qualityphase.New(judge, cfg.Phases.Quality, workDir)
@@ -453,30 +547,8 @@ func runQualityPhase(
 		return nil, fmt.Errorf("persisting task state: %w", err)
 	}
 
-	for _, attempt := range task.Attempts {
-		if attempt.Phase != state.PhaseQuality {
-			continue
-		}
-		maxLoops := cfg.Phases.Quality.MaxLoops
-		passStr := "x"
-		if attempt.Verdict != nil && attempt.Verdict.Pass {
-			passStr = "ok"
-		}
-		score := 0.0
-		if attempt.Verdict != nil {
-			score = attempt.Verdict.Score
-		}
-		fmt.Printf("   Loop %d/%d: %.0f%% %s\n", attempt.Loop, maxLoops, score, passStr)
-	}
-
-	switch {
-	case result.Pass:
-		fmt.Println("-> Quality phase complete")
-	case result.RequeueToCode:
-		fmt.Println("-> Quality phase failed: code rework required (escalating)")
-	case result.Escalate:
-		fmt.Println("-> Quality phase escalated")
-	}
+	emitPhaseAttempts(r, task, state.PhaseQuality, cfg.Phases.Quality.MaxLoops)
+	emitPhaseDone(r, task, state.PhaseQuality, result.Pass, result.Escalate, result.RequeueToCode, result.LastScore, result.Loops)
 
 	return result, nil
 }

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/escalation"
 	"github.com/vairdict/vairdict/internal/state"
+	"github.com/vairdict/vairdict/internal/ui"
 )
 
 // helper: make a task that has been advanced through the state machine
@@ -265,6 +266,153 @@ func TestDispatchEscalation_DefaultsToStdoutWhenChannelEmpty(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Escalation") {
 		t.Errorf("expected default-stdout output, got %q", out.String())
+	}
+}
+
+// fakeRenderer records every renderer method call so emit* helper tests
+// can assert on the sequence of events without coupling to specific text.
+type fakeRenderer struct {
+	loops []fakeLoopCall
+	dones []fakeDoneCall
+}
+
+type fakeLoopCall struct {
+	phase state.Phase
+	loop  int
+	max   int
+	score float64
+	pass  bool
+}
+
+type fakeDoneCall struct {
+	phase   state.Phase
+	outcome ui.PhaseOutcome
+	score   float64
+	loops   int
+	summary string
+	gaps    []state.Gap
+}
+
+func (f *fakeRenderer) RunStart(string, string, string) {}
+func (f *fakeRenderer) Note(string, string)             {}
+func (f *fakeRenderer) PhaseStart(state.Phase)          {}
+func (f *fakeRenderer) PRCreated(string)                {}
+func (f *fakeRenderer) VerdictPosted(float64, bool)     {}
+func (f *fakeRenderer) RunComplete(string)              {}
+func (f *fakeRenderer) Error(error)                     {}
+func (f *fakeRenderer) Close() error                    { return nil }
+func (f *fakeRenderer) Escalation(string, state.Phase, int, float64, []state.Gap) {
+}
+
+func (f *fakeRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
+	f.loops = append(f.loops, fakeLoopCall{phase, loop, max, score, pass})
+}
+
+func (f *fakeRenderer) PhaseDone(phase state.Phase, outcome ui.PhaseOutcome, score float64, loops int, summary string, gaps []state.Gap) {
+	f.dones = append(f.dones, fakeDoneCall{phase, outcome, score, loops, summary, gaps})
+}
+
+func TestEmitPhaseAttempts_FiltersByPhase(t *testing.T) {
+	task := state.NewTask("t-1", "intent")
+	task.Attempts = []state.Attempt{
+		{Phase: state.PhasePlan, Loop: 1, Verdict: &state.Verdict{Score: 90, Pass: true}},
+		{Phase: state.PhaseCode, Loop: 1, Verdict: &state.Verdict{Score: 60, Pass: false}},
+		{Phase: state.PhaseCode, Loop: 2, Verdict: &state.Verdict{Score: 85, Pass: true}},
+	}
+	r := &fakeRenderer{}
+
+	emitPhaseAttempts(r, task, state.PhaseCode, 3)
+
+	if len(r.loops) != 2 {
+		t.Fatalf("expected 2 loop events, got %d", len(r.loops))
+	}
+	if r.loops[0].loop != 1 || r.loops[0].score != 60 || r.loops[0].pass {
+		t.Errorf("first code loop wrong: %+v", r.loops[0])
+	}
+	if r.loops[1].loop != 2 || r.loops[1].score != 85 || !r.loops[1].pass {
+		t.Errorf("second code loop wrong: %+v", r.loops[1])
+	}
+	if r.loops[1].max != 3 {
+		t.Errorf("max loops not threaded, got %d", r.loops[1].max)
+	}
+}
+
+func TestEmitPhaseAttempts_NilVerdictUsesZero(t *testing.T) {
+	task := state.NewTask("t-1", "intent")
+	task.Attempts = []state.Attempt{
+		{Phase: state.PhasePlan, Loop: 1, Verdict: nil},
+	}
+	r := &fakeRenderer{}
+
+	emitPhaseAttempts(r, task, state.PhasePlan, 3)
+
+	if len(r.loops) != 1 {
+		t.Fatalf("expected 1 loop event, got %d", len(r.loops))
+	}
+	if r.loops[0].score != 0 || r.loops[0].pass {
+		t.Errorf("nil verdict should render as score=0 pass=false, got %+v", r.loops[0])
+	}
+}
+
+func TestEmitPhaseDone_OutcomeMapping(t *testing.T) {
+	task := state.NewTask("t-1", "intent")
+	task.Attempts = []state.Attempt{
+		{Phase: state.PhasePlan, Loop: 1, Verdict: &state.Verdict{
+			Score:   92,
+			Pass:    true,
+			Summary: "## Decided\n- thing",
+			Gaps:    []state.Gap{{Severity: state.SeverityP2, Description: "note"}},
+		}},
+	}
+
+	cases := []struct {
+		name          string
+		pass          bool
+		escalate      bool
+		requeueToCode bool
+		want          ui.PhaseOutcome
+	}{
+		{"pass", true, false, false, ui.OutcomePass},
+		{"fail", false, false, false, ui.OutcomeFail},
+		{"escalate", false, true, false, ui.OutcomeEscalate},
+		{"requeue_to_code", false, false, true, ui.OutcomeRequeueToCode},
+		// requeue_to_code wins over escalate when both are set
+		{"requeue_before_escalate", false, true, true, ui.OutcomeRequeueToCode},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &fakeRenderer{}
+			emitPhaseDone(r, task, state.PhasePlan, tc.pass, tc.escalate, tc.requeueToCode, 92, 1)
+			if len(r.dones) != 1 {
+				t.Fatalf("expected 1 done event, got %d", len(r.dones))
+			}
+			if r.dones[0].outcome != tc.want {
+				t.Errorf("outcome = %v, want %v", r.dones[0].outcome, tc.want)
+			}
+			if r.dones[0].summary != "## Decided\n- thing" {
+				t.Errorf("summary not threaded from verdict: %q", r.dones[0].summary)
+			}
+			if len(r.dones[0].gaps) != 1 {
+				t.Errorf("gaps not threaded from verdict: %+v", r.dones[0].gaps)
+			}
+		})
+	}
+}
+
+func TestEmitPhaseDone_NoVerdictEmitsEmpty(t *testing.T) {
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	emitPhaseDone(r, task, state.PhasePlan, false, true, false, 0, 3)
+
+	if len(r.dones) != 1 {
+		t.Fatalf("expected 1 done event, got %d", len(r.dones))
+	}
+	if r.dones[0].summary != "" || r.dones[0].gaps != nil {
+		t.Errorf("expected empty summary/gaps when no verdict, got %+v", r.dones[0])
+	}
+	if r.dones[0].outcome != ui.OutcomeEscalate {
+		t.Errorf("outcome = %v, want escalate", r.dones[0].outcome)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/google/uuid v1.6.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.48.1
@@ -26,7 +27,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -22,17 +22,52 @@ type ExecRunner struct {
 	Dir string
 }
 
-// Run executes a command.
+// ExecError wraps exec.Cmd failures with captured stderr so callers (and
+// the user) see *why* a gh / git shellout failed instead of a bare
+// "exit status 1". Returned by ExecRunner.Run when the command exits
+// with a non-zero status.
+type ExecError struct {
+	Cmd    string
+	Stderr string
+	Err    error
+}
+
+// Error renders the underlying error along with any captured stderr. The
+// stderr is trimmed of a trailing newline but otherwise printed verbatim
+// so the user gets the original gh / git message.
+func (e *ExecError) Error() string {
+	stderr := strings.TrimRight(e.Stderr, "\n")
+	if stderr == "" {
+		return fmt.Sprintf("%s: %v", e.Cmd, e.Err)
+	}
+	return fmt.Sprintf("%s: %v: %s", e.Cmd, e.Err, stderr)
+}
+
+// Unwrap exposes the underlying exec error for errors.Is / errors.As.
+func (e *ExecError) Unwrap() error { return e.Err }
+
+// Run executes a command, capturing stdout and stderr into separate
+// buffers. On success the stdout bytes are returned. On failure an
+// *ExecError is returned that carries the captured stderr so the caller
+// can surface a useful diagnostic. The returned byte slice still
+// contains stdout in both cases so existing callers that read Run's
+// output on error continue to work.
 func (e *ExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	if e.Dir != "" {
 		cmd.Dir = e.Dir
 	}
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	err := cmd.Run()
-	return out.Bytes(), err
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.Bytes(), &ExecError{
+			Cmd:    name + " " + strings.Join(args, " "),
+			Stderr: stderr.String(),
+			Err:    err,
+		}
+	}
+	return stdout.Bytes(), nil
 }
 
 // PR represents a created pull request.

--- a/internal/github/exec_test.go
+++ b/internal/github/exec_test.go
@@ -1,0 +1,45 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExecRunnerFailureIncludesStderr(t *testing.T) {
+	r := &ExecRunner{}
+	// `sh -c "echo out; echo err 1>&2; exit 3"` lets us verify that
+	// stdout is preserved and stderr ends up in the wrapped error.
+	stdout, err := r.Run(context.Background(), "sh", "-c", "echo out; echo boom 1>&2; exit 3")
+	if err == nil {
+		t.Fatal("expected error from non-zero exit")
+	}
+	if !strings.Contains(string(stdout), "out") {
+		t.Errorf("stdout not preserved: %q", stdout)
+	}
+	var ee *ExecError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *ExecError, got %T", err)
+	}
+	if !strings.Contains(ee.Stderr, "boom") {
+		t.Errorf("stderr not captured: %q", ee.Stderr)
+	}
+	if !strings.Contains(ee.Error(), "boom") {
+		t.Errorf("Error() should surface stderr: %q", ee.Error())
+	}
+	if ee.Unwrap() == nil {
+		t.Error("Unwrap should return underlying error")
+	}
+}
+
+func TestExecRunnerSuccessReturnsStdoutOnly(t *testing.T) {
+	r := &ExecRunner{}
+	out, err := r.Run(context.Background(), "sh", "-c", "echo hi; echo warn 1>&2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "hi" {
+		t.Errorf("stdout = %q, want hi", out)
+	}
+}

--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -48,10 +48,26 @@ For each gap, set "blocking" to true only for P0 and P1 severity.
 Score is a float from 0 to 100 representing how well the plan covers the intent.
 Higher scores mean better coverage.
 
+The "summary" field is a short human-readable narrative in markdown-ish form
+that will be rendered under the plan phase header in the CLI. Use these exact
+sub-section headers (omit a section if empty), with "- " bullet items:
+
+## Decided
+- <locked-in design decision>
+
+## Risks
+- <risk or open question the planner should know>
+
+## Files to touch
+- <path/to/file.go — brief reason>
+
+Keep each bullet to one line. Do not include any other sections or prose.
+
 Respond with this exact JSON structure:
 {
   "score": <float 0-100>,
   "pass": <bool>,
+  "summary": "<markdown-ish narrative as described above>",
   "gaps": [
     {
       "severity": "<P0|P1|P2|P3>",

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
@@ -262,5 +263,40 @@ func TestJudge_EmptyGapsAndQuestions(t *testing.T) {
 	}
 	if verdict.Questions != nil {
 		t.Errorf("expected nil questions, got %v", verdict.Questions)
+	}
+}
+
+func TestJudge_SummaryRoundTrip(t *testing.T) {
+	// The judge must preserve the narrative summary the LLM emits so the
+	// CLI renderer can show decisions/risks/files under the phase header.
+	want := "## Decided\n- Use cobra for CLI\n\n## Risks\n- dependency on gh CLI"
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Score:   90,
+			Pass:    true,
+			Summary: want,
+		},
+	}
+
+	judge := New(fake, defaultCfg())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Summary != want {
+		t.Errorf("summary lost in round-trip\n got: %q\nwant: %q", verdict.Summary, want)
+	}
+}
+
+func TestJudge_SystemPromptMentionsSummary(t *testing.T) {
+	// Regression guard: if the summary instructions get stripped from the
+	// system prompt, the renderer silently loses its narrative block.
+	if !strings.Contains(systemPrompt, "summary") {
+		t.Error("system prompt no longer instructs the LLM to emit a summary field")
+	}
+	for _, section := range []string{"## Decided", "## Risks", "## Files to touch"} {
+		if !strings.Contains(systemPrompt, section) {
+			t.Errorf("system prompt missing summary sub-section %q", section)
+		}
 	}
 }

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -78,10 +78,23 @@ For each gap, set "blocking" to true only for P0 and P1 severity.
 Score is a float from 0 to 100 representing how well the implementation fulfills the intent.
 Set pass to true if the implementation adequately fulfills the intent (score >= 70).
 
+The "summary" field is a short human-readable narrative in markdown-ish form
+that will be rendered under the quality phase header in the CLI. Use these
+exact sub-section headers (omit a section if empty), with "- " bullet items:
+
+## Reviewed
+- <what you checked against the intent/plan>
+
+## Notes
+- <observation, caveat, or follow-up worth surfacing>
+
+Keep each bullet to one line. Do not include any other sections or prose.
+
 Respond with this exact JSON structure:
 {
   "score": <float 0-100>,
   "pass": <bool>,
+  "summary": "<markdown-ish narrative as described above>",
   "gaps": [
     {
       "severity": "<P0|P1|P2|P3>",

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
@@ -452,4 +453,41 @@ func containsStr(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestJudge_SummaryRoundTrip(t *testing.T) {
+	// The quality judge must preserve the narrative summary the LLM emits
+	// so the CLI renderer can show reviewed/notes under the phase header.
+	want := "## Reviewed\n- Intent matches implementation\n\n## Notes\n- e2e tests still green"
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Score:   85,
+			Pass:    true,
+			Summary: want,
+		},
+	}
+
+	cfg := config.Config{}
+	cfg.Phases.Quality.E2ERequired = false
+	judge := New(fake, &FakeRunner{}, cfg)
+	verdict, err := judge.Judge(context.Background(), "build it", "the plan", "/tmp/work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Summary != want {
+		t.Errorf("summary lost in round-trip\n got: %q\nwant: %q", verdict.Summary, want)
+	}
+}
+
+func TestJudge_SystemPromptMentionsSummary(t *testing.T) {
+	// Regression guard: if the summary instructions get stripped from the
+	// system prompt, the renderer silently loses its narrative block.
+	if !strings.Contains(systemPrompt, "summary") {
+		t.Error("system prompt no longer instructs the LLM to emit a summary field")
+	}
+	for _, section := range []string{"## Reviewed", "## Notes"} {
+		if !strings.Contains(systemPrompt, section) {
+			t.Errorf("system prompt missing summary sub-section %q", section)
+		}
+	}
 }

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -103,6 +103,10 @@ type Verdict struct {
 	Pass      bool       `json:"pass"`
 	Gaps      []Gap      `json:"gaps"`
 	Questions []Question `json:"questions"`
+	// Summary is an optional human-readable narrative the judge produces
+	// alongside the structured verdict (decisions, reviewed items, etc).
+	// It is rendered in cli mode under the phase header. May be empty.
+	Summary string `json:"summary,omitempty"`
 }
 
 // Attempt records one execution of a phase.

--- a/internal/ui/ci.go
+++ b/internal/ui/ci.go
@@ -1,0 +1,96 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// ciRenderer is the non-interactive renderer used in CI / pipes. It writes a
+// concise plain-text trace of every event to the configured Writer using a
+// stable, grep-friendly format. Detailed structured logging still happens
+// via the global slog handler — this renderer only adds the high-level
+// progress markers a CI log reader actually needs.
+type ciRenderer struct {
+	w io.Writer
+}
+
+func newCIRenderer(out io.Writer) *ciRenderer {
+	return &ciRenderer{w: out}
+}
+
+func (r *ciRenderer) printf(format string, args ...any) {
+	_, _ = fmt.Fprintf(r.w, format, args...)
+}
+
+func (r *ciRenderer) Close() error { return nil }
+
+func (r *ciRenderer) RunStart(taskID, intent, logPath string) {
+	r.printf("vairdict: run start task=%s intent=%q log=%s\n", taskID, oneLine(intent), logPath)
+	slog.Info("run start", "task", taskID, "log", logPath)
+}
+
+func (r *ciRenderer) Note(label, value string) {
+	r.printf("vairdict: %s=%s\n", label, value)
+}
+
+func (r *ciRenderer) PhaseStart(phase state.Phase) {
+	r.printf("vairdict: phase start phase=%s\n", phase)
+}
+
+func (r *ciRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
+	r.printf("vairdict: phase loop phase=%s loop=%d/%d score=%.0f pass=%v\n", phase, loop, max, score, pass)
+}
+
+func (r *ciRenderer) PhaseDone(
+	phase state.Phase,
+	outcome PhaseOutcome,
+	score float64,
+	loops int,
+	summary string,
+	gaps []state.Gap,
+) {
+	r.printf("vairdict: phase done phase=%s outcome=%s score=%.0f loops=%d gaps=%d\n",
+		phase, outcomeName(outcome), score, loops, len(gaps))
+	if summary != "" {
+		// One log entry, multi-line is fine — CI log readers handle it.
+		r.printf("vairdict: phase summary phase=%s\n%s\n", phase, summary)
+	}
+}
+
+func (r *ciRenderer) PRCreated(url string) {
+	r.printf("vairdict: pr created url=%s\n", url)
+}
+
+func (r *ciRenderer) VerdictPosted(score float64, pass bool) {
+	r.printf("vairdict: verdict posted score=%.0f pass=%v\n", score, pass)
+}
+
+func (r *ciRenderer) Escalation(taskID string, phase state.Phase, loops int, score float64, gaps []state.Gap) {
+	r.printf("vairdict: escalation task=%s phase=%s loops=%d score=%.0f gaps=%d\n",
+		taskID, phase, loops, score, len(gaps))
+}
+
+func (r *ciRenderer) RunComplete(taskID string) {
+	r.printf("vairdict: run complete task=%s\n", taskID)
+}
+
+func (r *ciRenderer) Error(err error) {
+	r.printf("vairdict: error %s\n", err.Error())
+}
+
+func outcomeName(o PhaseOutcome) string {
+	switch o {
+	case OutcomePass:
+		return "pass"
+	case OutcomeFail:
+		return "fail"
+	case OutcomeEscalate:
+		return "escalate"
+	case OutcomeRequeueToCode:
+		return "requeue_to_code"
+	}
+	return "unknown"
+}

--- a/internal/ui/cli.go
+++ b/internal/ui/cli.go
@@ -1,0 +1,210 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// cliRenderer prints sectioned, colored, emoji-decorated output for human
+// consumption in a terminal. It buffers via bufio for efficient writes and
+// flushes on every public method so output appears immediately even if the
+// caller forgets to Close().
+type cliRenderer struct {
+	w       *bufio.Writer
+	pal     palette
+	glyphs  glyphSet
+	colors  ColorScheme
+	useASCI bool
+}
+
+func newCLIRenderer(out io.Writer, colors ColorScheme, ascii bool) *cliRenderer {
+	r := &cliRenderer{
+		w:       bufio.NewWriter(out),
+		pal:     paletteFor(colors),
+		colors:  colors,
+		useASCI: ascii,
+	}
+	if ascii {
+		r.glyphs = asciiGlyphs()
+	} else {
+		r.glyphs = unicodeGlyphs()
+	}
+	return r
+}
+
+// flush flushes the buffer; ignored errors are written to /dev/stderr would
+// just deadlock the user, so we silently swallow on a fully-broken writer.
+func (r *cliRenderer) flush() {
+	_ = r.w.Flush()
+}
+
+func (r *cliRenderer) Close() error {
+	return r.w.Flush()
+}
+
+// printf is a small helper that writes to the buffered writer; ignoring the
+// error is fine for a terminal sink — there is no useful recovery.
+func (r *cliRenderer) printf(format string, args ...any) {
+	_, _ = fmt.Fprintf(r.w, format, args...)
+}
+
+func (r *cliRenderer) println(s string) {
+	_, _ = r.w.WriteString(s)
+	_, _ = r.w.WriteString("\n")
+}
+
+// ── Renderer methods ──────────────────────────────────────────────────────
+
+func (r *cliRenderer) RunStart(taskID, intent, logPath string) {
+	defer r.flush()
+	r.println("")
+	r.printf("%s%s  vairdict run %s· task %s%s\n",
+		r.pal.bold, r.glyphs.logo, r.pal.dim, taskID, r.pal.reset)
+	if intent != "" {
+		r.printf("   %s\n", oneLine(intent))
+	}
+	if logPath != "" {
+		r.printf("   %slogs: %s%s\n", r.pal.dim, logPath, r.pal.reset)
+	}
+}
+
+func (r *cliRenderer) Note(label, value string) {
+	defer r.flush()
+	if value == "" {
+		r.printf("   %s%s%s\n", r.pal.dim, label, r.pal.reset)
+		return
+	}
+	r.printf("   %s%s:%s %s\n", r.pal.dim, label, r.pal.reset, value)
+}
+
+func (r *cliRenderer) PhaseStart(phase state.Phase) {
+	defer r.flush()
+	r.println("")
+	r.printf("%s%s %s%s\n", r.pal.bold, r.glyphs.phase(phase), phaseTitle(phase), r.pal.reset)
+}
+
+func (r *cliRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
+	defer r.flush()
+	mark := r.glyphs.fail
+	if pass {
+		mark = r.glyphs.pass
+	}
+	scoreColor := r.pal.scoreColor(score)
+	if !pass {
+		scoreColor = r.pal.red
+	}
+	rule := strings.Repeat(r.glyphs.rule, 12)
+	r.printf("   Loop %d/%d %s %s%.0f%%%s %s\n",
+		loop, max, rule, scoreColor, score, r.pal.reset, mark)
+}
+
+func (r *cliRenderer) PhaseDone(
+	phase state.Phase,
+	outcome PhaseOutcome,
+	score float64,
+	loops int,
+	summary string,
+	gaps []state.Gap,
+) {
+	defer r.flush()
+
+	if summary != "" {
+		r.println("")
+		r.renderSummary(summary)
+	}
+
+	if outcome != OutcomePass && len(gaps) > 0 {
+		r.println("")
+		r.renderGaps(gaps)
+	}
+}
+
+func (r *cliRenderer) PRCreated(url string) {
+	defer r.flush()
+	r.println("")
+	r.printf("%s%s PR opened%s\n", r.pal.bold, r.glyphs.prCreated, r.pal.reset)
+	r.printf("   %s\n", url)
+}
+
+func (r *cliRenderer) VerdictPosted(score float64, pass bool) {
+	defer r.flush()
+	tag := "FAIL"
+	if pass {
+		tag = "PASS"
+	}
+	color := r.pal.scoreColor(score)
+	if !pass {
+		color = r.pal.red
+	}
+	r.printf("   verdict: %s%.0f%% %s%s\n", color, score, tag, r.pal.reset)
+}
+
+func (r *cliRenderer) Escalation(taskID string, phase state.Phase, loops int, score float64, gaps []state.Gap) {
+	defer r.flush()
+	r.println("")
+	r.printf("%s%s%s Escalation%s\n", r.pal.bold, r.pal.red, r.glyphs.escalate, r.pal.reset)
+	r.printf("   task:    %s\n", taskID)
+	r.printf("   phase:   %s\n", phaseTitle(phase))
+	r.printf("   loops:   %d\n", loops)
+	r.printf("   score:   %s%.0f%%%s\n", r.pal.red, score, r.pal.reset)
+	if len(gaps) > 0 {
+		r.println("")
+		r.renderGaps(gaps)
+	}
+	r.println("")
+	r.printf("   %sHuman intervention required.%s\n", r.pal.dim, r.pal.reset)
+}
+
+func (r *cliRenderer) RunComplete(taskID string) {
+	defer r.flush()
+	r.println("")
+	r.printf("%s%s done%s · task %s\n", r.pal.bold, r.glyphs.pass, r.pal.reset, taskID)
+}
+
+func (r *cliRenderer) Error(err error) {
+	defer r.flush()
+	r.println("")
+	r.printf("%s%s%s error%s: %s\n", r.pal.bold, r.pal.red, r.glyphs.fail, r.pal.reset, err.Error())
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+// renderSummary prints a multi-section narrative summary. The summary
+// format is freeform markdown-ish text with `## Section` headers and
+// `- item` bullets. Anything else is printed as-is, indented.
+func (r *cliRenderer) renderSummary(summary string) {
+	for line := range strings.SplitSeq(strings.TrimRight(summary, "\n"), "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "":
+			r.println("")
+		case strings.HasPrefix(trimmed, "## "):
+			r.printf("   %s%s%s\n", r.pal.bold, strings.TrimPrefix(trimmed, "## "), r.pal.reset)
+		case strings.HasPrefix(trimmed, "- "):
+			r.printf("     %s %s\n", r.glyphs.bullet, strings.TrimPrefix(trimmed, "- "))
+		default:
+			r.printf("   %s\n", trimmed)
+		}
+	}
+}
+
+func (r *cliRenderer) renderGaps(gaps []state.Gap) {
+	r.printf("   %sGaps%s\n", r.pal.bold, r.pal.reset)
+	for _, g := range gaps {
+		marker := "  "
+		if g.Blocking {
+			marker = r.pal.red + r.glyphs.blocking + r.pal.reset
+		}
+		r.printf("     %s [%s] %s\n", marker, g.Severity, g.Description)
+	}
+}
+
+// oneLine collapses any newlines in s to spaces so multi-line intents render
+// on a single header line.
+func oneLine(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", " "), "\n", " ")
+}

--- a/internal/ui/glyphs.go
+++ b/internal/ui/glyphs.go
@@ -1,0 +1,78 @@
+package ui
+
+import "github.com/vairdict/vairdict/internal/state"
+
+// glyphSet maps semantic icons to their unicode and ASCII forms. cli mode
+// picks one map at construction based on the --ascii flag.
+type glyphSet struct {
+	logo       string
+	plan       string
+	code       string
+	quality    string
+	pass       string
+	fail       string
+	escalate   string
+	blocking   string
+	bullet     string
+	rule       string
+	prCreated  string
+	branchIcon string
+}
+
+func unicodeGlyphs() glyphSet {
+	return glyphSet{
+		logo:       "⚖️",
+		plan:       "📋",
+		code:       "⌨️",
+		quality:    "🔍",
+		pass:       "✅",
+		fail:       "❌",
+		escalate:   "⚠️",
+		blocking:   "⛔",
+		bullet:     "•",
+		rule:       "─",
+		prCreated:  "✅",
+		branchIcon: "↳",
+	}
+}
+
+func asciiGlyphs() glyphSet {
+	return glyphSet{
+		logo:       "[V]",
+		plan:       "[PLAN]",
+		code:       "[CODE]",
+		quality:    "[JUDGE]",
+		pass:       "[OK]",
+		fail:       "[FAIL]",
+		escalate:   "[!]",
+		blocking:   "[X]",
+		bullet:     "*",
+		rule:       "-",
+		prCreated:  "[OK]",
+		branchIcon: "->",
+	}
+}
+
+func (g glyphSet) phase(p state.Phase) string {
+	switch p {
+	case state.PhasePlan:
+		return g.plan
+	case state.PhaseCode:
+		return g.code
+	case state.PhaseQuality:
+		return g.quality
+	}
+	return g.bullet
+}
+
+func phaseTitle(p state.Phase) string {
+	switch p {
+	case state.PhasePlan:
+		return "Plan phase"
+	case state.PhaseCode:
+		return "Code phase"
+	case state.PhaseQuality:
+		return "Quality phase"
+	}
+	return string(p)
+}

--- a/internal/ui/json.go
+++ b/internal/ui/json.go
@@ -1,0 +1,109 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// jsonRenderer emits one JSON object per event so callers can pipe vairdict
+// output through jq or feed it into another tool. Every event has an "event"
+// field naming the kind plus event-specific payload fields.
+type jsonRenderer struct {
+	enc *json.Encoder
+	w   io.Writer
+}
+
+func newJSONRenderer(out io.Writer) *jsonRenderer {
+	return &jsonRenderer{
+		enc: json.NewEncoder(out),
+		w:   out,
+	}
+}
+
+func (r *jsonRenderer) Close() error { return nil }
+
+// emit writes one event object. We tolerate encode errors silently — there
+// is no useful recovery for a broken stdout sink.
+func (r *jsonRenderer) emit(event string, payload map[string]any) {
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	payload["event"] = event
+	_ = r.enc.Encode(payload)
+}
+
+func (r *jsonRenderer) RunStart(taskID, intent, logPath string) {
+	r.emit("run_start", map[string]any{
+		"task_id": taskID,
+		"intent":  intent,
+		"log":     logPath,
+	})
+}
+
+func (r *jsonRenderer) Note(label, value string) {
+	r.emit("note", map[string]any{
+		"label": label,
+		"value": value,
+	})
+}
+
+func (r *jsonRenderer) PhaseStart(phase state.Phase) {
+	r.emit("phase_start", map[string]any{"phase": string(phase)})
+}
+
+func (r *jsonRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
+	r.emit("phase_loop", map[string]any{
+		"phase": string(phase),
+		"loop":  loop,
+		"max":   max,
+		"score": score,
+		"pass":  pass,
+	})
+}
+
+func (r *jsonRenderer) PhaseDone(
+	phase state.Phase,
+	outcome PhaseOutcome,
+	score float64,
+	loops int,
+	summary string,
+	gaps []state.Gap,
+) {
+	r.emit("phase_done", map[string]any{
+		"phase":   string(phase),
+		"outcome": outcomeName(outcome),
+		"score":   score,
+		"loops":   loops,
+		"summary": summary,
+		"gaps":    gaps,
+	})
+}
+
+func (r *jsonRenderer) PRCreated(url string) {
+	r.emit("pr_created", map[string]any{"url": url})
+}
+
+func (r *jsonRenderer) VerdictPosted(score float64, pass bool) {
+	r.emit("verdict_posted", map[string]any{"score": score, "pass": pass})
+}
+
+func (r *jsonRenderer) Escalation(taskID string, phase state.Phase, loops int, score float64, gaps []state.Gap) {
+	r.emit("escalation", map[string]any{
+		"task_id": taskID,
+		"phase":   string(phase),
+		"loops":   loops,
+		"score":   score,
+		"gaps":    gaps,
+	})
+}
+
+func (r *jsonRenderer) RunComplete(taskID string) {
+	r.emit("run_complete", map[string]any{"task_id": taskID})
+}
+
+func (r *jsonRenderer) Error(err error) {
+	r.emit("error", map[string]any{"error": fmt.Sprintf("%v", err)})
+}

--- a/internal/ui/logfile.go
+++ b/internal/ui/logfile.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// LogFile represents an open per-task log file. Callers create one with
+// OpenLogFile, install its slog.Handler as the global default for the run,
+// and Close it when the run finishes.
+type LogFile struct {
+	path string
+	f    *os.File
+}
+
+// OpenLogFile creates ~/.vairdict/logs/<taskID>.log (and parents) and
+// returns a LogFile handle. The directory is created with 0700 since logs
+// may contain prompt content. If $HOME is unwritable, returns an error and
+// callers should fall back to the existing slog handler.
+func OpenLogFile(taskID string) (*LogFile, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home dir: %w", err)
+	}
+	dir := filepath.Join(home, ".vairdict", "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("creating log dir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, taskID+".log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening log file %s: %w", path, err)
+	}
+	return &LogFile{path: path, f: f}, nil
+}
+
+// Path returns the absolute filesystem path of the log file.
+func (l *LogFile) Path() string { return l.path }
+
+// Handler returns a JSON slog handler that writes to this log file. Pair
+// with slog.SetDefault(slog.New(l.Handler())) at the start of a run.
+func (l *LogFile) Handler() slog.Handler {
+	return slog.NewJSONHandler(l.f, &slog.HandlerOptions{Level: slog.LevelDebug})
+}
+
+// Close flushes and closes the underlying file.
+func (l *LogFile) Close() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	return l.f.Close()
+}

--- a/internal/ui/palette.go
+++ b/internal/ui/palette.go
@@ -1,0 +1,76 @@
+package ui
+
+// palette is a small set of ANSI escape sequences. We deliberately keep this
+// minimal — no dependency on lipgloss/termenv — because vairdict's CLI output
+// only needs a handful of colors and the SGR codes never change.
+type palette struct {
+	reset  string
+	bold   string
+	dim    string
+	red    string // failures, blocking gaps
+	green  string // success, scores ≥ 80
+	yellow string // borderline scores 70-79
+	blue   string // info accents
+	cyan   string // headers
+}
+
+func defaultPalette() palette {
+	return palette{
+		reset:  "\033[0m",
+		bold:   "\033[1m",
+		dim:    "\033[2m",
+		red:    "\033[31m",
+		green:  "\033[32m",
+		yellow: "\033[33m",
+		blue:   "\033[34m",
+		cyan:   "\033[36m",
+	}
+}
+
+// accessiblePalette swaps red↔orange and green↔blue so red-green color
+// vision deficiency users can still distinguish pass/fail/borderline.
+// Orange (38;5;208) and a brighter blue replace the failure / success
+// codes; yellow stays as the borderline marker.
+func accessiblePalette() palette {
+	return palette{
+		reset:  "\033[0m",
+		bold:   "\033[1m",
+		dim:    "\033[2m",
+		red:    "\033[38;5;208m", // orange — failure
+		green:  "\033[38;5;33m",  // bright blue — success
+		yellow: "\033[33m",       // yellow stays
+		blue:   "\033[38;5;39m",
+		cyan:   "\033[36m",
+	}
+}
+
+// noColorPalette is a zero-valued palette: every escape is the empty string,
+// so writing colored text becomes a plain string concatenation that costs
+// nothing and prints nothing extra.
+func noColorPalette() palette {
+	return palette{}
+}
+
+func paletteFor(scheme ColorScheme) palette {
+	switch scheme {
+	case ColorsAccessible:
+		return accessiblePalette()
+	case ColorsNone:
+		return noColorPalette()
+	default:
+		return defaultPalette()
+	}
+}
+
+// scoreColor returns the palette color appropriate for a numeric score.
+// >=80 is success, 70-79 is borderline, <70 is failure.
+func (p palette) scoreColor(score float64) string {
+	switch {
+	case score >= 80:
+		return p.green
+	case score >= 70:
+		return p.yellow
+	default:
+		return p.red
+	}
+}

--- a/internal/ui/tty.go
+++ b/internal/ui/tty.go
@@ -1,0 +1,24 @@
+package ui
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// IsTerminal returns true if the given file descriptor is attached to a TTY.
+// Wrapped here so callers don't need to import go-isatty directly and so it
+// can be stubbed in tests.
+func IsTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}
+
+// NoColorEnv returns true when the user has disabled color via the
+// NO_COLOR environment variable. We follow the convention at no-color.org:
+// any non-empty value disables color.
+func NoColorEnv() bool {
+	return os.Getenv("NO_COLOR") != ""
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,178 @@
+// Package ui owns all human-facing terminal output for vairdict.
+//
+// Three rendering modes are supported via the Renderer interface:
+//
+//   - cli  — colored, sectioned, emoji-decorated output for interactive use
+//   - ci   — slog-style structured logs for non-interactive runs (CI / pipes)
+//   - json — one JSON object per event for programmatic consumption
+//
+// The default mode is auto-detected: cli if stdout is a TTY, otherwise ci.
+//
+// Callers (cmd/vairdict/run.go) construct a Renderer via New(opts) and call
+// methods like PhaseStart, PhaseLoop, PhaseDone instead of using fmt.Println
+// or slog directly. This keeps presentation concerns out of orchestration
+// code and makes it possible to test the rendered output in isolation.
+package ui
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// Mode is the high-level output style.
+type Mode string
+
+const (
+	ModeCLI  Mode = "cli"
+	ModeCI   Mode = "ci"
+	ModeJSON Mode = "json"
+)
+
+// ParseMode validates a user-supplied mode string. An empty input means
+// "auto" — the caller decides based on TTY detection.
+func ParseMode(s string) (Mode, error) {
+	switch Mode(s) {
+	case "":
+		return "", nil
+	case ModeCLI, ModeCI, ModeJSON:
+		return Mode(s), nil
+	default:
+		return "", fmt.Errorf("unknown output mode %q (want: cli, ci, json)", s)
+	}
+}
+
+// ColorScheme controls ANSI coloring in cli mode. The accessible scheme uses
+// blue/orange/yellow instead of red/green for users with red-green color
+// vision deficiency. NoColor disables ANSI escapes entirely.
+type ColorScheme string
+
+const (
+	ColorsDefault    ColorScheme = "default"
+	ColorsAccessible ColorScheme = "accessible"
+	ColorsNone       ColorScheme = "no-color"
+)
+
+// ParseColorScheme validates a user-supplied color flag. An empty input
+// means "auto" — the caller decides based on TTY detection and the NO_COLOR
+// environment variable.
+func ParseColorScheme(s string) (ColorScheme, error) {
+	switch ColorScheme(s) {
+	case "":
+		return "", nil
+	case ColorsDefault, ColorsAccessible, ColorsNone:
+		return ColorScheme(s), nil
+	default:
+		return "", fmt.Errorf("unknown colors %q (want: default, accessible, no-color)", s)
+	}
+}
+
+// PhaseOutcome describes how a phase exited. Renderers use this to pick
+// the right glyph and colour and to decide whether to print a gaps block.
+type PhaseOutcome int
+
+const (
+	OutcomePass PhaseOutcome = iota
+	OutcomeFail
+	OutcomeEscalate
+	OutcomeRequeueToCode
+)
+
+// Options holds the construction parameters for a Renderer.
+type Options struct {
+	Mode        Mode
+	Colors      ColorScheme
+	ASCII       bool
+	IsTTY       bool // whether Out is a terminal
+	NoColorEnv  bool // value of NO_COLOR env (if set, force ColorsNone)
+	TerminalCol int  // 0 means unknown / unbounded
+	Out         io.Writer
+}
+
+// Renderer is the abstract surface every output mode must satisfy. Methods
+// are intentionally chunky (one per logical event) so each implementation
+// can choose its own representation.
+type Renderer interface {
+	// RunStart prints the run header (task id, intent, log file path).
+	RunStart(taskID, intent, logPath string)
+
+	// Note prints a low-priority informational line (e.g. "Branch: foo").
+	Note(label, value string)
+
+	// PhaseStart prints the section header for a phase.
+	PhaseStart(phase state.Phase)
+
+	// PhaseLoop prints one loop's progress line within a phase.
+	PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool)
+
+	// PhaseDone prints the closing summary block for a phase: outcome,
+	// score, loops, narrative summary (if any), and gaps (if any).
+	PhaseDone(
+		phase state.Phase,
+		outcome PhaseOutcome,
+		score float64,
+		loops int,
+		summary string,
+		gaps []state.Gap,
+	)
+
+	// PRCreated prints the success line for PR creation.
+	PRCreated(url string)
+
+	// VerdictPosted prints the success line for posting the verdict comment.
+	VerdictPosted(score float64, pass bool)
+
+	// Escalation prints the escalation block, used when a phase fails
+	// after max loops or returns RequeueToCode.
+	Escalation(taskID string, phase state.Phase, loops int, score float64, gaps []state.Gap)
+
+	// RunComplete prints the final success line.
+	RunComplete(taskID string)
+
+	// Error prints an error block (rendered red in cli mode).
+	Error(err error)
+
+	// Close flushes any buffered output. Always safe to call.
+	Close() error
+}
+
+// New constructs a Renderer for the given options. If Mode is empty, it
+// auto-detects: cli for TTYs, ci otherwise. If Colors is empty, it
+// auto-detects: ColorsNone if not a TTY or NO_COLOR is set, otherwise
+// ColorsDefault.
+func New(opts Options) Renderer {
+	if opts.Out == nil {
+		panic("ui.New: Out writer is required")
+	}
+
+	mode := opts.Mode
+	if mode == "" {
+		if opts.IsTTY {
+			mode = ModeCLI
+		} else {
+			mode = ModeCI
+		}
+	}
+
+	colors := opts.Colors
+	if colors == "" {
+		if !opts.IsTTY || opts.NoColorEnv {
+			colors = ColorsNone
+		} else {
+			colors = ColorsDefault
+		}
+	}
+	if opts.NoColorEnv {
+		colors = ColorsNone
+	}
+
+	switch mode {
+	case ModeCLI:
+		return newCLIRenderer(opts.Out, colors, opts.ASCII)
+	case ModeJSON:
+		return newJSONRenderer(opts.Out)
+	default:
+		return newCIRenderer(opts.Out)
+	}
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,0 +1,165 @@
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+func TestParseMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    Mode
+		wantErr bool
+	}{
+		{"", "", false},
+		{"cli", ModeCLI, false},
+		{"ci", ModeCI, false},
+		{"json", ModeJSON, false},
+		{"html", "", true},
+	}
+	for _, tc := range cases {
+		got, err := ParseMode(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseMode(%q) err=%v wantErr=%v", tc.in, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("ParseMode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseColorScheme(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    ColorScheme
+		wantErr bool
+	}{
+		{"", "", false},
+		{"default", ColorsDefault, false},
+		{"accessible", ColorsAccessible, false},
+		{"no-color", ColorsNone, false},
+		{"rainbow", "", true},
+	}
+	for _, tc := range cases {
+		got, err := ParseColorScheme(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseColorScheme(%q) err=%v wantErr=%v", tc.in, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("ParseColorScheme(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNewAutoDetectsMode(t *testing.T) {
+	// TTY → cli
+	var buf bytes.Buffer
+	r := New(Options{Out: &buf, IsTTY: true})
+	if _, ok := r.(*cliRenderer); !ok {
+		t.Errorf("expected cliRenderer for TTY, got %T", r)
+	}
+	// non-TTY → ci
+	r = New(Options{Out: &buf, IsTTY: false})
+	if _, ok := r.(*ciRenderer); !ok {
+		t.Errorf("expected ciRenderer for non-TTY, got %T", r)
+	}
+	// explicit json
+	r = New(Options{Out: &buf, Mode: ModeJSON, IsTTY: true})
+	if _, ok := r.(*jsonRenderer); !ok {
+		t.Errorf("expected jsonRenderer, got %T", r)
+	}
+}
+
+func TestNewColorAutoDetect(t *testing.T) {
+	var buf bytes.Buffer
+	// TTY without NO_COLOR → default palette (non-empty escape)
+	r := New(Options{Out: &buf, IsTTY: true}).(*cliRenderer)
+	if r.pal.reset == "" {
+		t.Error("expected non-empty reset on default palette")
+	}
+	// NO_COLOR env forces no-color even on TTY
+	r = New(Options{Out: &buf, IsTTY: true, NoColorEnv: true}).(*cliRenderer)
+	if r.pal.reset != "" {
+		t.Error("NO_COLOR should force empty palette")
+	}
+}
+
+func TestCLIRendererWritesOutput(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(Options{Out: &buf, Mode: ModeCLI, Colors: ColorsNone})
+	r.RunStart("abc123", "fix bug", "/tmp/log")
+	r.PhaseStart(state.PhasePlan)
+	r.PhaseLoop(state.PhasePlan, 1, 3, 92, true)
+	r.PhaseDone(state.PhasePlan, OutcomePass, 92, 1, "## Decided\n- a thing", nil)
+	r.RunComplete("abc123")
+	_ = r.Close()
+
+	out := buf.String()
+	for _, want := range []string{"abc123", "fix bug", "/tmp/log", "Plan phase", "Loop 1/3", "Decided", "a thing"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestJSONRendererEmitsValidJSON(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(Options{Out: &buf, Mode: ModeJSON})
+	r.RunStart("abc", "intent", "/tmp/x.log")
+	r.PhaseLoop(state.PhaseCode, 2, 3, 75.5, false)
+	r.PhaseDone(state.PhaseCode, OutcomeFail, 75.5, 2, "", []state.Gap{{Severity: state.SeverityP1, Description: "oops"}})
+	r.Error(errors.New("boom"))
+
+	dec := json.NewDecoder(&buf)
+	for dec.More() {
+		var m map[string]any
+		if err := dec.Decode(&m); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := m["event"]; !ok {
+			t.Errorf("missing event field: %v", m)
+		}
+	}
+}
+
+func TestASCIIGlyphSwap(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(Options{Out: &buf, Mode: ModeCLI, Colors: ColorsNone, ASCII: true}).(*cliRenderer)
+	if r.glyphs.logo != "[V]" {
+		t.Errorf("ascii logo = %q, want [V]", r.glyphs.logo)
+	}
+	r.RunStart("t1", "intent", "")
+	if strings.Contains(buf.String(), "⚖") {
+		t.Error("ASCII mode should not emit unicode emoji")
+	}
+}
+
+func TestPaletteSelection(t *testing.T) {
+	if paletteFor(ColorsDefault).red != "\033[31m" {
+		t.Error("default palette red wrong")
+	}
+	if paletteFor(ColorsAccessible).red != "\033[38;5;208m" {
+		t.Error("accessible palette should use orange for red")
+	}
+	if paletteFor(ColorsNone).red != "" {
+		t.Error("no-color palette should have empty escapes")
+	}
+}
+
+func TestScoreColor(t *testing.T) {
+	p := defaultPalette()
+	if p.scoreColor(90) != p.green {
+		t.Error("90 should be green")
+	}
+	if p.scoreColor(75) != p.yellow {
+		t.Error("75 should be yellow")
+	}
+	if p.scoreColor(50) != p.red {
+		t.Error("50 should be red")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/ui` package with `cli`/`ci`/`json` renderers behind a single `Renderer` interface, plus `--output`, `--colors` (default/accessible/no-color), and `--ascii` flags. Auto-detects mode and colors from TTY and `NO_COLOR`.
- Routes slog into `~/.vairdict/logs/<task>.log` per run so the terminal stays readable while structured logs are still available.
- Plan + quality judge prompts now emit a `summary` narrative (`## Decided / ## Risks / ## Files to touch` and `## Reviewed / ## Notes`), rendered under the phase header. Code phase synthesises a `## Files touched` summary from `git diff --stat origin/main...HEAD`.
- `github.ExecRunner` splits stdout/stderr and returns `*ExecError` carrying the real `gh`/`git` message so failures no longer surface as bare `exit status 1`.

Closes #43, #44, #45.

## Test plan
- [x] `go test ./...` — all packages green
- [x] `golangci-lint run ./...` — clean
- [x] New tests: `internal/ui/ui_test.go` (parsing, auto-detect, NO_COLOR, palettes, ASCII swap, CLI + JSON render), `internal/github/exec_test.go` (ExecError captures stderr, `errors.As` works), `cmd/vairdict/run_test.go` (emitPhaseAttempts / emitPhaseDone via fake renderer), plan + quality judge summary JSON round-trip + regression guard on system prompt sub-sections

Deeper integration coverage for `runTask` is tracked in #51 (orchestration DI refactor) and intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)