### PR TITLE
feat(cmd): auto-merge PRs on passing verdict

### DIFF
--- a/cmd/vairdict/autovairdict.go
+++ b/cmd/vairdict/autovairdict.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const configPath = "vairdict.yaml"
+
+var enableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable features",
+}
+
+var disableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable features",
+}
+
+var enableAutoVairdictCmd = &cobra.Command{
+	Use:   "auto-vairdict",
+	Short: "Enable automatic merge on passing verdict",
+	Long:  `Sets auto_vairdict: true in vairdict.yaml. When enabled, a passing verdict triggers auto-merge via the GitHub API.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return setAutoVairdict(true)
+	},
+}
+
+var disableAutoVairdictCmd = &cobra.Command{
+	Use:   "auto-vairdict",
+	Short: "Disable automatic merge on passing verdict",
+	Long:  `Sets auto_vairdict: false in vairdict.yaml. When disabled (default), a passing verdict only approves the PR.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return setAutoVairdict(false)
+	},
+}
+
+func init() {
+	enableCmd.AddCommand(enableAutoVairdictCmd)
+	disableCmd.AddCommand(disableAutoVairdictCmd)
+	rootCmd.AddCommand(enableCmd)
+	rootCmd.AddCommand(disableCmd)
+}
+
+// setAutoVairdict reads vairdict.yaml, sets auto_vairdict, and writes back.
+// Uses raw map manipulation to preserve field ordering as much as the
+// yaml.v3 round-trip allows.
+func setAutoVairdict(enabled bool) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", configPath, err)
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("parsing %s: %w", configPath, err)
+	}
+
+	raw["auto_vairdict"] = enabled
+
+	out, err := yaml.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, out, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", configPath, err)
+	}
+
+	if enabled {
+		fmt.Println("auto-vairdict enabled: passing verdicts will auto-merge PRs")
+	} else {
+		fmt.Println("auto-vairdict disabled: passing verdicts will only approve PRs")
+	}
+	return nil
+}

--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strconv"
@@ -174,9 +175,10 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 
 	if deps.autoMerge {
 		if err := deps.gh.MergePR(ctx, prNumber); err != nil {
-			return fmt.Errorf("auto-merge PR #%d: %w", prNumber, err)
+			slog.Warn("auto-merge failed", "pr", prNumber, "error", err)
+		} else {
+			_, _ = fmt.Fprintf(deps.stdout, "auto-merged PR #%d\n", prNumber)
 		}
-		_, _ = fmt.Fprintf(deps.stdout, "auto-merged PR #%d\n", prNumber)
 	}
 	return nil
 }

--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -74,6 +74,7 @@ type reviewDeps struct {
 	stdout    io.Writer
 	intent    string // resolved value of --intent (empty = derive from linked issue)
 	noComment bool   // resolved value of --no-comment
+	autoMerge bool   // when true, auto-merge after passing verdict
 }
 
 // reviewGH is the narrow GitHub surface the review command depends on.
@@ -83,6 +84,7 @@ type reviewGH interface {
 	FetchIssue(ctx context.Context, n int) (*github.IssueDetails, error)
 	FetchPRDiff(ctx context.Context, n int) (string, error)
 	PostVerdict(ctx context.Context, n int, v *state.Verdict, p state.Phase, loop int) error
+	MergePR(ctx context.Context, n int) error
 }
 
 // reviewJudge is the narrow judge surface; *quality.QualityJudge satisfies
@@ -127,6 +129,7 @@ func runReview(prNumber int) error {
 		stdout:    os.Stdout,
 		intent:    reviewIntentFlag,
 		noComment: reviewNoCommentFlag,
+		autoMerge: cfg.AutoVairdict,
 	})
 }
 
@@ -167,6 +170,13 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 
 	if !verdict.Pass {
 		return fmt.Errorf("verdict failed: score %.0f%%", verdict.Score)
+	}
+
+	if deps.autoMerge {
+		if err := deps.gh.MergePR(ctx, prNumber); err != nil {
+			return fmt.Errorf("auto-merge PR #%d: %w", prNumber, err)
+		}
+		_, _ = fmt.Fprintf(deps.stdout, "auto-merged PR #%d\n", prNumber)
 	}
 	return nil
 }

--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -324,7 +324,7 @@ func TestRunReview_AutoMerge_FailingVerdict_NoMerge(t *testing.T) {
 	}
 }
 
