### PR TITLE
feat: vairdict review <pr> — judge an existing PR (#48)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -12,6 +12,7 @@ Update this file when opening, completing, or blocking an issue.
 ## Ready to Start
 - #36 dogfood: first full three-phase task on vairdict
 - #51 test: orchestration coverage for runTask + runQualityPhase (DI refactor)
+- #63 ui: VAIrdict logo in PR verdict comment header
 
 ## In Progress
 - #48 cmd: `vairdict review <pr>` — judge an existing PR
@@ -138,7 +139,7 @@ reviewed by the agent judge, only then created in GitHub.
 | M0        | done        | 1/1         |
 | M1        | done        | 9/9         |
 | M2        | done        | 6/6         |
-| M3        | in progress | 11/14       |
+| M3        | in progress | 11/15       |
 | M4        | not started | 0/5         |
 | M5        | not started | 0/6         |
 | M6        | not started | 0/5         |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -138,6 +138,8 @@ reviewed by the agent judge, only then created in GitHub.
 | M0        | done        | 1/1         |
 | M1        | done        | 9/9         |
 | M2        | done        | 6/6         |
-| M3        | in progress | 7/13        |
-| M4        | not started | 0/6         |
-| M5+       | not started | —           |
+| M3        | in progress | 11/14       |
+| M4        | not started | 0/5         |
+| M5        | not started | 0/6         |
+| M6        | not started | 0/5         |
+| M7+       | not started | —           |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,12 +10,11 @@ Update this file when opening, completing, or blocking an issue.
 ---
 
 ## Ready to Start
-- #48 cmd: `vairdict review <pr>` — judge an existing PR
 - #36 dogfood: first full three-phase task on vairdict
 - #51 test: orchestration coverage for runTask + runQualityPhase (DI refactor)
 
 ## In Progress
-- none
+- #48 cmd: `vairdict review <pr>` — judge an existing PR
 
 ## Blocked
 - #39 cmd/auto-vairdict: auto-merge on passing verdict (blocked on M3 complete)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 - spm installed, ship skill available
 
 **Issues:**
-- [ ] #9 chore: repo infrastructure setup
+- [x] #9 chore: repo infrastructure setup
 
 ---
 
@@ -32,14 +32,14 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 - `vairdict version` prints version string
 
 **Issues (in dependency order):**
-- [ ] #2 config: vairdict.yaml parsing + typed Config struct
-- [ ] #3 state: task state machine + SQLite persistence
-- [ ] #4 agents/claude: Anthropic API client + structured output
-- [ ] #1 bootstrap: init flow + vairdict.yaml generation
-- [ ] #5 judges/plan: plan judge + severity scoring
-- [ ] #6 phases/plan: plan phase orchestration
-- [ ] #7 cmd: cobra CLI (init, run, status, version)
-- [ ] #8 dogfood: run vairdict init on vairdict repo itself
+- [x] #2 config: vairdict.yaml parsing + typed Config struct
+- [x] #3 state: task state machine + SQLite persistence
+- [x] #4 agents/claude: Anthropic API client + structured output
+- [x] #1 bootstrap: init flow + vairdict.yaml generation
+- [x] #5 judges/plan: plan judge + severity scoring
+- [x] #6 phases/plan: plan phase orchestration
+- [x] #7 cmd: cobra CLI (init, run, status, version)
+- [x] #8 dogfood: run vairdict init on vairdict repo itself
 
 ---
 
@@ -53,11 +53,11 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 - PR opened automatically on passing code phase
 
 **Issues:**
-- [ ] agents/claudecode: Claude Code CLI runner
-- [ ] judges/code: calls spm ship, parses output, returns verdict
-- [ ] phases/code: code phase orchestration
-- [ ] github: PR creation + comments via GitHub API
-- [ ] dogfood: plan + code phases end to end on one vairdict task
+- [x] #19 agents/claudecode: Claude Code CLI runner
+- [x] #20 judges/code: calls spm ship, parses output, returns verdict
+- [x] #21 phases/code: code phase orchestration
+- [x] #22 github: PR creation + comments via GitHub API
+- [x] #23 dogfood: plan + code phases end to end on one vairdict task
 
 ---
 
@@ -72,64 +72,53 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 - Dogfood: first complete task run on vairdict itself
 
 **Issues:**
-- [ ] judges/quality: e2e + intent check vs original task
-- [ ] phases/quality: quality phase orchestration
-- [ ] escalation: loop limit + human notification
-- [ ] requeue: cross-phase routing logic
-- [ ] github/verdict: post structured judge verdict as PR comment
-- [ ] dogfood: first full three-phase task on vairdict
+- [x] #32 judges/quality: e2e + intent check vs original task
+- [x] #33 phases/quality: quality phase orchestration
+- [x] #34 escalation: loop limit + human notification
+- [x] #38 github/verdict: post structured judge verdict as PR comment
+- [ ] #48 cmd: `vairdict review <pr>` — judge an existing PR
+- [ ] #51 test: orchestration coverage for runTask + runQualityPhase
+- [ ] #36 dogfood: first full three-phase task on vairdict
 
 ---
 
 ## Milestone 4 — Distribution
-> Get VAIrdict in front of developers with zero friction.
+> Ship VAIrdict so it can run on every commit, in any repo, without hand-holding.
 
 **Definition of done:**
-- GitHub Action published and installable
-- `curl -fsSL vairdict.dev/install | sh` works on Mac + Linux
-- `brew install vairdict` works
-- vairdict.com live with email signup
-- First external person has run VAIrdict successfully
+- Tagged releases (`v0.0.x`) built by GoReleaser for Mac + Linux
+- `curl -fsSL <install-url> | sh` works on Mac + Linux
+- GitHub Action published and installable from the marketplace
+- Auto-review runs the judge on every PR push and posts the verdict as a comment
+- Auto-merge gates merges on a passing verdict
+- README documents quickstart + dogfooding story
+
+**Out of scope (deferred to Early Users):**
+- brew tap / `brew install vairdict`
+- vairdict.com landing page + email signup
+- Show HN / dev.to / ProductHunt launch posts
 
 **Issues:**
-- [ ] cmd/auto-vairdict: auto-merge on passing verdict
+- [ ] #39 cmd/auto-vairdict: auto-merge on passing verdict
+- [ ] release: GoReleaser + signed `v0.0.x` artifacts + install script
 - [ ] action: GitHub Action wrapper published to marketplace
-- [ ] release: GoReleaser + brew tap + install script
-- [ ] web: vairdict.com landing page + email signup
-- [ ] docs: README with quickstart + dogfooding story
-- [ ] launch: Show HN post + dev.to article
+- [ ] action/auto-review: run quality judge on every PR push, post verdict comment
+- [ ] docs: README quickstart + dogfooding story
 
 ---
 
-## Milestone 5 — Early Users
-> Validate with real teams outside your own repo.
-
-**Definition of done:**
-- 5 external repos running VAIrdict
-- Feedback collected from each
-- At least one skill published to skillpkg registry
-- ProductHunt launched
-
-**Issues:**
-- [ ] feedback: outreach to 5 teams, collect structured feedback
-- [ ] skills: judge-plan published to skillpkg registry
-- [ ] skills: judge-code published to skillpkg registry
-- [ ] skills: judge-quality published to skillpkg registry
-- [ ] slack: basic escalation notifications only
-- [ ] launch: ProductHunt + "Built with VAIrdict" badge
-
----
-
-## Milestone 6 — Parallelism
-> Multiple agents per phase, multiple tasks simultaneously.
+## Milestone 5 — Parallelism
+> Multiple agents per phase, multiple tasks simultaneously, isolated workspaces.
 
 **Definition of done:**
 - 3+ tasks running in parallel without interference
+- Each task runs in its own isolated workspace (git worktree or equivalent)
 - Dependency graph respected (task B waits for task A)
 - Merge conflicts detected and handled
 - No performance degradation at 5 concurrent tasks
 
 **Issues:**
+- [ ] workspace: isolated workspace per task (git worktree)
 - [ ] parallel: agent spawning per phase
 - [ ] deps: task dependency graph
 - [ ] queue: priority ordering + dependency resolution
@@ -138,81 +127,25 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 
 ---
 
-## Milestone 7 — Slack App (full)
-> Slack as the primary entry point for engineering teams.
+## Milestone 6 — Pluggable Agents
+> Claude Code is the default. Any CLI agent can replace it.
 
 **Definition of done:**
-- Task submitted via @vairdict in Slack
-- Phase updates posted to Slack automatically
-- Escalations sent to configured channel with context
-- Slack app listed in directory
+- Codex CLI usable as a completer backend
+- Gemini CLI usable as a completer backend
+- Backend selectable per phase in vairdict.yaml
+- Auto-resolver picks the best available backend like the existing claude resolver
 
 **Issues:**
-- [ ] slack/intake: task submission via @vairdict
-- [ ] slack/updates: phase status updates
-- [ ] slack/escalation: escalation with approve/reject
-- [ ] slack/status: vairdict status command in Slack
-- [ ] slack/publish: submit to Slack app directory
+- [ ] agents/codex: Codex CLI completer
+- [ ] agents/gemini: Gemini CLI completer
+- [ ] config: per-phase backend selection in vairdict.yaml
+- [ ] resolver: extend auto backend resolver to all agents
+- [ ] docs: agent backend selection guide
 
 ---
 
-## Milestone 8 — Web UI
-> Visibility into what agents are doing without reading logs.
-
-**Definition of done:**
-- Board view shows tasks flowing through phases
-- Judge scores visible per phase per task
-- Loop history readable for any task
-- Escalation manageable from web UI
-- vairdict.com/dashboard live
-
-**Issues:**
-- [ ] ui/board: kanban-style task board
-- [ ] ui/scores: judge scores + verdict details
-- [ ] ui/history: loop history + assumption log
-- [ ] ui/escalation: escalation management
-- [ ] ui/deploy: vairdict.com/dashboard live
-
----
-
-## Milestone 9 — Team Features
-> Multiple users, roles, and projects.
-
-**Definition of done:**
-- Multiple users can belong to one organization
-- Escalations route to correct person by role
-- Org-level vairdict.yaml + project overrides working
-- Audit log captures every agent action
-
-**Issues:**
-- [ ] teams/users: multi-user organizations
-- [ ] teams/roles: role-based access control
-- [ ] teams/config: org-level + project-level yaml merge
-- [ ] teams/routing: escalation routing by role
-- [ ] teams/audit: full audit log of agent activity
-- [ ] teams/analytics: tasks, loop rates, escalation rates
-
----
-
-## Milestone 10 — Coder Integration
-> Isolated cloud environments per agent.
-
-**Definition of done:**
-- Coder selectable as environment in vairdict.yaml
-- Each agent gets isolated workspace per task
-- Coder registry module published
-- local | github-actions | coder all working
-
-**Issues:**
-- [ ] coder/env: Coder as environment option
-- [ ] coder/workspace: isolated workspace per agent
-- [ ] coder/permissions: scoped permissions per workspace
-- [ ] coder/registry: module published to Coder registry
-- [ ] coder/docs: setup guide for Coder users
-
----
-
-## Milestone 11 — skillpkg Deep Integration
+## Milestone 7 — skillpkg Deep Integration
 > VAIrdict as a first-class skillpkg consumer and contributor.
 
 **Definition of done:**
@@ -225,15 +158,14 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 - [ ] spm/runtime: pull skills via spm at runtime
 - [ ] spm/versioning: skill versions in vairdict.yaml
 - [ ] spm/community: custom judge skill interface
+- [ ] skills/judge-plan: standalone plan judge skill
+- [ ] skills/judge-code: standalone code judge skill
+- [ ] skills/judge-quality: standalone quality judge skill
 - [ ] skills/judge-pr: standalone PR judge skill
-- [ ] skills/severity-score: severity scoring skill
-- [ ] skills/requeue: requeue-on-failure skill
-- [ ] skills/plan-writer: plan writer skill
-- [ ] skills/assumption-logger: assumption logger skill
 
 ---
 
-## Milestone 12 — Advanced Judging
+## Milestone 8 — Advanced Judging
 > Judges that learn and improve over time.
 
 **Definition of done:**
@@ -253,7 +185,7 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 
 ---
 
-## Milestone 13 — Monetization
+## Milestone 9 — Monetization
 > Sustainable business model.
 
 **Definition of done:**
@@ -271,44 +203,118 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 
 ---
 
-## Milestone 14 — Platform
+## Milestone 10 — Platform
 > VAIrdict as an ecosystem.
 
 **Definition of done:**
 - Public API live and documented
 - Linear + Jira integrations working
 - Community judge marketplace live
-- Third-party agent plugins (Codex, Gemini) working
+- "Built with VAIrdict" public dashboard
 
 **Issues:**
 - [ ] platform/api: public REST API
 - [ ] platform/linear: trigger from Linear issue
 - [ ] platform/jira: trigger from Jira ticket
 - [ ] platform/marketplace: community judge marketplace
-- [ ] platform/agents: Codex + Gemini CLI plugins
 - [ ] platform/badge: "Built with VAIrdict" public dashboard
 
 ---
 
-## Timeline
+## Milestone 11 — Early Users
+> Validate with real teams outside your own repo.
 
-| Milestone | Period       | Theme                   |
-|-----------|--------------|-------------------------|
-| M0        | Week 1       | Infrastructure          |
-| M1        | Week 1-2     | Foundation              |
-| M2        | Week 3-4     | Code phase              |
-| M3        | Week 5-6     | Full loop               |
-| M4        | Week 7-8     | Distribution            |
-| M5        | Week 9-10    | Early users             |
-| M6        | Month 4-5    | Parallelism             |
-| M7        | Month 5-6    | Slack                   |
-| M8        | Month 6      | Web UI                  |
-| M9        | Month 7      | Teams                   |
-| M10       | Month 8      | Coder                   |
-| M11       | Month 8-9    | skillpkg                |
-| M12       | Month 9-10   | Advanced judging        |
-| M13       | Month 10-11  | Monetization            |
-| M14       | Month 11-12  | Platform                |
+**Definition of done:**
+- brew tap live, `brew install vairdict` works
+- vairdict.com landing page + email signup live
+- 5 external repos running VAIrdict
+- Structured feedback collected from each
+- ProductHunt + Show HN launched
+
+**Issues:**
+- [ ] release/brew: brew tap + formula automation
+- [ ] web: vairdict.com landing page + email signup
+- [ ] feedback: outreach to 5 teams, collect structured feedback
+- [ ] launch: Show HN + dev.to article
+- [ ] launch: ProductHunt + "Built with VAIrdict" badge
+
+---
+
+## Milestone 12 — Slack App
+> Slack as the primary entry point for engineering teams.
+
+**Definition of done:**
+- Task submitted via @vairdict in Slack
+- Phase updates posted to Slack automatically
+- Escalations sent to configured channel with context
+- Slack app listed in directory
+
+**Issues:**
+- [ ] slack/intake: task submission via @vairdict
+- [ ] slack/updates: phase status updates
+- [ ] slack/escalation: escalation with approve/reject
+- [ ] slack/status: vairdict status command in Slack
+- [ ] slack/publish: submit to Slack app directory
+
+---
+
+## Milestone 13 — Team Features
+> Multiple users, roles, and projects.
+
+**Definition of done:**
+- Multiple users can belong to one organization
+- Escalations route to correct person by role
+- Org-level vairdict.yaml + project overrides working
+- Audit log captures every agent action
+
+**Issues:**
+- [ ] teams/users: multi-user organizations
+- [ ] teams/roles: role-based access control
+- [ ] teams/config: org-level + project-level yaml merge
+- [ ] teams/routing: escalation routing by role
+- [ ] teams/audit: full audit log of agent activity
+- [ ] teams/analytics: tasks, loop rates, escalation rates
+
+---
+
+## Milestone 14 — Coder Integration
+> Isolated cloud environments per agent.
+
+**Definition of done:**
+- Coder selectable as environment in vairdict.yaml
+- Each agent gets isolated cloud workspace per task
+- Coder registry module published
+- local | github-actions | coder all working
+
+**Issues:**
+- [ ] coder/env: Coder as environment option
+- [ ] coder/workspace: isolated cloud workspace per agent
+- [ ] coder/permissions: scoped permissions per workspace
+- [ ] coder/registry: module published to Coder registry
+- [ ] coder/docs: setup guide for Coder users
+
+---
+
+## Web UI
+> Visibility into what agents are doing without reading logs.
+
+Not scheduled. Slot in once early users ask for it (likely between M11 and M12).
+
+**Likely scope:**
+- Kanban-style task board
+- Judge scores + verdict details per phase per task
+- Loop history + assumption log per task
+- Escalation management from the UI
+- vairdict.com/dashboard live
+
+---
+
+## Open-Issue Backlog
+> Drained continuously between milestones — not its own milestone.
+
+Open GitHub issues that don't belong to a specific milestone are picked up
+opportunistically between milestone work. Bugs and small papercuts found
+during dogfooding land here.
 
 ---
 

--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -1,0 +1,189 @@
+// Package main — review.go implements the `vairdict review <pr-number>`
+// subcommand: it runs only the quality judge against an existing PR
+// (human-written or otherwise) and posts a verdict comment. This lets us
+// dogfood the judge on hand-written PRs without going through the full
+// plan→code→quality loop.
+//
+// Flow:
+//  1. Fetch the PR via gh (title, body, head/base ref)
+//  2. Resolve the linked issue from the body (Closes/Fixes/Resolves #N)
+//     and use its title+body as the intent — or fall back to --intent.
+//  3. Fetch the PR diff via gh (no checkout — keeps the user's tree clean)
+//  4. Run the quality judge with the diff stuffed into the prompt context
+//  5. Post the verdict via github.PostVerdict (or print to stdout when
+//     --no-comment is set).
+//
+// Exits non-zero on judge failure so it can gate CI workflows.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/github"
+	qualityjudge "github.com/vairdict/vairdict/internal/judges/quality"
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+var (
+	reviewIntentFlag    string
+	reviewNoCommentFlag bool
+)
+
+var reviewCmd = &cobra.Command{
+	Use:   "review <pr-number>",
+	Short: "Run the quality judge against an existing PR",
+	Long: `Fetch an existing PR and run only the quality judge against it,
+posting a structured verdict comment. The intent is derived from the
+issue linked in the PR body (Closes/Fixes #N); use --intent to override
+or supply one when no issue is linked.
+
+Use --no-comment to print the verdict to stdout instead of posting it
+on the PR (useful for local dry-runs).`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		prNumber, err := strconv.Atoi(args[0])
+		if err != nil || prNumber <= 0 {
+			return fmt.Errorf("invalid PR number %q", args[0])
+		}
+		return runReview(prNumber)
+	},
+}
+
+func init() {
+	reviewCmd.Flags().StringVar(&reviewIntentFlag, "intent", "", "explicit intent text (required if PR has no linked issue)")
+	reviewCmd.Flags().BoolVar(&reviewNoCommentFlag, "no-comment", false, "print verdict to stdout instead of posting on the PR")
+	rootCmd.AddCommand(reviewCmd)
+}
+
+// reviewDeps bundles the collaborators that runReviewWith needs so the
+// command body can be exercised in tests with fakes (no exec, no real
+// completer, no PROGRESS-changing side effects).
+type reviewDeps struct {
+	gh     reviewGH
+	judge  reviewJudge
+	cfg    *config.Config
+	stdout *os.File
+}
+
+// reviewGH is the narrow GitHub surface the review command depends on.
+// Both *github.Client and a test fake satisfy it.
+type reviewGH interface {
+	FetchPR(ctx context.Context, n int) (*github.PRDetails, error)
+	FetchIssue(ctx context.Context, n int) (*github.IssueDetails, error)
+	FetchPRDiff(ctx context.Context, n int) (string, error)
+	PostVerdict(ctx context.Context, n int, v *state.Verdict, p state.Phase, loop int) error
+}
+
+// reviewJudge is the narrow judge surface; *quality.QualityJudge satisfies
+// it. Plan is always empty for review mode (per #48 acceptance criteria).
+type reviewJudge interface {
+	Judge(ctx context.Context, intent string, plan string, workDir string) (*state.Verdict, error)
+}
+
+// runReview is the production entry point: it loads the config, builds
+// the real github client + quality judge, and delegates to runReviewWith
+// which contains the testable orchestration logic.
+func runReview(prNumber int) error {
+	overlayPath, err := config.ResolveOverlayPath(envFlag, config.IsCI(), ".", fileExistsFunc)
+	if err != nil {
+		return fmt.Errorf("resolving env: %w", err)
+	}
+	cfg, err := config.LoadConfigWithOverlay("vairdict.yaml", overlayPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	client, _, err := resolveCompleter(cfg)
+	if err != nil {
+		return err
+	}
+
+	workDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving working directory: %w", err)
+	}
+	ghClient := github.New(&github.ExecRunner{Dir: workDir})
+	judge := qualityjudge.New(client, &qualityjudge.ExecRunner{}, *cfg)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	return runReviewWith(ctx, prNumber, reviewDeps{
+		gh:     ghClient,
+		judge:  judge,
+		cfg:    cfg,
+		stdout: os.Stdout,
+	})
+}
+
+// runReviewWith is the orchestration core, factored out so tests can
+// inject fakes without touching the filesystem or network. It returns a
+// non-nil error on failed verdicts so the caller (cobra) propagates a
+// non-zero exit code — review is meant to gate CI.
+func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
+	pr, err := deps.gh.FetchPR(ctx, prNumber)
+	if err != nil {
+		return err
+	}
+
+	intent, err := resolveReviewIntent(ctx, deps.gh, pr)
+	if err != nil {
+		return err
+	}
+
+	diff, err := deps.gh.FetchPRDiff(ctx, prNumber)
+	if err != nil {
+		return err
+	}
+
+	// The QualityJudge.Judge signature is locked at (intent, plan, workDir)
+	// — see issue #48 acceptance criteria. Review mode has no plan, so we
+	// pass an empty plan and embed the diff into the workDir context line
+	// of the prompt by stuffing the diff into the intent string under a
+	// clearly delimited section. This avoids changing the judge API for
+	// a single command. The judge prompt already accepts free-form text.
+	enrichedIntent := fmt.Sprintf("%s\n\n## PR Diff (review mode)\n```diff\n%s\n```", intent, diff)
+
+	verdict, err := deps.judge.Judge(ctx, enrichedIntent, "", ".")
+	if err != nil {
+		return fmt.Errorf("running quality judge: %w", err)
+	}
+
+	if reviewNoCommentFlag {
+		_, _ = fmt.Fprintln(deps.stdout, github.FormatVerdictComment(verdict, state.PhaseQuality, 1))
+	} else {
+		if err := deps.gh.PostVerdict(ctx, prNumber, verdict, state.PhaseQuality, 1); err != nil {
+			return fmt.Errorf("posting verdict: %w", err)
+		}
+	}
+
+	if !verdict.Pass {
+		return fmt.Errorf("verdict failed: score %.0f%%", verdict.Score)
+	}
+	return nil
+}
+
+// resolveReviewIntent picks the intent for the judge: explicit --intent
+// flag wins; otherwise the first linked issue in the PR body is fetched
+// and rendered as "title\n\nbody". Errors out cleanly when neither
+// source is available so the user gets a clear next step.
+func resolveReviewIntent(ctx context.Context, gh reviewGH, pr *github.PRDetails) (string, error) {
+	if reviewIntentFlag != "" {
+		return reviewIntentFlag, nil
+	}
+	issueNum := github.ParseLinkedIssue(pr.Body)
+	if issueNum == 0 {
+		return "", fmt.Errorf("PR #%d has no linked issue (Closes/Fixes/Resolves #N) and --intent was not provided", pr.Number)
+	}
+	iss, err := gh.FetchIssue(ctx, issueNum)
+	if err != nil {
+		return "", err
+	}
+	return iss.Title + "\n\n" + iss.Body, nil
+}

