### PR TITLE
feat(release): GoReleaser + release workflow + install script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ builds:
     binary: vairdict
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{.Version}}
     goos:
       - linux
       - darwin
@@ -19,7 +21,8 @@ builds:
         goarch: arm64
 
 archives:
-  - formats:
+  - name_template: "vairdict_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
       - tar.gz
     format_overrides:
       - goos: windows
@@ -28,6 +31,14 @@ archives:
 
 checksum:
   name_template: "checksums.txt"
+
+release:
+  github:
+    owner: vairdict
+    name: vairdict
+  draft: false
+  prerelease: auto
+  name_template: "v{{ .Version }}"
 
 changelog:
   sort: asc

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MODULE := github.com/vairdict/vairdict
 VERSION := $(shell git describe --tags 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 
-.PHONY: build test lint install clean
+.PHONY: build test lint install clean release-snapshot
 
 build:
 	go build $(LDFLAGS) -o $(BINARY) ./cmd/vairdict
@@ -19,3 +19,6 @@ install:
 
 clean:
 	rm -f $(BINARY)
+
+release-snapshot:
+	goreleaser release --snapshot --clean

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# install.sh — download and install the latest vairdict binary.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/vairdict/vairdict/main/scripts/install.sh | sh
+#
+# Respects:
+#   INSTALL_DIR  — where to put the binary (default: /usr/local/bin)
+#   VERSION      — specific version to install (default: latest)
+
+set -e
+
+REPO="vairdict/vairdict"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# --- Detect OS and arch ---
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  arm64)   ARCH="arm64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+case "$OS" in
+  darwin|linux) ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    exit 1
+    ;;
+esac
+
+# --- Resolve version ---
+
+if [ -z "$VERSION" ]; then
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')"
+  if [ -z "$VERSION" ]; then
+    echo "Failed to detect latest version. Set VERSION explicitly." >&2
+    exit 1
+  fi
+fi
+
+# Strip leading 'v' if present.
+VERSION="${VERSION#v}"
+
+# --- Download and install ---
+
+TARBALL="vairdict_${VERSION}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/v${VERSION}/${TARBALL}"
+
+echo "Downloading vairdict v${VERSION} for ${OS}/${ARCH}..."
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL "$URL" -o "${TMPDIR}/${TARBALL}"
+tar -xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR"
+
+# Install binary.
+if [ -w "$INSTALL_DIR" ]; then
+  cp "${TMPDIR}/vairdict" "${INSTALL_DIR}/vairdict"
+else
+  echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+  sudo cp "${TMPDIR}/vairdict" "${INSTALL_DIR}/vairdict"
+fi
+
+chmod +x "${INSTALL_DIR}/vairdict"
+
+echo "vairdict v${VERSION} installed to ${INSTALL_DIR}/vairdict"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,26 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 curl -fsSL "$URL" -o "${TMPDIR}/${TARBALL}"
+
+# Verify checksum.
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/v${VERSION}/checksums.txt"
+curl -fsSL "$CHECKSUMS_URL" -o "${TMPDIR}/checksums.txt"
+EXPECTED="$(grep "${TARBALL}" "${TMPDIR}/checksums.txt" | awk '{print $1}')"
+if [ -z "$EXPECTED" ]; then
+  echo "Warning: no checksum found for ${TARBALL}, skipping verification" >&2
+else
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "${TMPDIR}/${TARBALL}" | awk '{print $1}')"
+  else
+    ACTUAL="$(shasum -a 256 "${TMPDIR}/${TARBALL}" | awk '{print $1}')"
+  fi
+  if [ "$EXPECTED" != "$ACTUAL" ]; then
+    echo "Checksum mismatch! Expected ${EXPECTED}, got ${ACTUAL}" >&2
+    exit 1
+  fi
+  echo "Checksum verified."
+fi
+
 tar -xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR"
 
 # Install binary.


### PR DESCRIPTION
## Summary
- Adds ldflags version injection + archive naming + release config to `.goreleaser.yml`
- GitHub Actions workflow (`.github/workflows/release.yml`) triggers on `v*` tag push: runs tests then GoReleaser
- `scripts/install.sh`: curl-pipe-sh installer auto-detects OS/arch, downloads from GitHub Releases
- `make release-snapshot` for local dry-run testing (validated: builds darwin/linux amd64+arm64)

Closes #66

## Test plan
- [x] `goreleaser check` passes
- [x] `make release-snapshot` builds all targets successfully
- [x] `go test ./...` passes
- [x] `make lint` clean
- [ ] Tag `v0.0.1` and verify GitHub Release is created (post-merge)
- [ ] Run `scripts/install.sh` on Mac after first release (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)