### PR TITLE
refactor: rename completer backends to claude / claude-cli / claude-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,58 @@ vairdict run "add forgot password flow"
 vairdict status
 ```
 
+## Agent roles & backends
+
+Each phase has its own agent role with a different job. They are
+configured separately under `agents:` in `vairdict.yaml`.
+
+```yaml
+agents:
+  planner: claude       # generates the plan from the intent
+  coder:   claude-code  # writes the code
+  judge:   claude       # scores plan, code, and quality
+```
+
+There are two **kinds** of agent roles, and they accept different values:
+
+### Completer roles — `planner`, `judge`
+
+Stateless: prompt in, structured JSON out, no tools, no file edits.
+Used by the planner and the three judges. Accepted values:
+
+| value        | meaning |
+|--------------|---------|
+| `claude`     | smart default — try local CLI, fall back to HTTP API |
+| `claude-cli` | strict: shell out to the local `claude` binary (errors if not on PATH) |
+| `claude-api` | strict: HTTP call against api.anthropic.com (errors if no API key) |
+
+`claude-cli` is the zero-auth path: if you have the `claude` binary
+installed and logged in, vairdict reuses your subscription session — no
+API key needed. CI environments without an interactive login set
+`claude-api` (or use the `vairdict.ci.yaml` overlay).
+
+### Coder role — `coder`
+
+Agentic: reads files, edits files, runs shell commands, runs tests.
+This is fundamentally different from a completer — the output is **side
+effects on your working directory**, not a JSON struct. Currently the
+only supported value is:
+
+| value         | meaning |
+|---------------|---------|
+| `claude-code` | the local Claude Code agent (the `claude` binary in agentic mode) |
+
+`claude-code` and `claude-cli` happen to invoke the same `claude`
+binary, but they use it for entirely different jobs: `claude-cli` runs
+it as a one-shot JSON function (`claude -p --output-format json`),
+while `claude-code` runs it as a long-running autonomous agent that
+modifies your filesystem (`claude -p --dangerously-skip-permissions`).
+There is no HTTP equivalent of `claude-code` because no HTTP endpoint
+edits your filesystem and runs your tests for you.
+
 ## How agents use this repo
 
-See [AGENTS.md](./AGENTS.md) for how the three-layer 
+See [AGENTS.md](./AGENTS.md) for how the three-layer
 agent team operates on this codebase.
 
 ## Status

--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -1,11 +1,17 @@
 // Package main — completer.go resolves which LLM backend to use for the
-// planner and judges. Both the HTTP claude.Client and the local claudecli
-// wrapper satisfy the same structural interface (CompleteWithSystem); the
-// call-sites in run.go are typed against `completer` so either can be
-// injected. The resolver prefers the local `claude` CLI when it is on PATH
-// and no API key is configured — this is the zero-auth local-dev path.
-// In CI, or when a user explicitly sets agents.judge, the resolver honors
-// that choice.
+// planner and judges (the "completer" roles, distinct from the "coder" role
+// in internal/agents/claudecode which uses tools and edits the filesystem).
+//
+// Three values are accepted in vairdict.yaml under agents.planner /
+// agents.judge:
+//
+//	claude      — smart default: try claude-cli, fall back to claude-api
+//	claude-cli  — strict local subprocess (errors if `claude` not on PATH)
+//	claude-api  — strict HTTP API client (errors if no API key configured)
+//
+// The bare value `claude` exists so future families (gpt, gemini, …) can
+// follow the same convention: bare = smart default for the family, suffixed
+// = explicit transport.
 package main
 
 import (
@@ -25,38 +31,37 @@ type completer interface {
 }
 
 // backendKind is the resolved backend identifier returned alongside the
-// completer instance so it can be surfaced in CLI output and logs.
+// completer instance so it can be surfaced in CLI output and logs. Note
+// this is the *resolved* kind — `claude` (smart) is never returned here;
+// it has already collapsed to claude-cli or claude-api.
 type backendKind string
 
 const (
-	backendClaude    backendKind = "claude"     // HTTP API
 	backendClaudeCLI backendKind = "claude-cli" // local `claude -p`
+	backendClaudeAPI backendKind = "claude-api" // HTTP API
 )
 
-// chooseBackend returns the backend that should be used given the user's
-// agents.judge setting and the local environment. It does not construct any
-// client; it only decides which one to build.
+// chooseBackend returns the resolved backend for the given config setting.
+// `cliAvailable` is injected (via claudecli.IsAvailable in production) so
+// the resolver is deterministic and unit-testable without touching PATH.
 //
-//	"", "auto"    → claude-cli if available and no API key set, else claude
-//	"claude"      → claude (HTTP)
-//	"claude-cli"  → claude-cli (local)
-//	anything else → error
-//
-// The `cliAvailable` and `haveAPIKey` parameters are injected so the choice
-// is deterministic and unit-testable without touching PATH or env.
-func chooseBackend(setting string, cliAvailable bool, haveAPIKey bool) (backendKind, error) {
+//	"", "claude" → claude-cli if PATH has it, else claude-api
+//	"claude-cli" → claude-cli (caller errors later if PATH lookup fails)
+//	"claude-api" → claude-api (caller errors later if no API key)
+//	"auto"       → deprecated alias for "claude" — accepted with no warn
+func chooseBackend(setting string, cliAvailable bool) (backendKind, error) {
 	switch setting {
-	case "", "auto":
-		if cliAvailable && !haveAPIKey {
+	case "", "claude", "auto":
+		if cliAvailable {
 			return backendClaudeCLI, nil
 		}
-		return backendClaude, nil
-	case "claude":
-		return backendClaude, nil
+		return backendClaudeAPI, nil
 	case "claude-cli":
 		return backendClaudeCLI, nil
+	case "claude-api":
+		return backendClaudeAPI, nil
 	default:
-		return "", fmt.Errorf("unknown agents.judge backend %q (want auto|claude|claude-cli)", setting)
+		return "", fmt.Errorf("unknown agents.judge backend %q (want claude|claude-cli|claude-api)", setting)
 	}
 }
 
@@ -64,11 +69,7 @@ func chooseBackend(setting string, cliAvailable bool, haveAPIKey bool) (backendK
 // matching client. The returned backendKind is informational (rendered as
 // a `completer:` note in CLI mode).
 func resolveCompleter(cfg *config.Config) (completer, backendKind, error) {
-	kind, err := chooseBackend(
-		cfg.Agents.Judge,
-		claudecli.IsAvailable(),
-		config.ResolveAPIKey() != "",
-	)
+	kind, err := chooseBackend(cfg.Agents.Judge, claudecli.IsAvailable())
 	if err != nil {
 		return nil, "", err
 	}
@@ -80,7 +81,7 @@ func resolveCompleter(cfg *config.Config) (completer, backendKind, error) {
 		return claudecli.New(
 			claudecli.WithExtraArgs("--dangerously-skip-permissions"),
 		), kind, nil
-	case backendClaude:
+	case backendClaudeAPI:
 		c, err := claude.NewClient(cfg)
 		if err != nil {
 			return nil, "", fmt.Errorf("creating claude client: %w", err)

--- a/cmd/vairdict/completer_test.go
+++ b/cmd/vairdict/completer_test.go
@@ -7,30 +7,32 @@ func TestChooseBackend(t *testing.T) {
 		name         string
 		setting      string
 		cliAvailable bool
-		haveAPIKey   bool
 		want         backendKind
 		wantErr      bool
 	}{
-		// Auto: prefer CLI when available and no API key.
-		{"auto cli only", "", true, false, backendClaudeCLI, false},
-		{"auto alias cli only", "auto", true, false, backendClaudeCLI, false},
-		// Auto: if API key is present, prefer HTTP even if CLI is there,
-		// so CI runs are deterministic and scripted usage is unchanged.
-		{"auto with api key", "", true, true, backendClaude, false},
-		// Auto: no CLI → fall back to HTTP even without an API key.
-		// claude.NewClient will then fail with a clear AuthError.
-		{"auto no cli no key", "", false, false, backendClaude, false},
-		{"auto no cli with key", "", false, true, backendClaude, false},
-		// Explicit overrides.
-		{"explicit claude", "claude", true, false, backendClaude, false},
-		{"explicit claude-cli", "claude-cli", false, true, backendClaudeCLI, false},
-		// Unknown value is a hard error so typos don't silently pick the
+		// Default (empty / "claude"): try cli, fall back to api.
+		{"default cli available", "", true, backendClaudeCLI, false},
+		{"default no cli", "", false, backendClaudeAPI, false},
+		{"claude cli available", "claude", true, backendClaudeCLI, false},
+		{"claude no cli", "claude", false, backendClaudeAPI, false},
+		// "auto" is a deprecated alias for "claude" — accepted silently.
+		{"auto cli available", "auto", true, backendClaudeCLI, false},
+		{"auto no cli", "auto", false, backendClaudeAPI, false},
+		// Strict modes — chooseBackend itself doesn't gate on availability.
+		// claude-cli failing on a host without claude is reported by the
+		// callsite when the subprocess actually runs.
+		{"strict cli", "claude-cli", false, backendClaudeCLI, false},
+		{"strict cli with cli", "claude-cli", true, backendClaudeCLI, false},
+		{"strict api", "claude-api", true, backendClaudeAPI, false},
+		{"strict api no cli", "claude-api", false, backendClaudeAPI, false},
+		// Typos surface as a hard error so users don't silently get the
 		// wrong backend.
-		{"unknown", "openai", true, false, "", true},
+		{"unknown value", "openai", true, "", true},
+		{"old http alias rejected", "claude-http", true, "", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := chooseBackend(tc.setting, tc.cliAvailable, tc.haveAPIKey)
+			got, err := chooseBackend(tc.setting, tc.cliAvailable)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,13 +89,13 @@ type ConventionsConfig struct {
 func Defaults() Config {
 	return Config{
 		Agents: AgentsConfig{
-			// "auto" lets the runtime pick between the HTTP claude.Client
-			// and the local `claude` CLI wrapper based on what's available
-			// (see cmd/vairdict/completer.go). Explicit "claude" or
-			// "claude-cli" still work.
-			Planner: "auto",
+			// "claude" is the smart default for the claude family: try
+			// the local CLI, fall back to the HTTP API. See
+			// cmd/vairdict/completer.go for the explicit alternatives
+			// (claude-cli / claude-api).
+			Planner: "claude",
 			Coder:   "claude-code",
-			Judge:   "auto",
+			Judge:   "claude",
 			Model:   "claude-sonnet-4-20250514",
 		},
 		Environment: EnvironmentConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -108,8 +108,8 @@ project:
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if cfg.Agents.Planner != "auto" {
-		t.Errorf("default agents.planner = %q, want %q", cfg.Agents.Planner, "auto")
+	if cfg.Agents.Planner != "claude" {
+		t.Errorf("default agents.planner = %q, want %q", cfg.Agents.Planner, "claude")
 	}
 	if cfg.Agents.Coder != "claude-code" {
 		t.Errorf("default agents.coder = %q, want %q", cfg.Agents.Coder, "claude-code")

--- a/vairdict.yaml
+++ b/vairdict.yaml
@@ -5,9 +5,9 @@ project:
   risk_tolerance: medium
 
 agents:
-  planner: auto
+  planner: claude
   coder: claude-code
-  judge: auto
+  judge: claude
   model: claude-sonnet-4-20250514
 
 environment:


### PR DESCRIPTION
## Summary
Replaces the claude-specific \`auto\` value with an explicit family-suffixed scheme that scales when other model families arrive:

| value | meaning |
|---|---|
| \`claude\` | smart default — try cli, fall back to api |
| \`claude-cli\` | strict local subprocess |
| \`claude-api\` | strict HTTP API |

Bare \`claude\` keeps zero-config local dev. Future families follow the same pattern (\`gpt\`, \`gpt-cli\`, \`gpt-api\`, …).

## Behavior change
Drops the API-key-as-CI-signal heuristic from \`chooseBackend\`. Only PATH presence matters now. CI environments without \`claude\` installed fall back to api automatically; CI environments that do have it but want to force api use \`claude-api\` explicitly (or via the upcoming \`vairdict.ci.yaml\` overlay in #49).

## Migration
\`auto\` is accepted as a deprecated alias of \`claude\` — old configs keep working with no warn.

## README
Adds an "Agent roles & backends" section explaining:
- Completer roles (\`planner\`, \`judge\`) and the three backend values
- Coder role (\`coder: claude-code\`) and why it can't be unified with \`claude-cli\` even though both invoke the same \`claude\` binary

## Test plan
- [x] \`go test ./...\` — all green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`chooseBackend\` table tests cover: default cli/no-cli, \`claude\` cli/no-cli, deprecated \`auto\` alias, strict cli/api, unknown value rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)