### PR TITLE
feat(workspace): isolated git worktree per task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,8 @@ coverage/
 # Logs
 *.log
 
+# VAIrdict workspaces (git worktrees)
+.vairdict/
+
 # Local notes / open discussion items (not for commit)
 open_issues.md

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -24,6 +24,7 @@ import (
 	qualityphase "github.com/vairdict/vairdict/internal/phases/quality"
 	"github.com/vairdict/vairdict/internal/state"
 	"github.com/vairdict/vairdict/internal/ui"
+	"github.com/vairdict/vairdict/internal/workspace"
 )
 
 const (
@@ -275,13 +276,25 @@ func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) err
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	// Resolve working directory.
-	workDir, err := os.Getwd()
+	// Resolve working directory — the repo root where vairdict was invoked.
+	repoRoot, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("resolving working directory: %w", err)
 	}
 
-	ghRunner := &github.ExecRunner{Dir: workDir}
+	// Create an isolated workspace (git worktree) for this task so
+	// concurrent tasks don't interfere with each other's file changes.
+	wsMgr := workspace.New(repoRoot, "", &workspace.ExecRunner{})
+	ws, err := wsMgr.Create(ctx, task.ID)
+	if err != nil {
+		return fmt.Errorf("creating workspace: %w", err)
+	}
+	defer func() { _ = ws.Cleanup(ctx) }()
+
+	workDir := ws.Path
+	r.Note("workspace", workDir)
+
+	ghRunner := &github.ExecRunner{Dir: repoRoot}
 	ghClient := github.New(ghRunner)
 
 	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -133,9 +133,11 @@ func (w *Workspace) Cleanup(ctx context.Context) error {
 }
 
 // PruneStale removes any leftover worktrees that were not cleaned up
