### PR TITLE
feat(action): GitHub Action wrapper for vairdict review

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,81 @@
+name: "VAIrdict Review"
+description: "Run the VAIrdict quality judge on a pull request and post a verdict comment"
+author: "vairdict"
+
+branding:
+  icon: "check-circle"
+  color: "blue"
+
+inputs:
+  version:
+    description: "VAIrdict version to install (default: latest)"
+    required: false
+    default: "latest"
+  anthropic-api-key:
+    description: "Anthropic API key for the quality judge"
+    required: true
+  intent:
+    description: "Explicit intent text (overrides linked issue detection)"
+    required: false
+    default: ""
+
+outputs:
+  score:
+    description: "Quality score (0-100)"
+    value: ${{ steps.review.outputs.score }}
+  pass:
+    description: "Whether the verdict passed (true/false)"
+    value: ${{ steps.review.outputs.pass }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve PR number
+      id: pr
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "pull_request_target" ]; then
+          echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::VAIrdict Review action requires a pull_request or pull_request_target trigger"
+          exit 1
+        fi
+
+    - name: Install VAIrdict
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        if [ "$VERSION" = "latest" ]; then
+          curl -fsSL https://raw.githubusercontent.com/vairdict/vairdict/main/scripts/install.sh | INSTALL_DIR="${{ runner.temp }}" sh
+        else
+          curl -fsSL https://raw.githubusercontent.com/vairdict/vairdict/main/scripts/install.sh | INSTALL_DIR="${{ runner.temp }}" VERSION="$VERSION" sh
+        fi
+
+    - name: Run VAIrdict review
+      id: review
+      shell: bash
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        INTENT_FLAG=""
+        if [ -n "${{ inputs.intent }}" ]; then
+          INTENT_FLAG="--intent ${{ inputs.intent }}"
+        fi
+
+        # Run review; capture output but don't fail the step yet.
+        set +e
+        OUTPUT=$("${{ runner.temp }}/vairdict" review ${{ steps.pr.outputs.number }} $INTENT_FLAG 2>&1)
+        EXIT_CODE=$?
+        set -e
+
+        echo "$OUTPUT"
+
+        # Extract score from log line: "quality judge verdict score=NN pass=true/false"
+        SCORE=$(echo "$OUTPUT" | grep -o 'score=[0-9.]*' | head -1 | cut -d= -f2)
+        PASS=$(echo "$OUTPUT" | grep -o 'pass=[a-z]*' | head -1 | cut -d= -f2)
+
+        echo "score=${SCORE:-0}" >> "$GITHUB_OUTPUT"
+        echo "pass=${PASS:-false}" >> "$GITHUB_OUTPUT"
+
+        exit $EXIT_CODE

--- a/action.yml
+++ b/action.yml
@@ -43,12 +43,13 @@ runs:
 
     - name: Install VAIrdict
       shell: bash
+      env:
+        VAIRDICT_VERSION: ${{ inputs.version }}
       run: |
-        VERSION="${{ inputs.version }}"
-        if [ "$VERSION" = "latest" ]; then
+        if [ "$VAIRDICT_VERSION" = "latest" ]; then
           curl -fsSL https://raw.githubusercontent.com/vairdict/vairdict/main/scripts/install.sh | INSTALL_DIR="${{ runner.temp }}" sh
         else
-          curl -fsSL https://raw.githubusercontent.com/vairdict/vairdict/main/scripts/install.sh | INSTALL_DIR="${{ runner.temp }}" VERSION="$VERSION" sh
+          curl -fsSL https://raw.githubusercontent.com/vairdict/vairdict/main/scripts/install.sh | INSTALL_DIR="${{ runner.temp }}" VERSION="$VAIRDICT_VERSION" sh
         fi
 
     - name: Run VAIrdict review

--- a/action.yml
+++ b/action.yml
@@ -57,15 +57,20 @@ runs:
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         GH_TOKEN: ${{ github.token }}
+        VAIRDICT_INTENT: ${{ inputs.intent }}
       run: |
         INTENT_FLAG=""
-        if [ -n "${{ inputs.intent }}" ]; then
-          INTENT_FLAG="--intent ${{ inputs.intent }}"
+        if [ -n "$VAIRDICT_INTENT" ]; then
+          INTENT_FLAG="--intent"
         fi
 
         # Run review; capture output but don't fail the step yet.
         set +e
-        OUTPUT=$("${{ runner.temp }}/vairdict" review ${{ steps.pr.outputs.number }} $INTENT_FLAG 2>&1)
+        if [ -n "$INTENT_FLAG" ]; then
+          OUTPUT=$("${{ runner.temp }}/vairdict" review ${{ steps.pr.outputs.number }} --intent "$VAIRDICT_INTENT" 2>&1)
+        else
+          OUTPUT=$("${{ runner.temp }}/vairdict" review ${{ steps.pr.outputs.number }} 2>&1)
+        fi
         EXIT_CODE=$?
         set -e
 

--- a/docs/example-workflow.yml
+++ b/docs/example-workflow.yml
@@ -2,12 +2,18 @@
 #
 # Copy this file to .github/workflows/vairdict.yml in your repo.
 # Set ANTHROPIC_API_KEY as a repository secret.
+#
+# Uses pull_request for standard PRs. Switch to pull_request_target
+# if you need to review PRs from forks (requires careful secret scoping).
 
 name: VAIrdict Review
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Uncomment for fork PRs (secrets available but code runs from base):
+  # pull_request_target:
+  #   types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/docs/example-workflow.yml
+++ b/docs/example-workflow.yml
@@ -1,0 +1,32 @@
+# Example: run VAIrdict review on every PR.
+#
+# Copy this file to .github/workflows/vairdict.yml in your repo.
+# Set ANTHROPIC_API_KEY as a repository secret.
+
+name: VAIrdict Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: vairdict/vairdict@v0
+        id: vairdict
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Gate on verdict
+        if: steps.vairdict.outputs.pass != 'true'
+        run: |
+          echo "VAIrdict verdict failed (score: ${{ steps.vairdict.outputs.score }})"
+          exit 1


### PR DESCRIPTION
## Summary
- `action.yml` composite action at repo root — installs vairdict from GitHub Releases, runs `vairdict review <pr>`, posts verdict comment
- Inputs: `version` (default: latest), `anthropic-api-key` (required), `intent` (optional override)
- Outputs: `score`, `pass` for downstream conditional steps
- Works with `pull_request` and `pull_request_target` triggers
- Example workflow in `docs/example-workflow.yml`
- Marketplace-ready metadata (branding, description, author)

Closes #67

## Test plan
- [x] `go test ./...` passes
- [x] `make lint` clean
- [x] `action.yml` validates (composite action with proper inputs/outputs)
- [ ] End-to-end: add workflow to a test repo and open a PR (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)