--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -86,9 +86,10 @@ type reviewGH interface {
 }
 
 // reviewJudge is the narrow judge surface; *quality.QualityJudge satisfies
-// it. Plan is always empty for review mode (per #48 acceptance criteria).
+// it. Plan is always empty for review mode (per #48 acceptance criteria);
+// the third argument is the unified diff fetched from the PR.
 type reviewJudge interface {
-	Judge(ctx context.Context, intent string, plan string, workDir string) (*state.Verdict, error)
+	Judge(ctx context.Context, intent string, plan string, diff string) (*state.Verdict, error)
 }
 
 // runReview is the production entry point: it loads the config, builds
@@ -149,15 +150,9 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 		return err
 	}
 
-	// The QualityJudge.Judge signature is locked at (intent, plan, workDir)
-	// — see issue #48 acceptance criteria. Review mode has no plan, so we
-	// pass an empty plan and embed the diff into the workDir context line
-	// of the prompt by stuffing the diff into the intent string under a
-	// clearly delimited section. This avoids changing the judge API for
-	// a single command. The judge prompt already accepts free-form text.
-	enrichedIntent := fmt.Sprintf("%s\n\n## PR Diff (review mode)\n```diff\n%s\n```", intent, diff)
-
-	verdict, err := deps.judge.Judge(ctx, enrichedIntent, "", ".")
+	// Review mode has no plan — pass empty. The diff is what the judge
+	// actually evaluates.
+	verdict, err := deps.judge.Judge(ctx, intent, "", diff)
 	if err != nil {
 		return fmt.Errorf("running quality judge: %w", err)
 	}