-func TestRunReview_AutoMerge_Error_Propagates(t *testing.T) {
+func TestRunReview_AutoMerge_Error_WarnsOnly(t *testing.T) {
 	t.Parallel()
 	gh := &fakeReviewGH{
 		pr:       &github.PRDetails{Number: 10, Body: "Closes #11"},
@@ -337,11 +337,11 @@ func TestRunReview_AutoMerge_Error_Propagates(t *testing.T) {
 	deps := baseDeps(gh, judge)
 	deps.autoMerge = true
 
-	err := runReviewWith(context.Background(), 10, deps)
-	if err == nil {
-		t.Fatal("expected auto-merge error")
+	// Auto-merge failure should warn, not error — the verdict still passed.
+	if err := runReviewWith(context.Background(), 10, deps); err != nil {
+		t.Fatalf("auto-merge failure should not propagate as error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "auto-merge") {
-		t.Errorf("error should mention auto-merge, got: %v", err)
+	if !gh.mergeCalled {
+		t.Error("expected MergePR to be called")
 	}
 }

--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -26,6 +26,8 @@ type fakeReviewGH struct {
 	postedNumber int
 	postedVerd   *state.Verdict
 	postCalled   bool
+	mergeCalled  bool
+	mergeErr     error
 }
 
 func (f *fakeReviewGH) FetchPR(_ context.Context, _ int) (*github.PRDetails, error) {
@@ -42,6 +44,10 @@ func (f *fakeReviewGH) PostVerdict(_ context.Context, n int, v *state.Verdict, _
 	f.postedNumber = n
 	f.postedVerd = v
 	return f.postErr
+}
+func (f *fakeReviewGH) MergePR(_ context.Context, _ int) error {
+	f.mergeCalled = true
+	return f.mergeErr
 }
 
 // fakeReviewJudge captures the inputs to Judge so tests can verify the
@@ -254,5 +260,88 @@ func TestRunReview_PostVerdictError_Propagates(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "posting verdict") {
 		t.Errorf("error should mention posting, got: %v", err)
+	}
+}
+
+func TestRunReview_AutoMerge_Enabled(t *testing.T) {
+	t.Parallel()
+	gh := &fakeReviewGH{
+		pr:    &github.PRDetails{Number: 10, Body: "Closes #11"},
+		issue: &github.IssueDetails{Number: 11, Title: "t", Body: "b"},
+		diff:  "diff",
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	deps := baseDeps(gh, judge)
+	deps.autoMerge = true
+
+	if err := runReviewWith(context.Background(), 10, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gh.mergeCalled {
+		t.Error("expected MergePR to be called when autoMerge is enabled")
+	}
+}
+
+func TestRunReview_AutoMerge_Disabled(t *testing.T) {
+	t.Parallel()
+	gh := &fakeReviewGH{
+		pr:    &github.PRDetails{Number: 10, Body: "Closes #11"},
+		issue: &github.IssueDetails{Number: 11, Title: "t", Body: "b"},
+		diff:  "diff",
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	deps := baseDeps(gh, judge)
+	// autoMerge defaults to false
+
+	if err := runReviewWith(context.Background(), 10, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gh.mergeCalled {
+		t.Error("MergePR should not be called when autoMerge is disabled")
+	}
+}
+
+func TestRunReview_AutoMerge_FailingVerdict_NoMerge(t *testing.T) {
+	t.Parallel()
+	gh := &fakeReviewGH{
+		pr:    &github.PRDetails{Number: 10, Body: "Closes #11"},
+		issue: &github.IssueDetails{Number: 11, Title: "t", Body: "b"},
+		diff:  "diff",
+	}
+	judge := &fakeReviewJudge{verdict: failingVerdict()}
+
+	deps := baseDeps(gh, judge)
+	deps.autoMerge = true
+
+	err := runReviewWith(context.Background(), 10, deps)
+	if err == nil {
+		t.Fatal("expected error for failing verdict")
+	}
+	if gh.mergeCalled {
+		t.Error("MergePR should not be called on failing verdict")
+	}
+}
+
+func TestRunReview_AutoMerge_Error_Propagates(t *testing.T) {
+	t.Parallel()
+	gh := &fakeReviewGH{
+		pr:       &github.PRDetails{Number: 10, Body: "Closes #11"},
+		issue:    &github.IssueDetails{Number: 11, Title: "t", Body: "b"},
+		diff:     "diff",
+		mergeErr: errors.New("merge conflict"),
+	}
+	judge := &fakeReviewJudge{verdict: passingVerdict()}
+
+	deps := baseDeps(gh, judge)
+	deps.autoMerge = true
+
+	err := runReviewWith(context.Background(), 10, deps)
+	if err == nil {
+		t.Fatal("expected auto-merge error")
+	}
+	if !strings.Contains(err.Error(), "auto-merge") {
+		t.Errorf("error should mention auto-merge, got: %v", err)
 	}
 }

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -130,6 +130,7 @@ type ghOrchestrator interface {
 	CreateBranch(ctx context.Context, taskID, intent string) (string, error)
 	CreatePR(ctx context.Context, opts github.CreatePROpts) (*github.PR, error)
 	PostVerdict(ctx context.Context, prNumber int, v *state.Verdict, phase state.Phase, loop int) error
+	MergePR(ctx context.Context, prNumber int) error
 }
 
 // runDeps bundles all dependencies the orchestration loop needs.
@@ -141,6 +142,7 @@ type runDeps struct {
 	commit       func(ctx context.Context, task *state.Task) error
 	onEscalation func(ctx context.Context, task *state.Task, result escalation.Result) error
 	issueNumber  int
+	autoMerge    bool
 }
 
 // --- Default (production) phase runner implementations ---
@@ -192,6 +194,7 @@ func defaultRunDeps(cfg *config.Config, client completer, store *state.Store, wo
 			return escalateAndExit(ctx, task, result, cfg.Escalation, ghClient)
 		},
 		issueNumber: issueFlag,
+		autoMerge:   cfg.AutoVairdict,
 	}
 }
 
@@ -387,6 +390,15 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 				slog.Warn("failed to post verdict comment", "error", err)
 			} else {
 				r.VerdictPosted(lastVerdict.Score, lastVerdict.Pass)
+			}
+		}
+
+		// --- Auto-merge if enabled and verdict passed ---
+		if deps.autoMerge && lastVerdict != nil && lastVerdict.Pass {
+			if err := deps.gh.MergePR(ctx, pr.Number); err != nil {
+				slog.Warn("auto-merge failed", "error", err)
+			} else {
+				r.Note("auto-merge", fmt.Sprintf("PR #%d merged", pr.Number))
 			}
 		}
 	}

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -512,10 +512,12 @@ type fakeGHOrch struct {
 	pr         *github.PR
 	prErr      error
 	verdictErr error
+	mergeErr   error
 
 	branchCalled  bool
 	prCalled      bool
 	verdictCalled bool
+	mergeCalled   bool
 }
 
 func (f *fakeGHOrch) CreateBranch(context.Context, string, string) (string, error) {
@@ -531,6 +533,11 @@ func (f *fakeGHOrch) CreatePR(context.Context, github.CreatePROpts) (*github.PR,
 func (f *fakeGHOrch) PostVerdict(context.Context, int, *state.Verdict, state.Phase, int) error {
 	f.verdictCalled = true
 	return f.verdictErr
+}
+
+func (f *fakeGHOrch) MergePR(context.Context, int) error {
+	f.mergeCalled = true
+	return f.mergeErr
 }
 
 // orchBundle groups the fakes so tests can inspect them after a run.
@@ -772,5 +779,60 @@ func TestRunOrchestration_BranchCreationFailure(t *testing.T) {
 	}
 	if b.escalationCalled {
 		t.Error("branch failure should not trigger escalation")
+	}
+}
+
+func TestRunOrchestration_AutoMerge_Enabled(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	deps := b.deps()
+	deps.autoMerge = true
+	err := runOrchestration(context.Background(), deps, task, r)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !b.gh.mergeCalled {
+		t.Error("MergePR should be called when autoMerge is enabled and verdict passes")
+	}
+}
+
+func TestRunOrchestration_AutoMerge_Disabled(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	deps := b.deps()
+	deps.autoMerge = false
+	err := runOrchestration(context.Background(), deps, task, r)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.gh.mergeCalled {
+		t.Error("MergePR should NOT be called when autoMerge is disabled")
+	}
+}
+
+func TestRunOrchestration_AutoMerge_FailureDoesNotFailRun(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	b.gh.mergeErr = errors.New("merge conflict")
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	deps := b.deps()
+	deps.autoMerge = true
+	err := runOrchestration(context.Background(), deps, task, r)
+
+	if err != nil {
+		t.Fatalf("auto-merge failure should not fail the run, got %v", err)
+	}
+	if !b.gh.mergeCalled {
+		t.Error("MergePR should have been attempted")
 	}
 }

--- a/cmd/vairdict/status.go
+++ b/cmd/vairdict/status.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/state"
 )
 
@@ -17,6 +18,16 @@ If a task ID is provided, show detailed information including the full
 verdict history, assumptions, and attempts.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Show auto-vairdict status from config.
+		cfg, cfgErr := config.LoadConfig("vairdict.yaml")
+		if cfgErr == nil {
+			autoMerge := "disabled"
+			if cfg.AutoVairdict {
+				autoMerge = "enabled"
+			}
+			fmt.Printf("auto-vairdict: %s\n\n", autoMerge)
+		}
+
 		dbPath, err := state.DefaultDBPath()
 		if err != nil {
 			return fmt.Errorf("resolving database path: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,13 +10,14 @@ import (
 )
 
 type Config struct {
-	Project     ProjectConfig     `yaml:"project"`
-	Agents      AgentsConfig      `yaml:"agents"`
-	Environment EnvironmentConfig `yaml:"environment"`
-	Commands    CommandsConfig    `yaml:"commands"`
-	Phases      PhasesConfig      `yaml:"phases"`
-	Escalation  EscalationConfig  `yaml:"escalation"`
-	Conventions ConventionsConfig `yaml:"conventions"`
+	Project      ProjectConfig     `yaml:"project"`
+	Agents       AgentsConfig      `yaml:"agents"`
+	Environment  EnvironmentConfig `yaml:"environment"`
+	Commands     CommandsConfig    `yaml:"commands"`
+	Phases       PhasesConfig      `yaml:"phases"`
+	Escalation   EscalationConfig  `yaml:"escalation"`
+	Conventions  ConventionsConfig `yaml:"conventions"`
+	AutoVairdict bool              `yaml:"auto_vairdict"`
 }
 
 type ProjectConfig struct {
@@ -410,7 +411,7 @@ func warnUnknownFields(data []byte) {
 	known := map[string]bool{
 		"project": true, "agents": true, "environment": true,
 		"commands": true, "phases": true, "escalation": true,
-		"conventions": true,
+		"conventions": true, "auto_vairdict": true,
 	}
 
 	var raw map[string]any

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -363,6 +363,19 @@ func (c *Client) PostVerdict(ctx context.Context, prNumber int, verdict *state.V
 	return nil
 }
 
+// MergePR merges a PR via `gh pr merge --squash --delete-branch`. The
+// squash strategy is hardcoded for now — merge strategy configuration
+// is out of scope for M4.
+func (c *Client) MergePR(ctx context.Context, prNumber int) error {
+	_, err := c.runner.Run(ctx, "gh", "pr", "merge", fmt.Sprintf("%d", prNumber),
+		"--squash", "--delete-branch")
+	if err != nil {
+		return fmt.Errorf("merging PR #%d: %w", prNumber, err)
+	}
+	slog.Info("PR merged", "pr", prNumber)
+	return nil
+}
+
 // FormatPRBody generates a PR body from task data.
 func FormatPRBody(task *state.Task, issueNumber int, summary string) string {
 	var b strings.Builder

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -19,6 +19,7 @@ func successRunner() *FakeRunner {
 			"gh pr create":  {Output: []byte("https://github.com/foo/bar/pull/1\n")},
 			"gh pr comment": {Output: []byte("ok")},
 			"gh pr review":  {Output: []byte("ok")},
+			"gh pr merge":   {Output: []byte("ok")},
 		},
 	}
 }
@@ -274,6 +275,61 @@ func TestPostVerdict_Fail_CommentsOnly(t *testing.T) {
 	}
 	if !foundComment {
 		t.Error("expected gh pr comment to be called for failing verdict")
+	}
+}
+
+func TestMergePR_Success(t *testing.T) {
+	runner := successRunner()
+	client := New(runner)
+
+	err := client.MergePR(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, call := range runner.Calls {
+		if call.Name == "gh" && len(call.Args) >= 3 &&
+			call.Args[0] == "pr" && call.Args[1] == "merge" && call.Args[2] == "42" {
+			found = true
+			// Verify squash + delete-branch flags
+			hasSquash := false
+			hasDelete := false
+			for _, a := range call.Args {
+				if a == "--squash" {
+					hasSquash = true
+				}
+				if a == "--delete-branch" {
+					hasDelete = true
+				}
+			}
+			if !hasSquash {
+				t.Error("expected --squash flag")
+			}
+			if !hasDelete {
+				t.Error("expected --delete-branch flag")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected gh pr merge to be called")
+	}
+}
+
+func TestMergePR_Error(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh pr merge": {Err: errors.New("merge conflict")},
+		},
+	}
+	client := New(runner)
+
+	err := client.MergePR(context.Background(), 99)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, err) {
+		t.Errorf("error not wrapped properly: %v", err)
 	}
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/vairdict/vairdict/internal/state"
@@ -328,8 +329,8 @@ func TestMergePR_Error(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !errors.Is(err, err) {
-		t.Errorf("error not wrapped properly: %v", err)
+	if !strings.Contains(err.Error(), "merge conflict") {
+		t.Errorf("expected wrapped merge conflict error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `auto_vairdict` config flag + CLI commands (`vairdict enable/disable auto-vairdict`) to control automatic merge behavior
- Wires `MergePR` (gh pr merge --squash --delete-branch) into both `vairdict run` and `vairdict review` flows after passing quality verdicts
- Displays auto-vairdict status in `vairdict status` output

## Test plan
- [x] 4 new review auto-merge tests (enabled, disabled, failing verdict, merge error)
- [x] 3 new orchestration auto-merge tests (enabled, disabled, merge failure)
- [x] 2 MergePR unit tests (success + error)
- [x] `make test` — all 16 packages pass
- [x] `make lint` — 0 issues

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)