### PR TITLE
feat(cmd): DI refactor for runTask orchestration + 7 tests

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,10 +10,10 @@ Update this file when opening, completing, or blocking an issue.
 ---
 
 ## Ready to Start
-- #51 test: orchestration coverage for runTask + runQualityPhase (DI refactor)
+- none
 
 ## In Progress
-- none
+- #51 test: orchestration coverage for runTask + runQualityPhase (DI refactor)
 
 ## Blocked
 - #39 cmd/auto-vairdict: auto-merge on passing verdict (blocked on M3 complete)

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -106,6 +106,95 @@ func fileExistsFunc(path string) bool {
 	return err == nil && !info.IsDir()
 }
 
+// --- Orchestration interfaces ---
+//
+// These describe what the run orchestrator needs from each subsystem.
+// Production uses defaultRunDeps; tests inject fakes. Interfaces are
+// co-located here (not in the subsystem packages) because they describe
+// the orchestrator's requirements, not the implementations' capabilities.
+
+type planRunner interface {
+	Run(ctx context.Context, task *state.Task) (*planphase.PhaseResult, error)
+}
+
+type codeRunner interface {
+	Run(ctx context.Context, task *state.Task, plan string) (*codephase.PhaseResult, error)
+}
+
+type qualityRunner interface {
+	Run(ctx context.Context, task *state.Task, plan string) (*qualityphase.PhaseResult, error)
+}
+
+// ghOrchestrator is the subset of github.Client the orchestrator needs.
+type ghOrchestrator interface {
+	CreateBranch(ctx context.Context, taskID, intent string) (string, error)
+	CreatePR(ctx context.Context, opts github.CreatePROpts) (*github.PR, error)
+	PostVerdict(ctx context.Context, prNumber int, v *state.Verdict, phase state.Phase, loop int) error
+}
+
+// runDeps bundles all dependencies the orchestration loop needs.
+type runDeps struct {
+	plan         planRunner
+	code         codeRunner
+	quality      qualityRunner
+	gh           ghOrchestrator
+	commit       func(ctx context.Context, task *state.Task) error
+	onEscalation func(ctx context.Context, task *state.Task, result escalation.Result) error
+	issueNumber  int
+}
+
+// --- Default (production) phase runner implementations ---
+
+type defaultPlanRunner struct {
+	cfg    *config.Config
+	client completer
+	store  *state.Store
+	r      ui.Renderer
+}
+
+func (d *defaultPlanRunner) Run(ctx context.Context, task *state.Task) (*planphase.PhaseResult, error) {
+	return runPlanPhase(ctx, d.cfg, d.client, d.store, task, d.r)
+}
+
+type defaultCodeRunner struct {
+	cfg     *config.Config
+	store   *state.Store
+	workDir string
+	r       ui.Renderer
+}
+
+func (d *defaultCodeRunner) Run(ctx context.Context, task *state.Task, plan string) (*codephase.PhaseResult, error) {
+	return runCodePhase(ctx, d.cfg, d.store, task, plan, d.workDir, d.r)
+}
+
+type defaultQualityRunner struct {
+	cfg     *config.Config
+	client  completer
+	store   *state.Store
+	workDir string
+	r       ui.Renderer
+}
+
+func (d *defaultQualityRunner) Run(ctx context.Context, task *state.Task, plan string) (*qualityphase.PhaseResult, error) {
+	return runQualityPhase(ctx, d.cfg, d.client, d.store, task, plan, d.workDir, d.r)
+}
+
+func defaultRunDeps(cfg *config.Config, client completer, store *state.Store, workDir string, r ui.Renderer, ghClient *github.Client) runDeps {
+	return runDeps{
+		plan:    &defaultPlanRunner{cfg: cfg, client: client, store: store, r: r},
+		code:    &defaultCodeRunner{cfg: cfg, store: store, workDir: workDir, r: r},
+		quality: &defaultQualityRunner{cfg: cfg, client: client, store: store, workDir: workDir, r: r},
+		gh:      ghClient,
+		commit: func(ctx context.Context, task *state.Task) error {
+			return commitChanges(ctx, task, workDir, r)
+		},
+		onEscalation: func(ctx context.Context, task *state.Task, result escalation.Result) error {
+			return escalateAndExit(ctx, task, result, cfg.Escalation, ghClient)
+		},
+		issueNumber: issueFlag,
+	}
+}
+
 func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) error {
 	// Resolve overlay path from --env / CI auto-detect.
 	overlayPath, err := config.ResolveOverlayPath(envFlag, config.IsCI(), ".", fileExistsFunc)
@@ -192,8 +281,16 @@ func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) err
 	ghRunner := &github.ExecRunner{Dir: workDir}
 	ghClient := github.New(ghRunner)
 