-// (e.g. from a crashed process). It scans the base directory for
+// (e.g. from a crashed process). It asks git to prune its internal
+// worktree metadata, then scans the base directory and removes any
 // directories that are not registered as active worktrees.
 func (m *Manager) PruneStale(ctx context.Context) error {
+	// Let git clean up its own stale metadata first.
 	_, _ = m.runner.Run(ctx, m.repoRoot, "git", "worktree", "prune")
 
 	baseDir := filepath.Join(m.repoRoot, m.baseDir)
@@ -147,28 +149,44 @@ func (m *Manager) PruneStale(ctx context.Context) error {
 		return fmt.Errorf("reading worktree base dir: %w", err)
 	}
 
+	// Build a set of active worktree paths from git.
+	activeWorktrees := m.listActiveWorktrees(ctx)
+
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
 		worktreePath := filepath.Join(baseDir, entry.Name())
 
-		// Check if this directory is a registered worktree.
-		_, err := m.runner.Run(ctx, m.repoRoot, "git", "worktree", "list", "--porcelain")
-		if err != nil {
+		// Skip directories that are still active worktrees.
+		if activeWorktrees[worktreePath] {
 			continue
 		}
 
-		// If the directory exists but isn't in the worktree list, remove it.
-		// For simplicity, just try to remove it — git worktree remove will
-		// fail gracefully if it's still active.
-		_, rmErr := m.runner.Run(ctx, m.repoRoot, "git", "worktree", "remove", "--force", worktreePath)
-		if rmErr != nil {
-			_ = os.RemoveAll(worktreePath)
-		}
+		// Not an active worktree — remove the orphaned directory.
+		slog.Info("pruning stale worktree", "path", worktreePath)
+		_ = os.RemoveAll(worktreePath)
 	}
 
 	return nil
+}
+
+// listActiveWorktrees returns a set of absolute paths for all currently
+// registered git worktrees.
+func (m *Manager) listActiveWorktrees(ctx context.Context) map[string]bool {
+	out, err := m.runner.Run(ctx, m.repoRoot, "git", "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil
+	}
+
+	active := make(map[string]bool)
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "worktree ") {
+			path := strings.TrimPrefix(line, "worktree ")
+			active[path] = true
+		}
+	}
+	return active
 }
 
 // resolveMainBranch returns the name of the main branch (main or master).

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,0 +1,189 @@
+// Package workspace manages isolated git worktrees for concurrent task execution.
+// Each task gets its own worktree so multiple tasks can run in parallel without
+// interfering with each other's file changes.
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultBaseDir is the default directory under the repo root where worktrees
+// are created. Each task gets a subdirectory named after its task ID.
+const DefaultBaseDir = ".vairdict/worktrees"
+
+// Manager creates and removes git worktrees for task isolation.
+type Manager struct {
+	// repoRoot is the absolute path to the main repository.
+	repoRoot string
+	// baseDir is the directory under repoRoot where worktrees are created.
+	baseDir string
+	// runner executes git commands. Injected for testing.
+	runner CommandRunner
+}
+
+// CommandRunner executes shell commands. Injected for testing.
+type CommandRunner interface {
+	Run(ctx context.Context, dir string, name string, args ...string) ([]byte, error)
+}
+
+// ExecRunner is the real implementation using os/exec.
+type ExecRunner struct{}
+
+// Run executes a command in the given directory.
+func (e *ExecRunner) Run(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.Bytes(), fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// New creates a Manager rooted at the given repository path. The baseDir
+// is relative to repoRoot; pass "" to use DefaultBaseDir.
+func New(repoRoot string, baseDir string, runner CommandRunner) *Manager {
+	if baseDir == "" {
+		baseDir = DefaultBaseDir
+	}
+	return &Manager{
+		repoRoot: repoRoot,
+		baseDir:  baseDir,
+		runner:   runner,
+	}
+}
+
+// Workspace represents an active git worktree for a task.
+type Workspace struct {
+	// Path is the absolute path to the worktree directory.
+	Path string
+	// Branch is the git branch created for this worktree.
+	Branch string
+
+	mgr    *Manager
+	taskID string
+}
+
+// Create creates a new git worktree for the given task. The worktree is
+// based on the current HEAD of the main branch. Returns a Workspace that
+// must be cleaned up with Cleanup() when the task is done.
+func (m *Manager) Create(ctx context.Context, taskID string) (*Workspace, error) {
+	branch := "vairdict/" + taskID
+	worktreePath := filepath.Join(m.repoRoot, m.baseDir, taskID)
+
+	// Ensure the base directory exists.
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
+		return nil, fmt.Errorf("creating worktree base dir: %w", err)
+	}
+
+	// Resolve the main branch name (main or master).
+	baseBranch, err := m.resolveMainBranch(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving main branch: %w", err)
+	}
+
+	// Create the worktree on a new branch based on the main branch.
+	_, err = m.runner.Run(ctx, m.repoRoot, "git", "worktree", "add",
+		"-b", branch, worktreePath, baseBranch)
+	if err != nil {
+		return nil, fmt.Errorf("creating worktree: %w", err)
+	}
+
+	slog.Info("workspace created", "task", taskID, "path", worktreePath, "branch", branch)
+
+	return &Workspace{
+		Path:   worktreePath,
+		Branch: branch,
+		mgr:    m,
+		taskID: taskID,
+	}, nil
+}
+
+// Cleanup removes the worktree directory and deletes its branch.
+// Safe to call multiple times — subsequent calls are no-ops.
+func (w *Workspace) Cleanup(ctx context.Context) error {
+	// Remove the worktree.
+	_, err := w.mgr.runner.Run(ctx, w.mgr.repoRoot, "git", "worktree", "remove", "--force", w.Path)
+	if err != nil {
+		slog.Warn("failed to remove worktree", "path", w.Path, "error", err)
+		// Try removing the directory manually as a fallback.
+		_ = os.RemoveAll(w.Path)
+	}
+
+	// Prune stale worktree entries.
+	_, _ = w.mgr.runner.Run(ctx, w.mgr.repoRoot, "git", "worktree", "prune")
+
+	// Delete the branch.
+	_, err = w.mgr.runner.Run(ctx, w.mgr.repoRoot, "git", "branch", "-D", w.Branch)
+	if err != nil {
+		slog.Debug("failed to delete worktree branch", "branch", w.Branch, "error", err)
+	}
+
+	slog.Info("workspace cleaned up", "task", w.taskID, "path", w.Path)
+	return nil
+}
+
+// PruneStale removes any leftover worktrees that were not cleaned up
+// (e.g. from a crashed process). It scans the base directory for
+// directories that are not registered as active worktrees.
+func (m *Manager) PruneStale(ctx context.Context) error {
+	_, _ = m.runner.Run(ctx, m.repoRoot, "git", "worktree", "prune")
+
+	baseDir := filepath.Join(m.repoRoot, m.baseDir)
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No worktrees directory — nothing to prune.
+		}
+		return fmt.Errorf("reading worktree base dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		worktreePath := filepath.Join(baseDir, entry.Name())
+
+		// Check if this directory is a registered worktree.
+		_, err := m.runner.Run(ctx, m.repoRoot, "git", "worktree", "list", "--porcelain")
+		if err != nil {
+			continue
+		}
+
+		// If the directory exists but isn't in the worktree list, remove it.
+		// For simplicity, just try to remove it — git worktree remove will
+		// fail gracefully if it's still active.
+		_, rmErr := m.runner.Run(ctx, m.repoRoot, "git", "worktree", "remove", "--force", worktreePath)
+		if rmErr != nil {
+			_ = os.RemoveAll(worktreePath)
+		}
+	}
+
+	return nil
+}
+
+// resolveMainBranch returns the name of the main branch (main or master).
+func (m *Manager) resolveMainBranch(ctx context.Context) (string, error) {
+	// Try "main" first.
+	_, err := m.runner.Run(ctx, m.repoRoot, "git", "rev-parse", "--verify", "main")
+	if err == nil {
+		return "main", nil
+	}
+
+	// Fall back to "master".
+	_, err = m.runner.Run(ctx, m.repoRoot, "git", "rev-parse", "--verify", "master")
+	if err == nil {
+		return "master", nil
+	}
+
+	return "", fmt.Errorf("neither 'main' nor 'master' branch found")
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,219 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// These tests use real git commands against a temporary repository.
+// They exercise the full worktree lifecycle without mocks.
+
+func setupTestRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		runner := &ExecRunner{}
+		_, err := runner.Run(context.Background(), dir, "git", args...)
+		if err != nil {
+			t.Fatalf("git %v failed: %v", args, err)
+		}
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "test")
+
+	// Create an initial commit so HEAD exists.
+	initial := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(initial, []byte("# test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "initial")
+
+	return dir
+}
+
+func TestCreate_And_Cleanup(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := New(repo, "", &ExecRunner{})
+
+	ctx := context.Background()
+	ws, err := mgr.Create(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Worktree directory should exist.
+	if _, err := os.Stat(ws.Path); os.IsNotExist(err) {
+		t.Fatal("worktree directory does not exist")
+	}
+
+	// Branch should match convention.
+	if ws.Branch != "vairdict/task-1" {
+		t.Errorf("branch = %q, want %q", ws.Branch, "vairdict/task-1")
+	}
+
+	// Worktree should contain the same files as the main repo.
+	readme := filepath.Join(ws.Path, "README.md")
+	if _, err := os.Stat(readme); os.IsNotExist(err) {
+		t.Error("worktree missing README.md from main branch")
+	}
+
+	// Create a file in the worktree — should not appear in main repo.
+	testFile := filepath.Join(ws.Path, "task-file.txt")
+	if err := os.WriteFile(testFile, []byte("task output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainTestFile := filepath.Join(repo, "task-file.txt")
+	if _, err := os.Stat(mainTestFile); !os.IsNotExist(err) {
+		t.Error("file created in worktree should not appear in main repo")
+	}
+
+	// Cleanup.
+	if err := ws.Cleanup(ctx); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+
+	// Worktree directory should be gone.
+	if _, err := os.Stat(ws.Path); !os.IsNotExist(err) {
+		t.Error("worktree directory should not exist after cleanup")
+	}
+}
+
+func TestCreate_ConcurrentTasks(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := New(repo, "", &ExecRunner{})
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 3)
+	workspaces := make(chan *Workspace, 3)
+
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			taskID := "concurrent-" + string(rune('a'+id))
+			ws, err := mgr.Create(ctx, taskID)
+			if err != nil {
+				errs <- err
+				return
+			}
+			workspaces <- ws
+
+			// Write a unique file in each worktree.
+			f := filepath.Join(ws.Path, "output.txt")
+			_ = os.WriteFile(f, []byte(taskID), 0o644)
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+	close(workspaces)
+
+	for err := range errs {
+		t.Fatalf("concurrent create failed: %v", err)
+	}
+
+	// Verify each worktree has its own unique file.
+	var allWs []*Workspace
+	for ws := range workspaces {
+		allWs = append(allWs, ws)
+		data, err := os.ReadFile(filepath.Join(ws.Path, "output.txt"))
+		if err != nil {
+			t.Errorf("failed to read output in %s: %v", ws.Path, err)
+			continue
+		}
+		// Content should match the task ID that created it.
+		if string(data) != ws.taskID {
+			t.Errorf("worktree %s has content %q, want %q", ws.Path, string(data), ws.taskID)
+		}
+	}
+
+	// Cleanup all.
+	for _, ws := range allWs {
+		if err := ws.Cleanup(ctx); err != nil {
+			t.Errorf("cleanup failed for %s: %v", ws.taskID, err)
+		}
+	}
+}
+
+func TestCleanup_Idempotent(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := New(repo, "", &ExecRunner{})
+	ctx := context.Background()
+
+	ws, err := mgr.Create(ctx, "idem-task")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// First cleanup.
+	if err := ws.Cleanup(ctx); err != nil {
+		t.Fatalf("first Cleanup failed: %v", err)
+	}
+
+	// Second cleanup should not error.
+	if err := ws.Cleanup(ctx); err != nil {
+		t.Fatalf("second Cleanup should be idempotent, got: %v", err)
+	}
+}
+
+func TestCleanup_AfterFailure(t *testing.T) {
+	// Simulate a task that creates files but "crashes" — cleanup should
+	// still remove the worktree.
+	repo := setupTestRepo(t)
+	mgr := New(repo, "", &ExecRunner{})
+	ctx := context.Background()
+
+	ws, err := mgr.Create(ctx, "crash-task")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Simulate work: create and modify files.
+	_ = os.WriteFile(filepath.Join(ws.Path, "partial.txt"), []byte("in progress"), 0o644)
+	runner := &ExecRunner{}
+	_, _ = runner.Run(ctx, ws.Path, "git", "add", ".")
+	_, _ = runner.Run(ctx, ws.Path, "git", "commit", "-m", "partial work")
+
+	// "Crash" — cleanup should still work.
+	if err := ws.Cleanup(ctx); err != nil {
+		t.Fatalf("Cleanup after crash failed: %v", err)
+	}
+
+	if _, err := os.Stat(ws.Path); !os.IsNotExist(err) {
+		t.Error("worktree should be removed after cleanup")
+	}
+}
+
+func TestPruneStale_NoWorktreesDir(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := New(repo, "", &ExecRunner{})
+
+	// PruneStale should not error when no worktrees directory exists.
+	if err := mgr.PruneStale(context.Background()); err != nil {
+		t.Fatalf("PruneStale with no worktrees dir should not error: %v", err)
+	}
+}
+
+func TestNew_CustomBaseDir(t *testing.T) {
+	mgr := New("/tmp/repo", "custom/worktrees", &ExecRunner{})
+	if mgr.baseDir != "custom/worktrees" {
+		t.Errorf("baseDir = %q, want %q", mgr.baseDir, "custom/worktrees")
+	}
+}
+
+func TestNew_DefaultBaseDir(t *testing.T) {
+	mgr := New("/tmp/repo", "", &ExecRunner{})
+	if mgr.baseDir != DefaultBaseDir {
+		t.Errorf("baseDir = %q, want %q", mgr.baseDir, DefaultBaseDir)
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/workspace/` package that manages git worktrees for task isolation
- `vairdict run` now executes each task in its own worktree, enabling concurrent task execution
- Worktrees are auto-cleaned on task completion (or failure), with stale pruning support
- GitHub client operates from repo root while code phase runs in the worktree
- `.gitignore` updated to exclude `.vairdict/` directory

Closes #77

## Test plan
- [x] All 7 workspace tests pass (create, cleanup, concurrent, idempotent, crash recovery, prune, defaults)
- [x] Full `make test` passes (17 packages)
- [ ] Run `vairdict review` on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)