--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -9,7 +9,7 @@
 //  2. Resolve the linked issue from the body (Closes/Fixes/Resolves #N)
 //     and use its title+body as the intent — or fall back to --intent.
 //  3. Fetch the PR diff via gh (no checkout — keeps the user's tree clean)
-//  4. Run the quality judge with the diff stuffed into the prompt context
+//  4. Run the quality judge with the diff passed as the diff argument
 //  5. Post the verdict via github.PostVerdict (or print to stdout when
 //     --no-comment is set).
 //

--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strconv"
@@ -61,14 +62,18 @@ func init() {
 	rootCmd.AddCommand(reviewCmd)
 }
 
-// reviewDeps bundles the collaborators that runReviewWith needs so the
-// command body can be exercised in tests with fakes (no exec, no real
-// completer, no PROGRESS-changing side effects).
+// reviewDeps bundles the collaborators and resolved options that
+// runReviewWith needs so the command body can be exercised in tests with
+// fakes (no exec, no real completer, no package-global flag state).
+// Flags are snapshotted into this struct at the cobra layer so the
+// orchestration core has no hidden inputs and is safe to run in parallel.
 type reviewDeps struct {
-	gh     reviewGH
-	judge  reviewJudge
-	cfg    *config.Config
-	stdout *os.File
+	gh        reviewGH
+	judge     reviewJudge
+	cfg       *config.Config
+	stdout    io.Writer
+	intent    string // resolved value of --intent (empty = derive from linked issue)
+	noComment bool   // resolved value of --no-comment
 }
 
 // reviewGH is the narrow GitHub surface the review command depends on.
@@ -115,10 +120,12 @@ func runReview(prNumber int) error {
 	defer cancel()
 
 	return runReviewWith(ctx, prNumber, reviewDeps{
-		gh:     ghClient,
-		judge:  judge,
-		cfg:    cfg,
-		stdout: os.Stdout,
+		gh:        ghClient,
+		judge:     judge,
+		cfg:       cfg,
+		stdout:    os.Stdout,
+		intent:    reviewIntentFlag,
+		noComment: reviewNoCommentFlag,
 	})
 }
 
@@ -132,7 +139,7 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 		return err
 	}
 
-	intent, err := resolveReviewIntent(ctx, deps.gh, pr)
+	intent, err := resolveReviewIntent(ctx, deps.gh, pr, deps.intent)
 	if err != nil {
 		return err
 	}
@@ -155,7 +162,7 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 		return fmt.Errorf("running quality judge: %w", err)
 	}
 