+	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient)
+	return runOrchestration(ctx, deps, task, r)
+}
+
+// runOrchestration is the testable core of runTask. It receives all
+// dependencies via deps so tests can substitute fakes for every
+// external interaction (phases, GitHub, git commit, escalation).
+func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.Renderer) error {
 	// --- Plan phase ---
-	planResult, err := runPlanPhase(ctx, cfg, client, store, task, r)
+	planResult, err := deps.plan.Run(ctx, task)
 	if err != nil {
 		r.Error(err)
 		return err
@@ -202,16 +299,16 @@ func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) err
 	if planResult.Escalate {
 		gaps := lastGapsForPhase(task, state.PhasePlan)
 		r.Escalation(task.ID, state.PhasePlan, planResult.Loops, planResult.LastScore, gaps)
-		return escalateAndExit(ctx, task, escalation.Result{
+		return deps.onEscalation(ctx, task, escalation.Result{
 			Phase:     state.PhasePlan,
 			Loops:     planResult.Loops,
 			LastScore: planResult.LastScore,
 			Gaps:      gaps,
-		}, cfg.Escalation, ghClient)
+		})
 	}
 
 	// --- Create branch before code phase so commits land on it ---
-	branch, err := ghClient.CreateBranch(ctx, task.ID, task.Intent)
+	branch, err := deps.gh.CreateBranch(ctx, task.ID, task.Intent)
 	if err != nil {
 		r.Error(err)
 		return fmt.Errorf("creating branch: %w", err)
@@ -219,7 +316,7 @@ func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) err
 	r.Note("branch", branch)
 
 	// --- Code phase ---
-	codeResult, err := runCodePhase(ctx, cfg, store, task, planResult.Plan, workDir, r)
+	codeResult, err := deps.code.Run(ctx, task, planResult.Plan)
 	if err != nil {
 		r.Error(err)
 		return err
@@ -228,22 +325,22 @@ func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) err
 	if codeResult.Escalate {
 		gaps := lastGapsForPhase(task, state.PhaseCode)
 		r.Escalation(task.ID, state.PhaseCode, codeResult.Loops, codeResult.LastScore, gaps)
-		return escalateAndExit(ctx, task, escalation.Result{
+		return deps.onEscalation(ctx, task, escalation.Result{
 			Phase:     state.PhaseCode,
 			Loops:     codeResult.Loops,
 			LastScore: codeResult.LastScore,
 			Gaps:      gaps,
-		}, cfg.Escalation, ghClient)
+		})
 	}
 
 	// --- Commit any changes the coder made ---
-	if err := commitChanges(ctx, task, workDir, r); err != nil {
+	if err := deps.commit(ctx, task); err != nil {
 		r.Error(err)
 		return err
 	}
 
 	// --- Quality phase (gates the PR) ---
-	qualityResult, err := runQualityPhase(ctx, cfg, client, store, task, planResult.Plan, workDir, r)
+	qualityResult, err := deps.quality.Run(ctx, task, planResult.Plan)
 	if err != nil {
 		r.Error(err)
 		return err
@@ -257,26 +354,35 @@ func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) err
 		// needed.
 		gaps := lastGapsForPhase(task, state.PhaseQuality)
 		r.Escalation(task.ID, state.PhaseQuality, qualityResult.Loops, qualityResult.LastScore, gaps)
-		return escalateAndExit(ctx, task, escalation.Result{
+		return deps.onEscalation(ctx, task, escalation.Result{
 			Phase:     state.PhaseQuality,
 			Loops:     qualityResult.Loops,
 			LastScore: qualityResult.LastScore,
 			Gaps:      gaps,
-		}, cfg.Escalation, ghClient)
+		})
 	}
 
 	// --- Create GitHub PR (only after quality passes) ---
-	pr, err := createPR(ctx, task, workDir, branch, r)
+	title := github.GeneratePRTitle(task)
+	body := github.FormatPRBody(task, deps.issueNumber, "Implemented via VAIrdict run")
+	pr, err := deps.gh.CreatePR(ctx, github.CreatePROpts{
+		Title:       title,
+		Body:        body,
+		BaseBranch:  "main",
+		HeadBranch:  branch,
+		IssueNumber: deps.issueNumber,
+	})
 	if err != nil {
 		r.Error(err)
-		return err
+		return fmt.Errorf("creating PR: %w", err)
 	}
+	r.PRCreated(pr.URL)
 
 	// --- Post quality verdict comment on PR ---
 	if pr.Number > 0 {
 		lastVerdict := lastVerdictForPhase(task, state.PhaseQuality)
 		if lastVerdict != nil {
-			if err := ghClient.PostVerdict(ctx, pr.Number, lastVerdict, state.PhaseQuality, qualityResult.Loops); err != nil {
+			if err := deps.gh.PostVerdict(ctx, pr.Number, lastVerdict, state.PhaseQuality, qualityResult.Loops); err != nil {
 				// Log but don't fail the whole run for a comment posting failure.
 				slog.Warn("failed to post verdict comment", "error", err)
 			} else {
@@ -517,29 +623,6 @@ func execCommandInDir(dir string, name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	return cmd.CombinedOutput()
-}
-
-func createPR(ctx context.Context, task *state.Task, workDir string, branch string, r ui.Renderer) (*github.PR, error) {
-	ghRunner := &github.ExecRunner{Dir: workDir}
-	ghClient := github.New(ghRunner)
-
-	// Build PR content.
-	title := github.GeneratePRTitle(task)
-	body := github.FormatPRBody(task, issueFlag, "Implemented via VAIrdict run")
-
-	pr, err := ghClient.CreatePR(ctx, github.CreatePROpts{
-		Title:       title,
-		Body:        body,
-		BaseBranch:  "main",
-		HeadBranch:  branch,
-		IssueNumber: issueFlag,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating PR: %w", err)
-	}
-
-	r.PRCreated(pr.URL)
-	return pr, nil
 }
 
 // lastVerdictForPhase returns the verdict from the last attempt of the given phase.

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/escalation"
+	"github.com/vairdict/vairdict/internal/github"
+	codephase "github.com/vairdict/vairdict/internal/phases/code"
+	planphase "github.com/vairdict/vairdict/internal/phases/plan"
+	qualityphase "github.com/vairdict/vairdict/internal/phases/quality"
 	"github.com/vairdict/vairdict/internal/state"
 	"github.com/vairdict/vairdict/internal/ui"
 )
@@ -439,5 +443,334 @@ func TestDispatchEscalation_AlreadyEscalatedNoOp(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Escalation") {
 		t.Errorf("expected escalation output even when already escalated, got %q", out.String())
+	}
+}
+
+// --- Orchestration test fakes ---
+
+type fakePlanRunner struct {
+	result *planphase.PhaseResult
+	gaps   []state.Gap
+	err    error
+	called bool
+}
+
+func (f *fakePlanRunner) Run(_ context.Context, task *state.Task) (*planphase.PhaseResult, error) {
+	f.called = true
+	if f.result != nil {
+		task.Attempts = append(task.Attempts, state.Attempt{
+			Phase: state.PhasePlan, Loop: f.result.Loops,
+			Verdict: &state.Verdict{Score: f.result.LastScore, Pass: f.result.Pass, Gaps: f.gaps},
+		})
+	}
+	return f.result, f.err
+}
+
+type fakeCodeRunner struct {
+	result *codephase.PhaseResult
+	gaps   []state.Gap
+	err    error
+	called bool
+	plan   string
+}
+
+func (f *fakeCodeRunner) Run(_ context.Context, task *state.Task, plan string) (*codephase.PhaseResult, error) {
+	f.called = true
+	f.plan = plan
+	if f.result != nil {
+		task.Attempts = append(task.Attempts, state.Attempt{
+			Phase: state.PhaseCode, Loop: f.result.Loops,
+			Verdict: &state.Verdict{Score: f.result.LastScore, Pass: f.result.Pass, Gaps: f.gaps},
+		})
+	}
+	return f.result, f.err
+}
+
+type fakeQualityRunner struct {
+	result *qualityphase.PhaseResult
+	gaps   []state.Gap
+	err    error
+	called bool
+	plan   string
+}
+
+func (f *fakeQualityRunner) Run(_ context.Context, task *state.Task, plan string) (*qualityphase.PhaseResult, error) {
+	f.called = true
+	f.plan = plan
+	if f.result != nil {
+		task.Attempts = append(task.Attempts, state.Attempt{
+			Phase: state.PhaseQuality, Loop: f.result.Loops,
+			Verdict: &state.Verdict{Score: f.result.LastScore, Pass: f.result.Pass, Gaps: f.gaps},
+		})
+	}
+	return f.result, f.err
+}
+
+type fakeGHOrch struct {
+	branchName string
+	branchErr  error
+	pr         *github.PR
+	prErr      error
+	verdictErr error
+
+	branchCalled  bool
+	prCalled      bool
+	verdictCalled bool
+}
+
+func (f *fakeGHOrch) CreateBranch(context.Context, string, string) (string, error) {
+	f.branchCalled = true
+	return f.branchName, f.branchErr
+}
+
+func (f *fakeGHOrch) CreatePR(context.Context, github.CreatePROpts) (*github.PR, error) {
+	f.prCalled = true
+	return f.pr, f.prErr
+}
+
+func (f *fakeGHOrch) PostVerdict(context.Context, int, *state.Verdict, state.Phase, int) error {
+	f.verdictCalled = true
+	return f.verdictErr
+}
+
+// orchBundle groups the fakes so tests can inspect them after a run.
+type orchBundle struct {
+	plan    *fakePlanRunner
+	code    *fakeCodeRunner
+	quality *fakeQualityRunner
+	gh      *fakeGHOrch
+
+	commitCalled     bool
+	escalationCalled bool
+	escalationResult escalation.Result
+}
+
+var errEscalated = errors.New("escalated (test sentinel)")
+
+func newOrchBundle() *orchBundle {
+	return &orchBundle{
+		plan: &fakePlanRunner{result: &planphase.PhaseResult{
+			Pass: true, Loops: 1, LastScore: 90, Plan: "the plan",
+		}},
+		code: &fakeCodeRunner{result: &codephase.PhaseResult{
+			Pass: true, Loops: 1, LastScore: 100,
+		}},
+		quality: &fakeQualityRunner{result: &qualityphase.PhaseResult{
+			Pass: true, Loops: 1, LastScore: 95,
+		}},
+		gh: &fakeGHOrch{
+			branchName: "vairdict/test-abc",
+			pr:         &github.PR{URL: "https://github.com/x/y/pull/42", Number: 42},
+		},
+	}
+}
+
+func (b *orchBundle) deps() runDeps {
+	return runDeps{
+		plan:    b.plan,
+		code:    b.code,
+		quality: b.quality,
+		gh:      b.gh,
+		commit: func(context.Context, *state.Task) error {
+			b.commitCalled = true
+			return nil
+		},
+		onEscalation: func(_ context.Context, _ *state.Task, result escalation.Result) error {
+			b.escalationCalled = true
+			b.escalationResult = result
+			return errEscalated
+		},
+	}
+}
+
+// --- Orchestration tests ---
+
+func TestRunOrchestration_HappyPath(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	task := state.NewTask("t-1", "build the thing")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !b.plan.called {
+		t.Error("plan runner not called")
+	}
+	if !b.code.called {
+		t.Error("code runner not called")
+	}
+	if b.code.plan != "the plan" {
+		t.Errorf("code runner got plan %q, want %q", b.code.plan, "the plan")
+	}
+	if !b.quality.called {
+		t.Error("quality runner not called")
+	}
+	if b.quality.plan != "the plan" {
+		t.Errorf("quality runner got plan %q, want %q", b.quality.plan, "the plan")
+	}
+	if !b.commitCalled {
+		t.Error("commit not called")
+	}
+	if !b.gh.branchCalled {
+		t.Error("CreateBranch not called")
+	}
+	if !b.gh.prCalled {
+		t.Error("CreatePR not called")
+	}
+	if !b.gh.verdictCalled {
+		t.Error("PostVerdict not called")
+	}
+	if b.escalationCalled {
+		t.Error("escalation should not be called on happy path")
+	}
+}
+
+func TestRunOrchestration_PlanEscalates(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	b.plan.result = &planphase.PhaseResult{Escalate: true, Loops: 3, LastScore: 40}
+	b.plan.gaps = []state.Gap{{Severity: state.SeverityP1, Description: "missing req", Blocking: true}}
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+
+	if !errors.Is(err, errEscalated) {
+		t.Fatalf("expected errEscalated, got %v", err)
+	}
+	if !b.escalationCalled {
+		t.Error("escalation not called")
+	}
+	if b.escalationResult.Phase != state.PhasePlan {
+		t.Errorf("escalation phase = %s, want plan", b.escalationResult.Phase)
+	}
+	if b.code.called {
+		t.Error("code should not run when plan escalates")
+	}
+	if b.quality.called {
+		t.Error("quality should not run when plan escalates")
+	}
+	if b.gh.branchCalled {
+		t.Error("branch should not be created when plan escalates")
+	}
+	if b.gh.prCalled {
+		t.Error("PR should not be created when plan escalates")
+	}
+}
+
+func TestRunOrchestration_CodeEscalates(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	b.code.result = &codephase.PhaseResult{Escalate: true, Loops: 3, LastScore: 25}
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+
+	if !errors.Is(err, errEscalated) {
+		t.Fatalf("expected errEscalated, got %v", err)
+	}
+	if b.escalationResult.Phase != state.PhaseCode {
+		t.Errorf("escalation phase = %s, want code", b.escalationResult.Phase)
+	}
+	if b.quality.called {
+		t.Error("quality should not run when code escalates")
+	}
+	if b.gh.prCalled {
+		t.Error("PR should not be created when code escalates")
+	}
+	if b.commitCalled {
+		t.Error("commit should not be called when code escalates")
+	}
+}
+
+func TestRunOrchestration_QualityEscalates(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	b.quality.result = &qualityphase.PhaseResult{Escalate: true, Loops: 3, LastScore: 30}
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+
+	if !errors.Is(err, errEscalated) {
+		t.Fatalf("expected errEscalated, got %v", err)
+	}
+	if b.escalationResult.Phase != state.PhaseQuality {
+		t.Errorf("escalation phase = %s, want quality", b.escalationResult.Phase)
+	}
+	if b.gh.prCalled {
+		t.Error("PR should not be created when quality escalates")
+	}
+	// Commit happens BEFORE quality, so it should have been called.
+	if !b.commitCalled {
+		t.Error("commit should be called even when quality escalates (happens before quality)")
+	}
+}
+
+func TestRunOrchestration_QualityRequeueToCode(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	b.quality.result = &qualityphase.PhaseResult{RequeueToCode: true, Loops: 2, LastScore: 50}
+	b.quality.gaps = []state.Gap{{Severity: state.SeverityP0, Description: "code broken", Blocking: true}}
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+
+	if !errors.Is(err, errEscalated) {
+		t.Fatalf("expected errEscalated, got %v", err)
+	}
+	if b.escalationResult.Phase != state.PhaseQuality {
+		t.Errorf("escalation phase = %s, want quality", b.escalationResult.Phase)
+	}
+	if b.gh.prCalled {
+		t.Error("PR should not be created on requeue")
+	}
+}
+
+func TestRunOrchestration_PostVerdictFailure_DoesNotFailRun(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	b.gh.verdictErr = errors.New("github API down")
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+
+	if err != nil {
+		t.Fatalf("PostVerdict failure should not fail the run, got %v", err)
+	}
+	if !b.gh.verdictCalled {
+		t.Error("PostVerdict should have been attempted")
+	}
+	if !b.gh.prCalled {
+		t.Error("PR should still be created")
+	}
+}
+
+func TestRunOrchestration_BranchCreationFailure(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	b.gh.branchErr = errors.New("branch already exists")
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "creating branch") {
+		t.Errorf("error should mention branch creation: %v", err)
+	}
+	if b.code.called {
+		t.Error("code should not run after branch creation failure")
+	}
+	if b.escalationCalled {
+		t.Error("branch failure should not trigger escalation")
 	}
 }


### PR DESCRIPTION
## Issue
Closes #51

## What was built
Extracted the run orchestration loop behind narrow interfaces so it's
unit-testable without network/CLI/git. Added 7 tests covering all
acceptance criteria from the issue.

### Changes
- `planRunner`, `codeRunner`, `qualityRunner` interfaces for phase execution
- `ghOrchestrator` interface for CreateBranch/CreatePR/PostVerdict
- `runDeps` struct bundles all dependencies
- `defaultRunDeps` builds production implementations (no behavior change)
- `runOrchestration` is the testable core; `runTask` is now a thin shell
- `createPR` helper inlined (was creating a redundant second ghClient)

### Tests added
1. Happy path: plan→code→quality→PR→verdict
2. Plan escalates: code/quality not invoked, PR not created
3. Code escalates: quality not invoked, no commit, no PR
4. Quality escalates: PR not created, commit still runs (happens before quality)
5. Quality RequeueToCode: treated as escalation, no PR
6. PostVerdict failure: logged but doesn't fail the run
7. Branch creation failure: wrapped error, no escalation triggered

## Test plan
- [x] `make test` — all pass
- [x] `make lint` — 0 issues
- [x] `go vet ./...` — clean
- [x] `vairdict review` on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)