### PR TITLE
feat(run): concurrent task runner with semaphore-based parallelism

### DIFF
--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ const (
 )
 
 var (
-	issueFlag  int
+	issueFlags []int
 	outputFlag string
 	colorsFlag string
 	asciiFlag  bool
@@ -41,16 +42,18 @@ var (
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run [intent]",
+	Use:   "run [intent...]",
 	Short: "Create a task and run it through the development phases",
-	Long: `Create a new task with the given intent, then run it through
-the plan and code phases. On success, creates a GitHub PR with
-the VAIrdict verdict. Streams progress updates as each phase
-loop executes.
+	Long: `Create one or more tasks with the given intents, then run each through
+the plan, code, and quality phases. On success, creates a GitHub PR with
+the VAIrdict verdict.
 
-Use --issue to fetch the intent from a GitHub issue:
-  vairdict run --issue 32`,
-	Args: cobra.MaximumNArgs(1),
+Multiple intents run concurrently (up to parallel.max_tasks from config):
+  vairdict run "add login" "fix logout bug"
+
+Use --issue to fetch intents from GitHub issues:
+  vairdict run --issue 32 --issue 45`,
+	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mode, err := ui.ParseMode(outputFlag)
 		if err != nil {
@@ -61,23 +64,41 @@ Use --issue to fetch the intent from a GitHub issue:
 			return err
 		}
 
-		var intent string
-		if issueFlag > 0 {
-			intent, err = fetchIssueIntent(issueFlag)
-			if err != nil {
-				return err
+		// Collect intents from positional args and --issue flags.
+		var intents []string
+		var issues []int
+		for _, num := range issueFlags {
+			if num > 0 {
+				intent, err := fetchIssueIntent(num)
+				if err != nil {
+					return err
+				}
+				intents = append(intents, intent)
+				issues = append(issues, num)
 			}
-		} else if len(args) == 1 {
-			intent = args[0]
-		} else {
+		}
+		intents = append(intents, args...)
+
+		if len(intents) == 0 {
 			return fmt.Errorf("provide an intent argument or use --issue")
 		}
-		return runTask(intent, mode, colors, asciiFlag)
+
+		// Single intent: run exactly as before (backward compatible).
+		if len(intents) == 1 {
+			issueNum := 0
+			if len(issues) > 0 {
+				issueNum = issues[0]
+			}
+			return runTask(intents[0], issueNum, mode, colors, asciiFlag)
+		}
+
+		// Multiple intents: concurrent execution.
+		return runTasks(intents, issues, mode, colors, asciiFlag)
 	},
 }
 
 func init() {
-	runCmd.Flags().IntVar(&issueFlag, "issue", 0, "GitHub issue number to use as intent")
+	runCmd.Flags().IntSliceVar(&issueFlags, "issue", nil, "GitHub issue number(s) to use as intent (repeatable)")
 	runCmd.Flags().StringVar(&outputFlag, "output", "", "output mode: cli|ci|json (default: auto-detect)")
 	runCmd.Flags().StringVar(&colorsFlag, "colors", "", "color scheme: default|accessible|no-color (default: auto-detect)")
 	runCmd.Flags().BoolVar(&asciiFlag, "ascii", false, "use ASCII glyphs instead of unicode emoji")
@@ -182,7 +203,7 @@ func (d *defaultQualityRunner) Run(ctx context.Context, task *state.Task, plan s
 	return runQualityPhase(ctx, d.cfg, d.client, d.store, task, plan, d.workDir, d.r)
 }
 
-func defaultRunDeps(cfg *config.Config, client completer, store *state.Store, workDir string, r ui.Renderer, ghClient *github.Client) runDeps {
+func defaultRunDeps(cfg *config.Config, client completer, store *state.Store, workDir string, r ui.Renderer, ghClient *github.Client, issueNumber int) runDeps {
 	return runDeps{
 		plan:    &defaultPlanRunner{cfg: cfg, client: client, store: store, r: r},
 		code:    &defaultCodeRunner{cfg: cfg, store: store, workDir: workDir, r: r},
@@ -194,12 +215,12 @@ func defaultRunDeps(cfg *config.Config, client completer, store *state.Store, wo
 		onEscalation: func(ctx context.Context, task *state.Task, result escalation.Result) error {
 			return escalateAndExit(ctx, task, result, cfg.Escalation, ghClient)
 		},
-		issueNumber: issueFlag,
+		issueNumber: issueNumber,
 		autoMerge:   cfg.AutoVairdict,
 	}
 }
 
-func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) error {
+func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme, ascii bool) error {
 	// Resolve overlay path from --env / CI auto-detect.
 	overlayPath, err := config.ResolveOverlayPath(envFlag, config.IsCI(), ".", fileExistsFunc)
 	if err != nil {
@@ -266,8 +287,8 @@ func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) err
 
 	r.RunStart(task.ID, intent, logPath)
 	r.Note("completer", string(backend))
-	if issueFlag > 0 {
-		r.Note("issue", fmt.Sprintf("#%d", issueFlag))
+	if issueNumber > 0 {
+		r.Note("issue", fmt.Sprintf("#%d", issueNumber))
 	}
 
 	slog.Info("task created", "id", task.ID, "intent", intent)
@@ -297,8 +318,180 @@ func runTask(intent string, mode ui.Mode, colors ui.ColorScheme, ascii bool) err
 	ghRunner := &github.ExecRunner{Dir: repoRoot}
 	ghClient := github.New(ghRunner)
 
-	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient)
+	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient, issueNumber)
 	return runOrchestration(ctx, deps, task, r)
+}
+
+// taskResult records the outcome of a single concurrent task.
+type taskResult struct {
+	TaskID string
+	Intent string
+	Err    error
+}
+
+// runTasks executes multiple intents concurrently with a semaphore
+// controlling the degree of parallelism. Shared resources (config, store,
+// completer) are created once; per-task resources (workspace, log file,
+// renderer, deps) are created inside each goroutine.
+func runTasks(intents []string, issues []int, mode ui.Mode, colors ui.ColorScheme, ascii bool) error {
+	// Resolve overlay path from --env / CI auto-detect.
+	overlayPath, err := config.ResolveOverlayPath(envFlag, config.IsCI(), ".", fileExistsFunc)
+	if err != nil {
+		return fmt.Errorf("resolving env: %w", err)
+	}
+
+	cfg, err := config.LoadConfigWithOverlay("vairdict.yaml", overlayPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	dbPath, err := state.DefaultDBPath()
+	if err != nil {
+		return fmt.Errorf("resolving database path: %w", err)
+	}
+
+	store, err := state.NewStore(dbPath)
+	if err != nil {
+		return fmt.Errorf("opening state store: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	client, _, err := resolveCompleter(cfg)
+	if err != nil {
+		return err
+	}
+
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving working directory: %w", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	// Print header for concurrent run.
+	_, _ = fmt.Fprintf(os.Stdout, "Running %d tasks (max %d concurrent)\n\n", len(intents), cfg.Parallel.MaxTasks)
+
+	sem := make(chan struct{}, cfg.Parallel.MaxTasks)
+	results := make([]taskResult, len(intents))
+	var wg sync.WaitGroup
+
+	for i, intent := range intents {
+		issueNum := 0
+		if i < len(issues) {
+			issueNum = issues[i]
+		}
+
+		wg.Add(1)
+		go func(idx int, intent string, issueNum int) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			results[idx] = runSingleTask(ctx, cfg, client, store, repoRoot, intent, issueNum)
+			r := results[idx]
+			status := "pass"
+			if r.Err != nil {
+				status = "FAIL"
+			}
+			_, _ = fmt.Fprintf(os.Stdout, "[%s] %s → %s\n", r.TaskID, truncate(intent, 60), status)
+		}(i, intent, issueNum)
+	}
+
+	wg.Wait()
+
+	// Print summary table.
+	_, _ = fmt.Fprintln(os.Stdout, "\n--- Summary ---")
+	var errs []string
+	for _, r := range results {
+		status := "pass"
+		detail := ""
+		if r.Err != nil {
+			status = "FAIL"
+			detail = ": " + r.Err.Error()
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "  [%s] %-6s %s%s\n", r.TaskID, status, truncate(r.Intent, 50), detail)
+		if r.Err != nil {
+			errs = append(errs, fmt.Sprintf("task %s: %v", r.TaskID, r.Err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%d of %d tasks failed:\n  %s", len(errs), len(results), strings.Join(errs, "\n  "))
+	}
+	return nil
+}
+
+// runSingleTask runs one task in the context of a concurrent runTasks call.
+// It creates per-task isolated resources (workspace, log file, renderer).
+func runSingleTask(
+	ctx context.Context,
+	cfg *config.Config,
+	client completer,
+	store *state.Store,
+	repoRoot string,
+	intent string,
+	issueNumber int,
+) taskResult {
+	taskID := uuid.New().String()[:8]
+	task := state.NewTask(taskID, intent)
+	res := taskResult{TaskID: taskID, Intent: intent}
+
+	if err := store.CreateTask(task); err != nil {
+		res.Err = fmt.Errorf("creating task: %w", err)
+		return res
+	}
+
+	logFile, logErr := ui.OpenLogFile(task.ID)
+	logger := slog.Default()
+	if logErr == nil {
+		logger = slog.New(logFile.Handler()).With("task_id", taskID)
+		defer func() { _ = logFile.Close() }()
+	}
+	logger.Info("task created", "id", task.ID, "intent", intent)
+
+	// Each concurrent task writes to its own log file, not stdout.
+	logWriter := io.Discard
+	if logFile != nil {
+		logWriter = logFile.File()
+	}
+
+	r := ui.New(ui.Options{
+		Mode:       ui.ModeCI,
+		Colors:     ui.ColorsNone,
+		ASCII:      true,
+		IsTTY:      false,
+		NoColorEnv: true,
+		Out:        logWriter,
+	})
+	defer func() { _ = r.Close() }()
+
+	r.RunStart(task.ID, intent, "")
+
+	wsMgr := workspace.New(repoRoot, "", &workspace.ExecRunner{})
+	ws, err := wsMgr.Create(ctx, task.ID)
+	if err != nil {
+		res.Err = fmt.Errorf("creating workspace: %w", err)
+		return res
+	}
+	defer func() { _ = ws.Cleanup(ctx) }()
+
+	workDir := ws.Path
+	ghRunner := &github.ExecRunner{Dir: repoRoot}
+	ghClient := github.New(ghRunner)
+
+	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient, issueNumber)
+	// In concurrent mode, escalation returns an error instead of os.Exit.
+	deps.onEscalation = func(ctx context.Context, task *state.Task, result escalation.Result) error {
+		if err := dispatchEscalation(ctx, task, result, cfg.Escalation, logWriter, ghClient); err != nil {
+			return fmt.Errorf("escalating task: %w", err)
+		}
+		return fmt.Errorf("task escalated in %s phase after %d loops (score: %.0f)", result.Phase, result.Loops, result.LastScore)
+	}
+
+	res.Err = runOrchestration(ctx, deps, task, r)
+	return res
 }
 
 // runOrchestration is the testable core of runTask. It receives all

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/vairdict/vairdict/internal/config"
@@ -835,4 +837,162 @@ func TestRunOrchestration_AutoMerge_FailureDoesNotFailRun(t *testing.T) {
 	if !b.gh.mergeCalled {
 		t.Error("MergePR should have been attempted")
 	}
+}
+
+// --- Concurrent runner tests ---
+
+// runConcurrentTest is a helper that calls runTasksConcurrent with the given
+// bundles and returns the collected results. It avoids real config loading,
+// store, workspaces, etc. by exercising runOrchestration directly.
+func runConcurrentTest(t *testing.T, bundles []*orchBundle, maxTasks int) []taskResult {
+	t.Helper()
+	intents := make([]string, len(bundles))
+	for i := range bundles {
+		intents[i] = fmt.Sprintf("intent-%d", i)
+	}
+
+	results := make([]taskResult, len(intents))
+	sem := make(chan struct{}, maxTasks)
+	var wg sync.WaitGroup
+
+	for i, b := range bundles {
+		task := state.NewTask(fmt.Sprintf("t-%d", i), intents[i])
+		r := &fakeRenderer{}
+		deps := b.deps()
+		wg.Add(1)
+		go func(idx int, task *state.Task, deps runDeps, r ui.Renderer) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			err := runOrchestration(context.Background(), deps, task, r)
+			results[idx] = taskResult{TaskID: task.ID, Intent: task.Intent, Err: err}
+		}(i, task, deps, r)
+	}
+
+	wg.Wait()
+	return results
+}
+
+func TestConcurrent_TwoTasksBothPass(t *testing.T) {
+	t.Parallel()
+	b1 := newOrchBundle()
+	b2 := newOrchBundle()
+
+	results := runConcurrentTest(t, []*orchBundle{b1, b2}, 3)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Errorf("task %d: unexpected error: %v", i, r.Err)
+		}
+	}
+	if !b1.gh.prCalled {
+		t.Error("task 0: PR not created")
+	}
+	if !b2.gh.prCalled {
+		t.Error("task 1: PR not created")
+	}
+}
+
+func TestConcurrent_OneFailsOneSucceeds(t *testing.T) {
+	t.Parallel()
+	b1 := newOrchBundle()
+	b2 := newOrchBundle()
+	b2.plan.result = &planphase.PhaseResult{Escalate: true, Loops: 3, LastScore: 30}
+
+	results := runConcurrentTest(t, []*orchBundle{b1, b2}, 3)
+
+	if results[0].Err != nil {
+		t.Errorf("task 0: expected success, got %v", results[0].Err)
+	}
+	if results[1].Err == nil {
+		t.Error("task 1: expected escalation error, got nil")
+	}
+	if !b1.gh.prCalled {
+		t.Error("task 0: PR should be created even when task 1 fails")
+	}
+	if b2.gh.prCalled {
+		t.Error("task 1: PR should not be created on escalation")
+	}
+}
+
+func TestConcurrent_SemaphoreRespected(t *testing.T) {
+	t.Parallel()
+	const numTasks = 4
+	const maxConcurrent = 2
+
+	var mu sync.Mutex
+	var running, peak int
+
+	results := make([]taskResult, numTasks)
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+
+	for i := 0; i < numTasks; i++ {
+		b := newOrchBundle()
+		task := state.NewTask(fmt.Sprintf("t-%d", i), fmt.Sprintf("intent-%d", i))
+		r := &fakeRenderer{}
+		deps := b.deps()
+
+		// Wrap the plan runner to track concurrency.
+		origPlan := deps.plan
+		deps.plan = &trackingPlanRunner{
+			inner:   origPlan,
+			mu:      &mu,
+			running: &running,
+			peak:    &peak,
+		}
+
+		wg.Add(1)
+		go func(idx int, task *state.Task, deps runDeps, r ui.Renderer) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			err := runOrchestration(context.Background(), deps, task, r)
+			results[idx] = taskResult{TaskID: task.ID, Intent: task.Intent, Err: err}
+		}(i, task, deps, r)
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	observed := peak
+	mu.Unlock()
+
+	if observed > maxConcurrent {
+		t.Errorf("peak concurrency = %d, want <= %d", observed, maxConcurrent)
+	}
+
+	for i, r := range results {
+		if r.Err != nil {
+			t.Errorf("task %d: unexpected error: %v", i, r.Err)
+		}
+	}
+}
+
+// trackingPlanRunner wraps a planRunner and tracks peak concurrency.
+type trackingPlanRunner struct {
+	inner   planRunner
+	mu      *sync.Mutex
+	running *int
+	peak    *int
+}
+
+func (tr *trackingPlanRunner) Run(ctx context.Context, task *state.Task) (*planphase.PhaseResult, error) {
+	tr.mu.Lock()
+	*tr.running++
+	if *tr.running > *tr.peak {
+		*tr.peak = *tr.running
+	}
+	tr.mu.Unlock()
+
+	defer func() {
+		tr.mu.Lock()
+		*tr.running--
+		tr.mu.Unlock()
+	}()
+
+	return tr.inner.Run(ctx, task)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,12 @@ type Config struct {
 	Phases       PhasesConfig      `yaml:"phases"`
 	Escalation   EscalationConfig  `yaml:"escalation"`
 	Conventions  ConventionsConfig `yaml:"conventions"`
+	Parallel     ParallelConfig    `yaml:"parallel"`
 	AutoVairdict bool              `yaml:"auto_vairdict"`
+}
+
+type ParallelConfig struct {
+	MaxTasks int `yaml:"max_tasks"`
 }
 
 type ProjectConfig struct {
@@ -90,6 +95,9 @@ type ConventionsConfig struct {
 // Defaults returns a Config with sensible defaults for all optional fields.
 func Defaults() Config {
 	return Config{
+		Parallel: ParallelConfig{
+			MaxTasks: 3,
+		},
 		Agents: AgentsConfig{
 			// "claude" is the smart default for the claude family: try
 			// the local CLI, fall back to the HTTP API. See
@@ -372,6 +380,11 @@ func Merge(base *Config, overrides Config) *Config {
 		merged.Escalation.Channel = overrides.Escalation.Channel
 	}
 
+	// Parallel
+	if overrides.Parallel.MaxTasks > 0 {
+		merged.Parallel.MaxTasks = overrides.Parallel.MaxTasks
+	}
+
 	// Conventions
 	if overrides.Conventions.Language != "" {
 		merged.Conventions.Language = overrides.Conventions.Language
@@ -402,6 +415,9 @@ func validate(cfg *Config) error {
 	if cfg.Escalation.AfterLoops < 1 {
 		return fmt.Errorf("validating config: escalation.after_loops must be >= 1")
 	}
+	if cfg.Parallel.MaxTasks < 1 {
+		return fmt.Errorf("validating config: parallel.max_tasks must be >= 1")
+	}
 	return nil
 }
 
@@ -411,7 +427,7 @@ func warnUnknownFields(data []byte) {
 	known := map[string]bool{
 		"project": true, "agents": true, "environment": true,
 		"commands": true, "phases": true, "escalation": true,
-		"conventions": true, "auto_vairdict": true,
+		"conventions": true, "parallel": true, "auto_vairdict": true,
 	}
 
 	var raw map[string]any

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -253,6 +253,75 @@ func TestMerge(t *testing.T) {
 	}
 }
 
+func TestParseConfig_ParallelDefaults(t *testing.T) {
+	data := []byte(`
+project:
+  name: test
+`)
+	cfg, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Parallel.MaxTasks != 3 {
+		t.Errorf("default parallel.max_tasks = %d, want 3", cfg.Parallel.MaxTasks)
+	}
+}
+
+func TestParseConfig_ParallelExplicit(t *testing.T) {
+	data := []byte(`
+project:
+  name: test
+parallel:
+  max_tasks: 5
+`)
+	cfg, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Parallel.MaxTasks != 5 {
+		t.Errorf("parallel.max_tasks = %d, want 5", cfg.Parallel.MaxTasks)
+	}
+}
+
+func TestParseConfig_ParallelMaxTasksZeroRejected(t *testing.T) {
+	data := []byte(`
+project:
+  name: test
+parallel:
+  max_tasks: 0
+`)
+	_, err := ParseConfig(data)
+	if err == nil {
+		t.Fatal("expected error for max_tasks=0, got nil")
+	}
+}
+
+func TestMerge_Parallel(t *testing.T) {
+	base := Defaults()
+	base.Project.Name = "base"
+
+	overrides := Config{
+		Parallel: ParallelConfig{MaxTasks: 8},
+	}
+
+	merged := Merge(&base, overrides)
+	if merged.Parallel.MaxTasks != 8 {
+		t.Errorf("merged parallel.max_tasks = %d, want 8", merged.Parallel.MaxTasks)
+	}
+}
+
+func TestMerge_ParallelZeroNoOverride(t *testing.T) {
+	base := Defaults()
+	base.Project.Name = "base"
+
+	overrides := Config{}
+
+	merged := Merge(&base, overrides)
+	if merged.Parallel.MaxTasks != 3 {
+		t.Errorf("merged parallel.max_tasks = %d, want 3 (base default)", merged.Parallel.MaxTasks)
+	}
+}
+
 func TestMerge_DoesNotMutateBase(t *testing.T) {
 	base := Defaults()
 	base.Project.Name = "original"

--- a/internal/ui/logfile.go
+++ b/internal/ui/logfile.go
@@ -45,6 +45,10 @@ func (l *LogFile) Handler() slog.Handler {
 	return slog.NewJSONHandler(l.f, &slog.HandlerOptions{Level: slog.LevelDebug})
 }
 
+// File returns the underlying *os.File so callers can use it as an
+// io.Writer (e.g. for renderer output in concurrent mode).
+func (l *LogFile) File() *os.File { return l.f }
+
 // Close flushes and closes the underlying file.
 func (l *LogFile) Close() error {
 	if l == nil || l.f == nil {

--- a/vairdict.yaml
+++ b/vairdict.yaml
@@ -41,6 +41,9 @@ escalation:
   notify_via: stdout
   channel: ""
 
+parallel:
+  max_tasks: 3
+
 conventions:
   language: go
   formatter: gofmt


### PR DESCRIPTION
## Summary

- Adds `ParallelConfig` (`parallel.max_tasks`, default 3) to config with merge, validation, and defaults
- Changes `--issue` to a repeatable flag (`--issue 42 --issue 43`) and accepts multiple positional intents
- New `runTasks()` orchestrates concurrent execution: semaphore limits parallelism, each goroutine gets its own workspace, log file, renderer, and logger
- In concurrent mode, escalation returns an error instead of calling `os.Exit()` — one task failing does not cancel others
- Single-intent path is fully backward compatible
- Adds `File()` accessor to `ui.LogFile` for concurrent renderer output

Closes #78

## Test plan

- [x] `TestParseConfig_ParallelDefaults` — default max_tasks is 3
- [x] `TestParseConfig_ParallelExplicit` — explicit config value honored
- [x] `TestParseConfig_ParallelMaxTasksZeroRejected` — validation rejects 0
- [x] `TestMerge_Parallel` / `TestMerge_ParallelZeroNoOverride` — merge semantics
- [x] `TestConcurrent_TwoTasksBothPass` — both tasks complete and create PRs
- [x] `TestConcurrent_OneFailsOneSucceeds` — failure doesn't cancel the other
- [x] `TestConcurrent_SemaphoreRespected` — peak concurrency tracked via `trackingPlanRunner`
- [x] All existing orchestration tests still pass (backward compat)
- [x] `make test`, `make lint`, `make build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)