-	if reviewNoCommentFlag {
+	if deps.noComment {
 		_, _ = fmt.Fprintln(deps.stdout, github.FormatVerdictComment(verdict, state.PhaseQuality, 1))
 	} else {
 		if err := deps.gh.PostVerdict(ctx, prNumber, verdict, state.PhaseQuality, 1); err != nil {
@@ -169,13 +176,15 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 	return nil
 }
 
-// resolveReviewIntent picks the intent for the judge: explicit --intent
-// flag wins; otherwise the first linked issue in the PR body is fetched
-// and rendered as "title\n\nbody". Errors out cleanly when neither
-// source is available so the user gets a clear next step.
-func resolveReviewIntent(ctx context.Context, gh reviewGH, pr *github.PRDetails) (string, error) {
-	if reviewIntentFlag != "" {
-		return reviewIntentFlag, nil
+// resolveReviewIntent picks the intent for the judge: an explicit
+// override (from --intent) wins; otherwise the first linked issue in the
+// PR body is fetched and rendered as "title\n\nbody". Errors out cleanly
+// when neither source is available so the user gets a clear next step.
+// The override is passed in (not read from package state) so the core is
+// parallel-test-safe.
+func resolveReviewIntent(ctx context.Context, gh reviewGH, pr *github.PRDetails, override string) (string, error) {
+	if override != "" {
+		return override, nil
 	}
 	issueNum := github.ParseLinkedIssue(pr.Body)
 	if issueNum == 0 {

--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"os"
+	"io"
 	"strings"
 	"testing"
 
@@ -58,13 +59,6 @@ func (f *fakeReviewJudge) Judge(_ context.Context, intent, plan, _ string) (*sta
 	return f.verdict, f.err
 }
 
-// resetReviewFlags clears package-level flag state between tests so they
-// don't bleed into each other (cobra parses flags into globals).
-func resetReviewFlags() {
-	reviewIntentFlag = ""
-	reviewNoCommentFlag = false
-}
-
 func passingVerdict() *state.Verdict {
 	return &state.Verdict{Score: 90, Pass: true}
 }
@@ -75,8 +69,15 @@ func failingVerdict() *state.Verdict {
 	}}
 }
 
+// baseDeps builds a reviewDeps with sensible defaults; tests override
+// the fields they care about. Stdout defaults to io.Discard so tests
+// don't accidentally pollute the test runner's output.
+func baseDeps(gh reviewGH, judge reviewJudge) reviewDeps {
+	return reviewDeps{gh: gh, judge: judge, stdout: io.Discard}
+}
+
 func TestRunReview_HappyPath_LinkedIssue(t *testing.T) {
-	resetReviewFlags()
+	t.Parallel()
 	gh := &fakeReviewGH{
 		pr:    &github.PRDetails{Number: 46, Title: "feat: foo", Body: "Closes #48"},
 		issue: &github.IssueDetails{Number: 48, Title: "review cmd", Body: "build it"},
@@ -84,12 +85,7 @@ func TestRunReview_HappyPath_LinkedIssue(t *testing.T) {
 	}
 	judge := &fakeReviewJudge{verdict: passingVerdict()}
 
-	err := runReviewWith(context.Background(), 46, reviewDeps{
-		gh:     gh,
-		judge:  judge,
-		stdout: os.Stdout,
-	})
-	if err != nil {
+	if err := runReviewWith(context.Background(), 46, baseDeps(gh, judge)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !gh.postCalled {
@@ -110,35 +106,35 @@ func TestRunReview_HappyPath_LinkedIssue(t *testing.T) {
 }
 
 func TestRunReview_ExplicitIntentOverridesLinkedIssue(t *testing.T) {
-	resetReviewFlags()
-	reviewIntentFlag = "do exactly this"
-	defer resetReviewFlags()
-
+	t.Parallel()
 	gh := &fakeReviewGH{
 		pr:   &github.PRDetails{Number: 5, Body: "Closes #1"},
 		diff: "+x",
 	}
 	judge := &fakeReviewJudge{verdict: passingVerdict()}
 
-	if err := runReviewWith(context.Background(), 5, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout}); err != nil {
+	deps := baseDeps(gh, judge)
+	deps.intent = "do exactly this"
+
+	if err := runReviewWith(context.Background(), 5, deps); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(judge.intent, "do exactly this") {
 		t.Errorf("expected explicit intent in judge call, got %q", judge.intent)
 	}
 	if gh.issue != nil && strings.Contains(judge.intent, "review cmd") {
-		t.Error("issue should not have been fetched when --intent set")
+		t.Error("issue should not have been fetched when intent override set")
 	}
 }
 
 func TestRunReview_NoLinkedIssue_NoIntentFlag_Errors(t *testing.T) {
-	resetReviewFlags()
+	t.Parallel()
 	gh := &fakeReviewGH{
 		pr: &github.PRDetails{Number: 9, Body: "no closing keyword here"},
 	}
 	judge := &fakeReviewJudge{verdict: passingVerdict()}
 
-	err := runReviewWith(context.Background(), 9, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	err := runReviewWith(context.Background(), 9, baseDeps(gh, judge))
 	if err == nil {
 		t.Fatal("expected error for missing intent")
 	}
@@ -151,7 +147,7 @@ func TestRunReview_NoLinkedIssue_NoIntentFlag_Errors(t *testing.T) {
 }
 
 func TestRunReview_JudgeError_Propagates(t *testing.T) {
-	resetReviewFlags()
+	t.Parallel()
 	gh := &fakeReviewGH{
 		pr:    &github.PRDetails{Number: 1, Body: "Closes #2"},
 		issue: &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
@@ -159,7 +155,7 @@ func TestRunReview_JudgeError_Propagates(t *testing.T) {
 	}
 	judge := &fakeReviewJudge{err: errors.New("boom")}
 
-	err := runReviewWith(context.Background(), 1, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	err := runReviewWith(context.Background(), 1, baseDeps(gh, judge))
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -172,7 +168,7 @@ func TestRunReview_JudgeError_Propagates(t *testing.T) {
 }
 
 func TestRunReview_FailingVerdict_PostsAndExitsNonZero(t *testing.T) {
-	resetReviewFlags()
+	t.Parallel()
 	gh := &fakeReviewGH{
 		pr:    &github.PRDetails{Number: 1, Body: "Closes #2"},
 		issue: &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
@@ -180,7 +176,7 @@ func TestRunReview_FailingVerdict_PostsAndExitsNonZero(t *testing.T) {
 	}
 	judge := &fakeReviewJudge{verdict: failingVerdict()}
 
-	err := runReviewWith(context.Background(), 1, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	err := runReviewWith(context.Background(), 1, baseDeps(gh, judge))
 	if err == nil {
 		t.Fatal("expected non-nil error to gate CI on failing verdict")
 	}
@@ -190,10 +186,7 @@ func TestRunReview_FailingVerdict_PostsAndExitsNonZero(t *testing.T) {
 }
 
 func TestRunReview_NoComment_PrintsToStdout(t *testing.T) {
-	resetReviewFlags()
-	reviewNoCommentFlag = true
-	defer resetReviewFlags()
-
+	t.Parallel()
 	gh := &fakeReviewGH{
 		pr:    &github.PRDetails{Number: 1, Body: "Closes #2"},
 		issue: &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
@@ -201,45 +194,35 @@ func TestRunReview_NoComment_PrintsToStdout(t *testing.T) {
 	}
 	judge := &fakeReviewJudge{verdict: passingVerdict()}
 
-	// Pipe stdout to a temp file we can read back.
-	tmp, err := os.CreateTemp("", "review-stdout-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Remove(tmp.Name()) }()
-	defer func() { _ = tmp.Close() }()
+	var buf bytes.Buffer
+	deps := baseDeps(gh, judge)
+	deps.noComment = true
+	deps.stdout = &buf
 
-	if err := runReviewWith(context.Background(), 1, reviewDeps{gh: gh, judge: judge, stdout: tmp}); err != nil {
+	if err := runReviewWith(context.Background(), 1, deps); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if gh.postCalled {
-		t.Error("PostVerdict should not be called when --no-comment is set")
+		t.Error("PostVerdict should not be called when noComment is set")
 	}
-	if _, err := tmp.Seek(0, 0); err != nil {
-		t.Fatal(err)
-	}
-	out, err := os.ReadFile(tmp.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(out), "VAIrdict Verdict") {
-		t.Errorf("expected verdict in stdout, got: %q", string(out))
+	if !strings.Contains(buf.String(), "VAIrdict Verdict") {
+		t.Errorf("expected verdict in stdout, got: %q", buf.String())
 	}
 }
 
 func TestRunReview_FetchPRError(t *testing.T) {
-	resetReviewFlags()
+	t.Parallel()
 	gh := &fakeReviewGH{prErr: errors.New("not found")}
 	judge := &fakeReviewJudge{verdict: passingVerdict()}
 
-	err := runReviewWith(context.Background(), 99, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	err := runReviewWith(context.Background(), 99, baseDeps(gh, judge))
 	if err == nil {
 		t.Fatal("expected error")
 	}
 }
 
 func TestRunReview_FetchDiffError(t *testing.T) {
-	resetReviewFlags()
+	t.Parallel()
 	gh := &fakeReviewGH{
 		pr:      &github.PRDetails{Number: 1, Body: "Closes #2"},
 		issue:   &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
@@ -247,8 +230,27 @@ func TestRunReview_FetchDiffError(t *testing.T) {
 	}
 	judge := &fakeReviewJudge{verdict: passingVerdict()}
 
-	err := runReviewWith(context.Background(), 1, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	err := runReviewWith(context.Background(), 1, baseDeps(gh, judge))
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestRunReview_PostVerdictError_Propagates(t *testing.T) {
+	t.Parallel()
+	gh := &fakeReviewGH{
+		pr:      &github.PRDetails{Number: 1, Body: "Closes #2"},
+		issue:   &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
+		diff:    "diff",
+		postErr: errors.New("api down"),
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	err := runReviewWith(context.Background(), 1, baseDeps(gh, judge))
+	if err == nil {
+		t.Fatal("expected post error to propagate")
+	}
+	if !strings.Contains(err.Error(), "posting verdict") {
+		t.Errorf("error should mention posting, got: %v", err)
 	}
 }

--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/github"
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// fakeReviewGH is a hand-rolled fake covering only the surface that
+// runReviewWith uses. Records every PostVerdict call so tests can assert
+// on what was sent.
+type fakeReviewGH struct {
+	pr           *github.PRDetails
+	prErr        error
+	issue        *github.IssueDetails
+	issueErr     error
+	diff         string
+	diffErr      error
+	postErr      error
+	postedNumber int
+	postedVerd   *state.Verdict
+	postCalled   bool
+}
+
+func (f *fakeReviewGH) FetchPR(_ context.Context, _ int) (*github.PRDetails, error) {
+	return f.pr, f.prErr
+}
+func (f *fakeReviewGH) FetchIssue(_ context.Context, _ int) (*github.IssueDetails, error) {
+	return f.issue, f.issueErr
+}
+func (f *fakeReviewGH) FetchPRDiff(_ context.Context, _ int) (string, error) {
+	return f.diff, f.diffErr
+}
+func (f *fakeReviewGH) PostVerdict(_ context.Context, n int, v *state.Verdict, _ state.Phase, _ int) error {
+	f.postCalled = true
+	f.postedNumber = n
+	f.postedVerd = v
+	return f.postErr
+}
+
+// fakeReviewJudge captures the inputs to Judge so tests can verify the
+// command stitches the intent + diff together correctly.
+type fakeReviewJudge struct {
+	verdict *state.Verdict
+	err     error
+	intent  string
+	plan    string
+}
+
+func (f *fakeReviewJudge) Judge(_ context.Context, intent, plan, _ string) (*state.Verdict, error) {
+	f.intent = intent
+	f.plan = plan
+	return f.verdict, f.err
+}
+
+// resetReviewFlags clears package-level flag state between tests so they
+// don't bleed into each other (cobra parses flags into globals).
+func resetReviewFlags() {
+	reviewIntentFlag = ""
+	reviewNoCommentFlag = false
+}
+
+func passingVerdict() *state.Verdict {
+	return &state.Verdict{Score: 90, Pass: true}
+}
+
+func failingVerdict() *state.Verdict {
+	return &state.Verdict{Score: 30, Pass: false, Gaps: []state.Gap{
+		{Severity: state.SeverityP0, Description: "broken", Blocking: true},
+	}}
+}
+
+func TestRunReview_HappyPath_LinkedIssue(t *testing.T) {
+	resetReviewFlags()
+	gh := &fakeReviewGH{
+		pr:    &github.PRDetails{Number: 46, Title: "feat: foo", Body: "Closes #48"},
+		issue: &github.IssueDetails{Number: 48, Title: "review cmd", Body: "build it"},
+		diff:  "diff --git a/x b/x\n+hi\n",
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	err := runReviewWith(context.Background(), 46, reviewDeps{
+		gh:     gh,
+		judge:  judge,
+		stdout: os.Stdout,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gh.postCalled {
+		t.Error("expected PostVerdict to be called")
+	}
+	if gh.postedNumber != 46 {
+		t.Errorf("posted to PR %d, want 46", gh.postedNumber)
+	}
+	if !strings.Contains(judge.intent, "review cmd") || !strings.Contains(judge.intent, "build it") {
+		t.Errorf("judge intent missing issue text: %q", judge.intent)
+	}
+	if !strings.Contains(judge.intent, "diff --git") {
+		t.Errorf("judge intent missing diff: %q", judge.intent)
+	}
+	if judge.plan != "" {
+		t.Errorf("plan should be empty in review mode, got %q", judge.plan)
+	}
+}
+
+func TestRunReview_ExplicitIntentOverridesLinkedIssue(t *testing.T) {
+	resetReviewFlags()
+	reviewIntentFlag = "do exactly this"
+	defer resetReviewFlags()
+
+	gh := &fakeReviewGH{
+		pr:   &github.PRDetails{Number: 5, Body: "Closes #1"},
+		diff: "+x",
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	if err := runReviewWith(context.Background(), 5, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(judge.intent, "do exactly this") {
+		t.Errorf("expected explicit intent in judge call, got %q", judge.intent)
+	}
+	if gh.issue != nil && strings.Contains(judge.intent, "review cmd") {
+		t.Error("issue should not have been fetched when --intent set")
+	}
+}
+
+func TestRunReview_NoLinkedIssue_NoIntentFlag_Errors(t *testing.T) {
+	resetReviewFlags()
+	gh := &fakeReviewGH{
+		pr: &github.PRDetails{Number: 9, Body: "no closing keyword here"},
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	err := runReviewWith(context.Background(), 9, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	if err == nil {
+		t.Fatal("expected error for missing intent")
+	}
+	if !strings.Contains(err.Error(), "no linked issue") {
+		t.Errorf("error should mention linked issue, got: %v", err)
+	}
+	if gh.postCalled {
+		t.Error("PostVerdict should not be called on intent error")
+	}
+}
+
+func TestRunReview_JudgeError_Propagates(t *testing.T) {
+	resetReviewFlags()
+	gh := &fakeReviewGH{
+		pr:    &github.PRDetails{Number: 1, Body: "Closes #2"},
+		issue: &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
+		diff:  "diff",
+	}
+	judge := &fakeReviewJudge{err: errors.New("boom")}
+
+	err := runReviewWith(context.Background(), 1, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "quality judge") {
+		t.Errorf("error should mention quality judge, got: %v", err)
+	}
+	if gh.postCalled {
+		t.Error("verdict should not be posted on judge error")
+	}
+}
+
+func TestRunReview_FailingVerdict_PostsAndExitsNonZero(t *testing.T) {
+	resetReviewFlags()
+	gh := &fakeReviewGH{
+		pr:    &github.PRDetails{Number: 1, Body: "Closes #2"},
+		issue: &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
+		diff:  "diff",
+	}
+	judge := &fakeReviewJudge{verdict: failingVerdict()}
+
+	err := runReviewWith(context.Background(), 1, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	if err == nil {
+		t.Fatal("expected non-nil error to gate CI on failing verdict")
+	}
+	if !gh.postCalled {
+		t.Error("failing verdict should still be posted before exiting")
+	}
+}
+
+func TestRunReview_NoComment_PrintsToStdout(t *testing.T) {
+	resetReviewFlags()
+	reviewNoCommentFlag = true
+	defer resetReviewFlags()
+
+	gh := &fakeReviewGH{
+		pr:    &github.PRDetails{Number: 1, Body: "Closes #2"},
+		issue: &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
+		diff:  "diff",
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	// Pipe stdout to a temp file we can read back.
+	tmp, err := os.CreateTemp("", "review-stdout-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	defer func() { _ = tmp.Close() }()
+
+	if err := runReviewWith(context.Background(), 1, reviewDeps{gh: gh, judge: judge, stdout: tmp}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gh.postCalled {
+		t.Error("PostVerdict should not be called when --no-comment is set")
+	}
+	if _, err := tmp.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	out, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "VAIrdict Verdict") {
+		t.Errorf("expected verdict in stdout, got: %q", string(out))
+	}
+}
+
+func TestRunReview_FetchPRError(t *testing.T) {
+	resetReviewFlags()
+	gh := &fakeReviewGH{prErr: errors.New("not found")}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	err := runReviewWith(context.Background(), 99, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunReview_FetchDiffError(t *testing.T) {
+	resetReviewFlags()
+	gh := &fakeReviewGH{
+		pr:      &github.PRDetails{Number: 1, Body: "Closes #2"},
+		issue:   &github.IssueDetails{Number: 2, Title: "t", Body: "b"},
+		diffErr: errors.New("no diff"),
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	err := runReviewWith(context.Background(), 1, reviewDeps{gh: gh, judge: judge, stdout: os.Stdout})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -45,17 +45,19 @@ func (f *fakeReviewGH) PostVerdict(_ context.Context, n int, v *state.Verdict, _
 }
 
 // fakeReviewJudge captures the inputs to Judge so tests can verify the
-// command stitches the intent + diff together correctly.
+// command threads intent / plan / diff through correctly.
 type fakeReviewJudge struct {
 	verdict *state.Verdict
 	err     error
 	intent  string
 	plan    string
+	diff    string
 }
 
-func (f *fakeReviewJudge) Judge(_ context.Context, intent, plan, _ string) (*state.Verdict, error) {
+func (f *fakeReviewJudge) Judge(_ context.Context, intent, plan, diff string) (*state.Verdict, error) {
 	f.intent = intent
 	f.plan = plan
+	f.diff = diff
 	return f.verdict, f.err
 }
 
@@ -97,8 +99,8 @@ func TestRunReview_HappyPath_LinkedIssue(t *testing.T) {
 	if !strings.Contains(judge.intent, "review cmd") || !strings.Contains(judge.intent, "build it") {
 		t.Errorf("judge intent missing issue text: %q", judge.intent)
 	}
-	if !strings.Contains(judge.intent, "diff --git") {
-		t.Errorf("judge intent missing diff: %q", judge.intent)
+	if !strings.Contains(judge.diff, "diff --git") {
+		t.Errorf("judge diff missing PR diff: %q", judge.diff)
 	}
 	if judge.plan != "" {
 		t.Errorf("plan should be empty in review mode, got %q", judge.plan)

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -392,15 +392,32 @@ func runCodePhase(ctx context.Context, cfg *config.Config, store *state.Store, t
 	return result, nil
 }
 
+// codeDiffBase returns the git base ref to diff against — origin/main when
+// it exists, otherwise local main. Hoisted out of codeDiffSummary so the
+// quality-phase diff helper uses the same base.
+func codeDiffBase(workDir string) string {
+	if _, err := execCommandInDir(workDir, "git", "rev-parse", "--verify", "origin/main"); err == nil {
+		return "origin/main"
+	}
+	return "main"
+}
+
+// codeDiffFull returns the full unified diff of HEAD against the diff base
+// (origin/main or main). Used to feed the quality judge concrete code
+// content rather than a directory path. Empty on error.
+func codeDiffFull(workDir string) string {
+	out, err := execCommandInDir(workDir, "git", "diff", codeDiffBase(workDir)+"...HEAD")
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
 // codeDiffSummary builds a `## Files touched` section from `git diff --stat`
 // against origin/main (or main if origin is not present). Empty on error so
 // the caller gracefully falls back to no summary.
 func codeDiffSummary(workDir string) string {
-	base := "main"
-	if _, err := execCommandInDir(workDir, "git", "rev-parse", "--verify", "origin/main"); err == nil {
-		base = "origin/main"
-	}
-	out, err := execCommandInDir(workDir, "git", "diff", "--stat", base+"...HEAD")
+	out, err := execCommandInDir(workDir, "git", "diff", "--stat", codeDiffBase(workDir)+"...HEAD")
 	if err != nil {
 		return ""
 	}
@@ -550,7 +567,12 @@ func runQualityPhase(
 	r.PhaseStart(state.PhaseQuality)
 
 	judge := qualityjudge.New(client, &qualityjudge.ExecRunner{}, *cfg)
-	phase := qualityphase.New(judge, cfg.Phases.Quality, workDir)
+	// Compute the unified diff once, here, so the judge gets concrete
+	// code content rather than just a working-directory path. The diff
+	// is stable across requeue loops because the quality phase never
+	// rewrites code.
+	diff := codeDiffFull(workDir)
+	phase := qualityphase.New(judge, cfg.Phases.Quality, diff)
 
 	result, err := phase.Run(ctx, task, plan)
 	if err != nil {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -3,9 +3,11 @@ package github
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -74,6 +76,25 @@ func (e *ExecRunner) Run(ctx context.Context, name string, args ...string) ([]by
 type PR struct {
 	URL    string
 	Number int
+}
+
+// PRDetails carries the fields needed to review an existing PR. It is the
+// minimal projection of `gh pr view --json` that the review command needs;
+// extending it is cheap if more fields are needed later.
+type PRDetails struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	Body        string `json:"body"`
+	HeadRefName string `json:"headRefName"`
+	BaseRefName string `json:"baseRefName"`
+}
+
+// IssueDetails is the minimal projection of `gh issue view --json` that the
+// review command uses to derive an intent string from a linked issue.
+type IssueDetails struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
 }
 
 // CreatePROpts holds options for creating a pull request.
@@ -163,6 +184,69 @@ func parsePRNumber(url string) int {
 	}
 	last := parts[len(parts)-1]
 	n, err := strconv.Atoi(last)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// FetchPR loads the metadata for an existing PR via `gh pr view --json`.
+// Returns a PRDetails populated from the gh JSON output. The fields fetched
+// are deliberately limited to those needed by the review command.
+func (c *Client) FetchPR(ctx context.Context, number int) (*PRDetails, error) {
+	out, err := c.runner.Run(ctx, "gh", "pr", "view", strconv.Itoa(number),
+		"--json", "number,title,body,headRefName,baseRefName")
+	if err != nil {
+		return nil, fmt.Errorf("fetching PR #%d: %w", number, err)
+	}
+	var pr PRDetails
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return nil, fmt.Errorf("parsing gh pr view output: %w", err)
+	}
+	return &pr, nil
+}
+
+// FetchIssue loads the metadata for an existing issue via `gh issue view`.
+// Used by the review command to derive an intent string from the issue
+// linked in the PR body.
+func (c *Client) FetchIssue(ctx context.Context, number int) (*IssueDetails, error) {
+	out, err := c.runner.Run(ctx, "gh", "issue", "view", strconv.Itoa(number),
+		"--json", "number,title,body")
+	if err != nil {
+		return nil, fmt.Errorf("fetching issue #%d: %w", number, err)
+	}
+	var iss IssueDetails
+	if err := json.Unmarshal(out, &iss); err != nil {
+		return nil, fmt.Errorf("parsing gh issue view output: %w", err)
+	}
+	return &iss, nil
+}
+
+// FetchPRDiff returns the unified diff of the PR via `gh pr diff <n>`.
+// Used by the review command to give the quality judge enough context
+// without actually checking the branch out.
+func (c *Client) FetchPRDiff(ctx context.Context, number int) (string, error) {
+	out, err := c.runner.Run(ctx, "gh", "pr", "diff", strconv.Itoa(number))
+	if err != nil {
+		return "", fmt.Errorf("fetching diff for PR #%d: %w", number, err)
+	}
+	return string(out), nil
+}
+
+// linkedIssueRe matches GitHub's PR-closes-issue keywords. Case-insensitive,
+// matches `Closes #12`, `fixes #34`, `Resolves: #56`, etc. Captures the
+// issue number into group 1.
+var linkedIssueRe = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[^\n#]*#(\d+)`)
+
+// ParseLinkedIssue scans a PR body for the first GitHub closing-keyword
+// reference (Closes/Fixes/Resolves) and returns the linked issue number,
+// or 0 if no such reference is found.
+func ParseLinkedIssue(body string) int {
+	m := linkedIssueRe.FindStringSubmatch(body)
+	if m == nil {
+		return 0
+	}
+	n, err := strconv.Atoi(m[1])
 	if err != nil {
 		return 0
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -345,13 +345,13 @@ func FormatPRBody(task *state.Task, issueNumber int, summary string) string {
 func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int) string {
 	var b strings.Builder
 
-	// Header with pass/fail status. The icon goes first so the outcome
-	// is visible at a glance in GitHub's PR feed (where comments are
-	// often skimmed without expanding).
+	// Header with pass/fail status. The icon sits next to the status
+	// word so it reads as a single unit ("✅ PASS") rather than a
+	// floating glyph at the start of the line.
 	if verdict.Pass {
-		b.WriteString("## ✅ VAIrdict Verdict: PASS\n\n")
+		b.WriteString("## VAIrdict Verdict: ✅ PASS\n\n")
 	} else {
-		b.WriteString("## ❌ VAIrdict Verdict: FAIL\n\n")
+		b.WriteString("## VAIrdict Verdict: ❌ FAIL\n\n")
 	}
 
 	// Summary line.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -276,24 +276,38 @@ func (c *Client) ApprovePR(ctx context.Context, prNumber int, body string) error
 	return nil
 }
 
-// PostVerdict posts a structured verdict comment on a PR. On pass, it also
-// approves the PR via the review API.
+// cannotApproveOwnPRRe matches the GitHub API error returned when the
+// authenticated user tries to approve a PR they authored. We detect this
+// (rather than failing the run) so PostVerdict can gracefully fall back
+// to a regular comment — discovered via dogfooding `vairdict review` on
+// a self-authored PR.
+var cannotApproveOwnPRRe = regexp.MustCompile(`(?i)can ?not approve your own pull request`)
+
+// PostVerdict posts a structured verdict comment on a PR. On pass, it
+// tries to approve via the review API; if GitHub refuses because the PR
+// is self-authored, it falls back to a plain comment so the verdict still
+// lands. On fail, it posts a plain comment directly.
 func (c *Client) PostVerdict(ctx context.Context, prNumber int, verdict *state.Verdict, phase state.Phase, loop int) error {
 	comment := FormatVerdictComment(verdict, phase, loop)
 
 	if verdict.Pass {
-		// Approve with the verdict as the review body.
-		if err := c.ApprovePR(ctx, prNumber, comment); err != nil {
+		err := c.ApprovePR(ctx, prNumber, comment)
+		if err == nil {
+			slog.Info("verdict posted", "pr", prNumber, "pass", true, "score", verdict.Score, "mode", "approval")
+			return nil
+		}
+		if !cannotApproveOwnPRRe.MatchString(err.Error()) {
 			return fmt.Errorf("posting verdict approval: %w", err)
 		}
-	} else {
-		// Post as a regular comment on failure.
-		if err := c.AddComment(ctx, prNumber, comment); err != nil {
-			return fmt.Errorf("posting verdict comment: %w", err)
-		}
+		// Self-authored PR — gh refuses approval. Fall through to a
+		// plain comment so the verdict still gets posted.
+		slog.Info("approval rejected (self-authored PR), falling back to comment", "pr", prNumber)
 	}
 
-	slog.Info("verdict posted", "pr", prNumber, "pass", verdict.Pass, "score", verdict.Score)
+	if err := c.AddComment(ctx, prNumber, comment); err != nil {
+		return fmt.Errorf("posting verdict comment: %w", err)
+	}
+	slog.Info("verdict posted", "pr", prNumber, "pass", verdict.Pass, "score", verdict.Score, "mode", "comment")
 	return nil
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -345,11 +345,13 @@ func FormatPRBody(task *state.Task, issueNumber int, summary string) string {
 func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int) string {
 	var b strings.Builder
 
-	// Header with pass/fail status.
+	// Header with pass/fail status. The icon goes first so the outcome
+	// is visible at a glance in GitHub's PR feed (where comments are
+	// often skimmed without expanding).
 	if verdict.Pass {
-		b.WriteString("## VAIrdict Verdict: PASS\n\n")
+		b.WriteString("## ✅ VAIrdict Verdict: PASS\n\n")
 	} else {
-		b.WriteString("## VAIrdict Verdict: FAIL\n\n")
+		b.WriteString("## ❌ VAIrdict Verdict: FAIL\n\n")
 	}
 
 	// Summary line.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -186,6 +186,45 @@ func TestPostVerdict_Pass_ApprovesAndComments(t *testing.T) {
 	}
 }
 
+func TestPostVerdict_Pass_SelfAuthored_FallsBackToComment(t *testing.T) {
+	// gh returns this exact error message when the authenticated user
+	// tries to approve their own PR. PostVerdict should swallow it and
+	// fall back to a plain comment so review-mode dogfooding works.
+	runner := successRunner()
+	runner.Responses["gh pr review"] = fakeResponse{
+		Err: errors.New("failed to create review: GraphQL: Review Can not approve your own pull request (addPullRequestReview)"),
+	}
+	client := New(runner)
+
+	verdict := &state.Verdict{Score: 92, Pass: true}
+	err := client.PostVerdict(context.Background(), 59, verdict, state.PhaseQuality, 1)
+	if err != nil {
+		t.Fatalf("expected fallback to comment, got error: %v", err)
+	}
+
+	foundComment := false
+	for _, call := range runner.Calls {
+		if call.Name == "gh" && len(call.Args) >= 2 && call.Args[0] == "pr" && call.Args[1] == "comment" {
+			foundComment = true
+		}
+	}
+	if !foundComment {
+		t.Error("expected fallback to gh pr comment after approval rejection")
+	}
+}
+
+func TestPostVerdict_Pass_OtherApprovalError_Propagates(t *testing.T) {
+	runner := successRunner()
+	runner.Responses["gh pr review"] = fakeResponse{Err: errors.New("network error")}
+	client := New(runner)
+
+	verdict := &state.Verdict{Score: 92, Pass: true}
+	err := client.PostVerdict(context.Background(), 7, verdict, state.PhaseQuality, 1)
+	if err == nil {
+		t.Fatal("expected non-self-PR approval errors to propagate")
+	}
+}
+
 func TestPostVerdict_Fail_CommentsOnly(t *testing.T) {
 	runner := successRunner()
 	client := New(runner)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -279,7 +279,7 @@ func TestFormatVerdictComment_Pass(t *testing.T) {
 		name string
 		want string
 	}{
-		{"header", "## ✅ VAIrdict Verdict: PASS"},
+		{"header", "## VAIrdict Verdict: ✅ PASS"},
 		{"score", "**Score:** 95%"},
 		{"phase", "**Phase:** quality"},
 		{"loop", "**Loop:** 1"},
@@ -320,7 +320,7 @@ func TestFormatVerdictComment_Fail(t *testing.T) {
 		name string
 		want string
 	}{
-		{"header", "## ❌ VAIrdict Verdict: FAIL"},
+		{"header", "## VAIrdict Verdict: ❌ FAIL"},
 		{"score", "**Score:** 40%"},
 		{"loop", "**Loop:** 2"},
 		{"blocking section", "### Blocking Gaps"},

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -279,7 +279,7 @@ func TestFormatVerdictComment_Pass(t *testing.T) {
 		name string
 		want string
 	}{
-		{"header", "## VAIrdict Verdict: PASS"},
+		{"header", "## ✅ VAIrdict Verdict: PASS"},
 		{"score", "**Score:** 95%"},
 		{"phase", "**Phase:** quality"},
 		{"loop", "**Loop:** 1"},
@@ -320,7 +320,7 @@ func TestFormatVerdictComment_Fail(t *testing.T) {
 		name string
 		want string
 	}{
-		{"header", "## VAIrdict Verdict: FAIL"},
+		{"header", "## ❌ VAIrdict Verdict: FAIL"},
 		{"score", "**Score:** 40%"},
 		{"loop", "**Loop:** 2"},
 		{"blocking section", "### Blocking Gaps"},

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -402,6 +402,100 @@ func TestGeneratePRTitle_Long(t *testing.T) {
 	}
 }
 
+func TestFetchPR(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh pr view": {Output: []byte(`{"number":46,"title":"add review cmd","body":"Closes #48","headRefName":"feat/x","baseRefName":"main"}`)},
+		},
+	}
+	client := New(runner)
+
+	pr, err := client.FetchPR(context.Background(), 46)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr.Number != 46 || pr.Title != "add review cmd" || pr.HeadRefName != "feat/x" || pr.BaseRefName != "main" {
+		t.Errorf("unexpected pr: %+v", pr)
+	}
+}
+
+func TestFetchPR_RunError(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh pr view": {Err: errors.New("not found")},
+		},
+	}
+	if _, err := New(runner).FetchPR(context.Background(), 9); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFetchPR_InvalidJSON(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh pr view": {Output: []byte("not json")},
+		},
+	}
+	if _, err := New(runner).FetchPR(context.Background(), 9); err == nil {
+		t.Fatal("expected json parse error")
+	}
+}
+
+func TestFetchIssue(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh issue view": {Output: []byte(`{"number":48,"title":"review cmd","body":"intent here"}`)},
+		},
+	}
+	iss, err := New(runner).FetchIssue(context.Background(), 48)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if iss.Number != 48 || iss.Title != "review cmd" || iss.Body != "intent here" {
+		t.Errorf("unexpected issue: %+v", iss)
+	}
+}
+
+func TestFetchPRDiff(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh pr diff": {Output: []byte("diff --git a/x b/x\n+hello\n")},
+		},
+	}
+	diff, err := New(runner).FetchPRDiff(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(diff, "+hello") {
+		t.Errorf("unexpected diff: %q", diff)
+	}
+}
+
+func TestParseLinkedIssue(t *testing.T) {
+	cases := []struct {
+		body string
+		want int
+	}{
+		{"Closes #42", 42},
+		{"closes #42", 42},
+		{"Fixes #7\n\nlots of context", 7},
+		{"Resolves #123 — done", 123},
+		{"fixed #5", 5},
+		{"resolved #5", 5},
+		{"some text Closes: #99", 99},
+		{"## Issue\nCloses #48\n", 48},
+		{"no linked issue here", 0},
+		{"#42 alone is not enough", 0},
+		{"see #42 for context", 0},
+		{"", 0},
+	}
+	for _, tc := range cases {
+		if got := ParseLinkedIssue(tc.body); got != tc.want {
+			t.Errorf("ParseLinkedIssue(%q) = %d, want %d", tc.body, got, tc.want)
+		}
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && containsStr(s, substr)
 }

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -112,19 +112,26 @@ Respond with this exact JSON structure:
   ]
 }`
 
-// Judge evaluates whether the code in workDir fulfills the given intent and plan.
-// It runs AI-based intent verification and optionally e2e tests, returning a
-// combined Verdict.
-func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, workDir string) (*state.Verdict, error) {
+// Judge evaluates whether the given diff fulfills the original intent and plan.
+// It runs AI-based intent verification (against the diff content, not a
+// directory path) and optionally e2e tests, returning a combined Verdict.
+//
+// `diff` is the full unified diff the LLM is asked to judge. Callers
+// (the quality phase orchestrator and `vairdict review`) compute it via
+// git before invoking the judge. An empty diff is allowed but will
+// produce a low score because the LLM has nothing concrete to evaluate.
+func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, diff string) (*state.Verdict, error) {
 	// Step 1: AI intent verification.
-	aiVerdict, err := j.evaluateIntent(ctx, intent, plan, workDir)
+	aiVerdict, err := j.evaluateIntent(ctx, intent, plan, diff)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating intent: %w", err)
 	}
 
-	// Step 2: Run e2e tests if configured.
+	// Step 2: Run e2e tests if configured. Run them in the current process
+	// working directory — the judge no longer takes a workDir, and the
+	// orchestrator always invokes us with the project root as cwd.
 	if j.cfg.Phases.Quality.E2ERequired && j.cfg.Commands.E2E != "" {
-		e2eGap := j.runE2E(ctx, workDir)
+		e2eGap := j.runE2E(ctx, ".")
 		if e2eGap != nil {
 			aiVerdict.Gaps = append(aiVerdict.Gaps, *e2eGap)
 			// Penalize score for e2e failure: reduce by 30 points, floor at 0.
@@ -144,10 +151,14 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, wo
 	return aiVerdict, nil
 }
 
-// evaluateIntent uses the Claude API to assess whether the code matches the intent.
-func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan string, workDir string) (*state.Verdict, error) {
-	prompt := fmt.Sprintf("## Original Intent\n%s\n\n## Approved Plan\n%s\n\n## Work Directory\n%s",
-		intent, plan, workDir)
+// evaluateIntent uses the Claude API to assess whether the diff matches the intent.
+func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan string, diff string) (*state.Verdict, error) {
+	diffSection := diff
+	if strings.TrimSpace(diffSection) == "" {
+		diffSection = "(no diff provided — judge cannot evaluate code changes)"
+	}
+	prompt := fmt.Sprintf("## Original Intent\n%s\n\n## Approved Plan\n%s\n\n## Diff (unified format)\n```diff\n%s\n```",
+		intent, plan, diffSection)
 
 	var verdict state.Verdict
 	if err := j.client.CompleteWithSystem(ctx, systemPrompt, prompt, &verdict); err != nil {

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -62,8 +62,10 @@ func New(client Completer, runner CommandRunner, cfg config.Config) *QualityJudg
 const systemPrompt = `You are a quality judge for a software development process engine.
 Your job is to evaluate whether implemented code fulfills the original task intent.
 
-You are given the original intent, the approved plan, and a summary of the work directory.
-Evaluate whether the implementation matches the intent and plan.
+You are given the original intent, the approved plan, and the unified diff
+of the changes that were made. Evaluate whether the diff actually
+implements the intent and plan. Base every observation on what the diff
+shows — never invent file contents that are not in the diff.
 
 You MUST respond with valid JSON only — no markdown, no explanation outside the JSON.
 

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -63,7 +63,7 @@ func TestJudge_Pass(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes", "/work")
+	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes", "diff --git a/x.go b/x.go\n+func H() {}")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestJudge_IntentMismatch(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "build auth system", "1. Implement auth", "/work")
+	verdict, err := judge.Judge(context.Background(), "build auth system", "1. Implement auth", "diff --git a/x.go b/x.go\n+func crud() {}")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestJudge_E2EPass(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestJudge_E2EFail(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestJudge_E2EFailHighScore(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestJudge_E2ENotRequired(t *testing.T) {
 	// E2ERequired is false by default.
 
 	judge := New(fake, nil, cfg)
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestJudge_E2ERequiredNoCommand(t *testing.T) {
 	// Commands.E2E is empty.
 
 	judge := New(fake, nil, cfg)
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestJudge_PassThresholdEnforced(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestJudge_PassAtExactThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestJudge_ClientError(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	_, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err == nil {
 		t.Fatal("expected error when client fails")
 	}
@@ -360,7 +360,7 @@ func TestJudge_MixedGapsWithE2E(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -405,7 +405,7 @@ func TestJudge_ScoreFloorAtZero(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "/work")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -423,13 +423,14 @@ func TestJudge_ScoreFloorAtZero(t *testing.T) {
 	}
 }
 
-func TestJudge_PromptContainsWorkDir(t *testing.T) {
+func TestJudge_PromptContainsDiff(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{Score: 80, Pass: true},
 	}
 
 	judge := New(fake, nil, testConfig())
-	_, err := judge.Judge(context.Background(), "intent", "plan", "/my/project/dir")
+	const diff = "diff --git a/foo.go b/foo.go\n+++ b/foo.go\n+func Foo() {}"
+	_, err := judge.Judge(context.Background(), "intent", "plan", diff)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -437,8 +438,33 @@ func TestJudge_PromptContainsWorkDir(t *testing.T) {
 	if len(fake.Calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
 	}
-	if !contains(fake.Calls[0].Prompt, "/my/project/dir") {
-		t.Error("expected prompt to contain work directory path")
+	if !contains(fake.Calls[0].Prompt, "func Foo() {}") {
+		t.Error("expected prompt to contain diff content")
+	}
+	if !contains(fake.Calls[0].Prompt, "## Diff") {
+		t.Error("expected prompt to contain diff section header")
+	}
+}
+
+func TestJudge_EmptyDiffPlaceholder(t *testing.T) {
+	// Empty diff should still produce a prompt — with a placeholder line
+	// — so the LLM gets a clear signal there is nothing to evaluate
+	// instead of an empty code block.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{Score: 10, Pass: false},
+	}
+
+	judge := New(fake, nil, testConfig())
+	_, err := judge.Judge(context.Background(), "intent", "plan", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.Calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
+	}
+	if !contains(fake.Calls[0].Prompt, "no diff provided") {
+		t.Error("expected empty-diff placeholder in prompt")
 	}
 }
 
@@ -470,7 +496,7 @@ func TestJudge_SummaryRoundTrip(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Phases.Quality.E2ERequired = false
 	judge := New(fake, &FakeRunner{}, cfg)
-	verdict, err := judge.Judge(context.Background(), "build it", "the plan", "/tmp/work")
+	verdict, err := judge.Judge(context.Background(), "build it", "the plan", "fake-diff")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/phases/quality/phase.go
+++ b/internal/phases/quality/phase.go
@@ -29,26 +29,32 @@ type PhaseResult struct {
 }
 
 // Judge is the interface for the quality judge. The real implementation lives
-// in internal/judges/quality.
+// in internal/judges/quality. The third argument is the unified diff of the
+// code under review — the judge no longer reads the working directory itself.
 type Judge interface {
-	Judge(ctx context.Context, intent, plan, workDir string) (*state.Verdict, error)
+	Judge(ctx context.Context, intent, plan, diff string) (*state.Verdict, error)
 }
 
 // QualityPhase orchestrates the quality phase: judge loop on already-coded work.
 // Unlike plan and code phases, there is no producer agent — the code is
-// already written by the time this phase runs.
+// already written by the time this phase runs. The diff is computed by the
+// orchestrator (cmd/vairdict/run.go) before constructing the phase, so the
+// same content is judged on every requeue loop.
 type QualityPhase struct {
-	judge   Judge
-	cfg     config.QualityPhaseConfig
-	workDir string
+	judge Judge
+	cfg   config.QualityPhaseConfig
+	diff  string
 }
 
-// New creates a QualityPhase with the given judge, config, and work directory.
-func New(judge Judge, cfg config.QualityPhaseConfig, workDir string) *QualityPhase {
+// New creates a QualityPhase with the given judge, config, and diff. The
+// diff should be the full unified diff of the code under review (e.g.
+// `git diff origin/main...HEAD`). An empty diff is allowed but will
+// produce a low-confidence verdict.
+func New(judge Judge, cfg config.QualityPhaseConfig, diff string) *QualityPhase {
 	return &QualityPhase{
-		judge:   judge,
-		cfg:     cfg,
-		workDir: workDir,
+		judge: judge,
+		cfg:   cfg,
+		diff:  diff,
 	}
 }
 
@@ -74,7 +80,7 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 			return nil, fmt.Errorf("transitioning to quality review: %w", err)
 		}
 
-		verdict, err := p.judge.Judge(ctx, task.Intent, plan, p.workDir)
+		verdict, err := p.judge.Judge(ctx, task.Intent, plan, p.diff)
 		if err != nil {
 			return nil, fmt.Errorf("running quality judge: %w", err)
 		}

--- a/internal/phases/quality/phase_test.go
+++ b/internal/phases/quality/phase_test.go
@@ -60,7 +60,7 @@ func TestRun_PassFirstTry(t *testing.T) {
 	}}
 
 	task := qualityTask(t)
-	phase := New(judge, defaultCfg(), "/work")
+	phase := New(judge, defaultCfg(), "fake-diff")
 
 	result, err := phase.Run(context.Background(), task, "the plan")
 	if err != nil {
@@ -98,7 +98,7 @@ func TestRun_PassOnRetry_NonBlockingGaps(t *testing.T) {
 	}}
 
 	task := qualityTask(t)
-	phase := New(judge, defaultCfg(), "/work")
+	phase := New(judge, defaultCfg(), "fake-diff")
 
 	result, err := phase.Run(context.Background(), task, "the plan")
 	if err != nil {
@@ -130,7 +130,7 @@ func TestRun_RequeueToCode_OnP0Gap(t *testing.T) {
 	}}
 
 	task := qualityTask(t)
-	phase := New(judge, defaultCfg(), "/work")
+	phase := New(judge, defaultCfg(), "fake-diff")
 
 	result, err := phase.Run(context.Background(), task, "the plan")
 	if err != nil {
@@ -165,7 +165,7 @@ func TestRun_RequeueToCode_OnP1Gap(t *testing.T) {
 	}}
 
 	task := qualityTask(t)
-	phase := New(judge, defaultCfg(), "/work")
+	phase := New(judge, defaultCfg(), "fake-diff")
 
 	result, err := phase.Run(context.Background(), task, "the plan")
 	if err != nil {
@@ -190,7 +190,7 @@ func TestRun_Escalation_NonBlockingLoopOut(t *testing.T) {
 	task := qualityTask(t)
 	cfg := defaultCfg()
 	cfg.MaxLoops = 2
-	phase := New(judge, cfg, "/work")
+	phase := New(judge, cfg, "fake-diff")
 
 	result, err := phase.Run(context.Background(), task, "the plan")
 	if err != nil {
@@ -211,7 +211,7 @@ func TestRun_JudgeError(t *testing.T) {
 	judge := &fakeJudge{err: errors.New("claude crashed")}
 
 	task := qualityTask(t)
-	phase := New(judge, defaultCfg(), "/work")
+	phase := New(judge, defaultCfg(), "fake-diff")
 
 	_, err := phase.Run(context.Background(), task, "the plan")
 	if err == nil {
@@ -226,7 +226,7 @@ func TestRun_WrongState(t *testing.T) {
 	judge := &fakeJudge{verdicts: []*state.Verdict{{Score: 100, Pass: true}}}
 
 	task := state.NewTask("test-1", "intent")
-	phase := New(judge, defaultCfg(), "/work")
+	phase := New(judge, defaultCfg(), "fake-diff")
 
 	_, err := phase.Run(context.Background(), task, "plan")
 	if err == nil {
@@ -245,7 +245,7 @@ func TestRun_AttemptsStored(t *testing.T) {
 	}}
 
 	task := qualityTask(t)
-	phase := New(judge, defaultCfg(), "/work")
+	phase := New(judge, defaultCfg(), "fake-diff")
 
 	result, err := phase.Run(context.Background(), task, "the plan")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `vairdict review <pr-number>` subcommand that runs only the quality judge against an existing PR and posts the verdict comment
- New `internal/github` helpers: `FetchPR`, `FetchIssue`, `FetchPRDiff`, `ParseLinkedIssue`
- Intent resolution: `--intent` wins → else parses `Closes/Fixes/Resolves #N` from PR body → else clean error
- `--no-comment` prints to stdout for local dry-run
- Failing verdict is still posted, then exits non-zero so it can gate CI
- Orchestration factored behind `reviewDeps` so tests use plain fakes (no exec, no real completer)
- Dogfooding-driven follow-up commit: self-PR approval falls back to a comment, review flags threaded through `reviewDeps` instead of package globals, `stdout` typed as `io.Writer`

Closes #48

## Test plan
- [x] `go test ./...` passes
- [x] `make lint` clean
- [x] Manual smoke test against PR #46: `vairdict review 46 --no-comment` → PASS 92%, exit 0
- [x] Manual smoke test posting on a real PR: `vairdict review 59` against this PR → 88% PASS, comment posted via fallback
- [x] Verify non-zero exit on failing verdict: `vairdict review 59 --intent "implement WebRTC..."` → score 0%, exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)