### PR TITLE
feat(judge): tool-use schema, temperature 0, deterministic scoring (#85)

### DIFF
--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -28,6 +28,7 @@ import (
 // satisfy it structurally.
 type completer interface {
 	CompleteWithSystem(ctx context.Context, system, prompt string, target any) error
+	CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
 }
 
 // backendKind is the resolved backend identifier returned alongside the
@@ -82,7 +83,12 @@ func resolveCompleter(cfg *config.Config) (completer, backendKind, error) {
 			claudecli.WithExtraArgs("--dangerously-skip-permissions"),
 		), kind, nil
 	case backendClaudeAPI:
-		c, err := claude.NewClient(cfg)
+		// Judges must be deterministic — temperature=0 removes sampling
+		// variance so the same (prompt, diff) pair produces the same verdict
+		// structure across runs. The planner shares this client, which is
+		// fine: its output is consumed by a judge anyway, so determinism
+		// flows through the whole pipeline.
+		c, err := claude.NewClient(cfg, claude.WithTemperature(0))
 		if err != nil {
 			return nil, "", fmt.Errorf("creating claude client: %w", err)
 		}

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -144,7 +144,7 @@ type codeRunner interface {
 }
 
 type qualityRunner interface {
-	Run(ctx context.Context, task *state.Task, plan string) (*qualityphase.PhaseResult, error)
+	Run(ctx context.Context, task *state.Task, plan string, codeFacts string) (*qualityphase.PhaseResult, error)
 }
 
 // ghOrchestrator is the subset of github.Client the orchestrator needs.
@@ -199,8 +199,8 @@ type defaultQualityRunner struct {
 	r       ui.Renderer
 }
 
-func (d *defaultQualityRunner) Run(ctx context.Context, task *state.Task, plan string) (*qualityphase.PhaseResult, error) {
-	return runQualityPhase(ctx, d.cfg, d.client, d.store, task, plan, d.workDir, d.r)
+func (d *defaultQualityRunner) Run(ctx context.Context, task *state.Task, plan string, codeFacts string) (*qualityphase.PhaseResult, error) {
+	return runQualityPhase(ctx, d.cfg, d.client, d.store, task, plan, codeFacts, d.workDir, d.r)
 }
 
 func defaultRunDeps(cfg *config.Config, client completer, store *state.Store, workDir string, r ui.Renderer, ghClient *github.Client, issueNumber int) runDeps {
@@ -549,7 +549,7 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 	}
 
 	// --- Quality phase (gates the PR) ---
-	qualityResult, err := deps.quality.Run(ctx, task, planResult.Plan)
+	qualityResult, err := deps.quality.Run(ctx, task, planResult.Plan, codeResult.Feedback)
 	if err != nil {
 		r.Error(err)
 		return err
@@ -862,12 +862,13 @@ func runQualityPhase(
 	store *state.Store,
 	task *state.Task,
 	plan string,
+	codeFacts string,
 	workDir string,
 	r ui.Renderer,
 ) (*qualityphase.PhaseResult, error) {
 	r.PhaseStart(state.PhaseQuality)
 
-	judge := qualityjudge.New(client, &qualityjudge.ExecRunner{}, *cfg)
+	judge := qualityjudge.New(client, &qualityjudge.ExecRunner{}, *cfg).WithCodeFacts(codeFacts)
 	// Compute the unified diff once, here, so the judge gets concrete
 	// code content rather than just a working-directory path. The diff
 	// is stable across requeue loops because the quality phase never

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -489,16 +489,18 @@ func (f *fakeCodeRunner) Run(_ context.Context, task *state.Task, plan string) (
 }
 
 type fakeQualityRunner struct {
-	result *qualityphase.PhaseResult
-	gaps   []state.Gap
-	err    error
-	called bool
-	plan   string
+	result    *qualityphase.PhaseResult
+	gaps      []state.Gap
+	err       error
+	called    bool
+	plan      string
+	codeFacts string
 }
 
-func (f *fakeQualityRunner) Run(_ context.Context, task *state.Task, plan string) (*qualityphase.PhaseResult, error) {
+func (f *fakeQualityRunner) Run(_ context.Context, task *state.Task, plan string, codeFacts string) (*qualityphase.PhaseResult, error) {
 	f.called = true
 	f.plan = plan
+	f.codeFacts = codeFacts
 	if f.result != nil {
 		task.Attempts = append(task.Attempts, state.Attempt{
 			Phase: state.PhaseQuality, Loop: f.result.Loops,

--- a/internal/agents/claude/client.go
+++ b/internal/agents/claude/client.go
@@ -72,15 +72,34 @@ func (e *APIError) Error() string {
 
 // messagesRequest is the request body for the Anthropic Messages API.
 type messagesRequest struct {
-	Model     string    `json:"model"`
-	MaxTokens int       `json:"max_tokens"`
-	System    string    `json:"system,omitempty"`
-	Messages  []message `json:"messages"`
+	Model       string      `json:"model"`
+	MaxTokens   int         `json:"max_tokens"`
+	System      string      `json:"system,omitempty"`
+	Messages    []message   `json:"messages"`
+	Temperature *float64    `json:"temperature,omitempty"`
+	Tools       []Tool      `json:"tools,omitempty"`
+	ToolChoice  *ToolChoice `json:"tool_choice,omitempty"`
 }
 
 type message struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
+}
+
+// Tool is a tool-use definition passed to the Anthropic Messages API.
+// InputSchema is a JSON Schema object describing the expected tool input shape;
+// the model's tool_use input will conform to it.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// ToolChoice forces the model to call a specific tool. Use type "tool" with a
+// Name to require a single structured response matching that tool's schema.
+type ToolChoice struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
 }
 
 // messagesResponse is the response body from the Anthropic Messages API.
@@ -91,8 +110,10 @@ type messagesResponse struct {
 }
 
 type contentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
 }
 
 type usage struct {
@@ -108,10 +129,11 @@ type HTTPClient interface {
 
 // Client communicates with the Anthropic Messages API.
 type Client struct {
-	apiKey     string
-	model      string
-	endpoint   string
-	httpClient HTTPClient
+	apiKey      string
+	model       string
+	endpoint    string
+	httpClient  HTTPClient
+	temperature *float64
 }
 
 // Option configures a Client.
@@ -135,6 +157,14 @@ func WithEndpoint(endpoint string) Option {
 func WithModel(model string) Option {
 	return func(cl *Client) {
 		cl.model = model
+	}
+}
+
+// WithTemperature sets a default sampling temperature applied to every
+// request. Judges should call this with 0 for deterministic verdicts.
+func WithTemperature(t float64) Option {
+	return func(cl *Client) {
+		cl.temperature = &t
 	}
 }
 
@@ -182,14 +212,39 @@ func (c *Client) Complete(ctx context.Context, prompt string, target any) error 
 // Messages API and unmarshals the JSON response into the target struct.
 func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, target any) error {
 	reqBody := messagesRequest{
-		Model:     c.model,
-		MaxTokens: defaultMaxTokens,
-		System:    system,
-		Messages: []message{
-			{Role: "user", Content: prompt},
-		},
+		Model:       c.model,
+		MaxTokens:   defaultMaxTokens,
+		System:      system,
+		Messages:    []message{{Role: "user", Content: prompt}},
+		Temperature: c.temperature,
 	}
+	return c.sendAndParse(ctx, reqBody, func(resp *messagesResponse) error {
+		return unmarshalText(resp, target)
+	})
+}
 
+// CompleteWithTool sends a prompt that forces the model to call the given tool
+// and unmarshals the tool's input into target. This path uses the Anthropic
+// tool-use API for structured output with a strict JSON schema, avoiding
+// prose-to-JSON parsing.
+func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, tool Tool, target any) error {
+	reqBody := messagesRequest{
+		Model:       c.model,
+		MaxTokens:   defaultMaxTokens,
+		System:      system,
+		Messages:    []message{{Role: "user", Content: prompt}},
+		Temperature: c.temperature,
+		Tools:       []Tool{tool},
+		ToolChoice:  &ToolChoice{Type: "tool", Name: tool.Name},
+	}
+	return c.sendAndParse(ctx, reqBody, func(resp *messagesResponse) error {
+		return unmarshalToolInput(resp, tool.Name, target)
+	})
+}
+
+// sendAndParse drives the retry loop for a single request and hands the
+// decoded response to the caller-supplied extractor.
+func (c *Client) sendAndParse(ctx context.Context, reqBody messagesRequest, extract func(*messagesResponse) error) error {
 	var lastErr error
 	for attempt := range maxRetries {
 		if err := ctx.Err(); err != nil {
@@ -198,12 +253,15 @@ func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, 
 
 		body, err := c.doRequest(ctx, reqBody)
 		if err == nil {
-			return c.parseResponse(body, target)
+			var resp messagesResponse
+			if decodeErr := json.Unmarshal(body, &resp); decodeErr != nil {
+				return &ParseError{Body: string(body), Err: fmt.Errorf("unmarshalling response: %w", decodeErr)}
+			}
+			return extract(&resp)
 		}
 
 		lastErr = err
 
-		// Only retry on rate-limit or server errors.
 		if !isRetryable(err) {
 			return err
 		}
@@ -265,26 +323,34 @@ func (c *Client) doRequest(ctx context.Context, reqBody messagesRequest) ([]byte
 	}
 }
 
-func (c *Client) parseResponse(body []byte, target any) error {
-	var resp messagesResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return &ParseError{Body: string(body), Err: fmt.Errorf("unmarshalling response: %w", err)}
-	}
-
+func unmarshalText(resp *messagesResponse, target any) error {
 	if len(resp.Content) == 0 {
-		return &ParseError{Body: string(body), Err: fmt.Errorf("empty content in response")}
+		return &ParseError{Err: fmt.Errorf("empty content in response")}
 	}
 
 	text := resp.Content[0].Text
-
-	// Try to extract JSON from the response text if it's wrapped in markdown.
 	cleaned := extractJSON(text)
 
 	if err := json.Unmarshal([]byte(cleaned), target); err != nil {
 		return &ParseError{Body: text, Err: fmt.Errorf("unmarshalling into target: %w", err)}
 	}
-
 	return nil
+}
+
+func unmarshalToolInput(resp *messagesResponse, toolName string, target any) error {
+	for _, block := range resp.Content {
+		if block.Type != "tool_use" || block.Name != toolName {
+			continue
+		}
+		if len(block.Input) == 0 {
+			return &ParseError{Err: fmt.Errorf("tool_use block %q had empty input", toolName)}
+		}
+		if err := json.Unmarshal(block.Input, target); err != nil {
+			return &ParseError{Body: string(block.Input), Err: fmt.Errorf("unmarshalling tool input: %w", err)}
+		}
+		return nil
+	}
+	return &ParseError{Err: fmt.Errorf("no tool_use block for tool %q in response", toolName)}
 }
 
 // extractJSON tries to extract a JSON object or array from text that may be

--- a/internal/agents/claude/client_test.go
+++ b/internal/agents/claude/client_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -502,6 +504,141 @@ func TestErrorTypes(t *testing.T) {
 			t.Errorf("unexpected error string: %s", err.Error())
 		}
 	})
+}
+
+// --- Tool-use tests ---
+
+func TestCompleteWithTool_Success(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	tool := Tool{
+		Name:        "submit_verdict",
+		Description: "submit a verdict",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req messagesRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decoding request: %v", err)
+		}
+		if len(req.Tools) != 1 || req.Tools[0].Name != "submit_verdict" {
+			t.Errorf("expected tools=[submit_verdict], got %+v", req.Tools)
+		}
+		if req.ToolChoice == nil || req.ToolChoice.Type != "tool" || req.ToolChoice.Name != "submit_verdict" {
+			t.Errorf("expected forced tool_choice for submit_verdict, got %+v", req.ToolChoice)
+		}
+
+		resp := messagesResponse{
+			Content: []contentBlock{{
+				Type:  "tool_use",
+				Name:  "submit_verdict",
+				Input: json.RawMessage(`{"answer":"structured"}`),
+			}},
+			StopReason: "tool_use",
+		}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	if err := c.CompleteWithTool(context.Background(), "sys", "prompt", tool, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Answer != "structured" {
+		t.Errorf("expected answer from tool_use block, got %q", result.Answer)
+	}
+}
+
+func TestCompleteWithTool_MissingToolBlock(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`plain text, no tool_use`)))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	err = c.CompleteWithTool(context.Background(), "", "prompt",
+		Tool{Name: "submit_verdict", InputSchema: json.RawMessage(`{}`)}, &result)
+	if err == nil {
+		t.Fatal("expected ParseError when no tool_use block is returned")
+	}
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestWithTemperature_IncludedInRequest(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var captured messagesRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decoding request: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`{"answer":"ok","score":1}`)))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL), WithTemperature(0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	if err := c.Complete(context.Background(), "prompt", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if captured.Temperature == nil {
+		t.Fatal("expected temperature to be set in request")
+	}
+	if *captured.Temperature != 0 {
+		t.Errorf("expected temperature=0, got %f", *captured.Temperature)
+	}
+}
+
+func TestWithoutTemperature_OmitsField(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var bodyBytes []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodyBytes = b
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`{"answer":"ok","score":1}`)))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	if err := c.Complete(context.Background(), "prompt", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(string(bodyBytes), `"temperature"`) {
+		t.Errorf("expected temperature field omitted when unset, got body: %s", bodyBytes)
+	}
 }
 
 func TestExtractJSON(t *testing.T) {

--- a/internal/agents/claude/fake.go
+++ b/internal/agents/claude/fake.go
@@ -20,10 +20,12 @@ type FakeClient struct {
 	Calls []FakeCall
 }
 
-// FakeCall records a single invocation of Complete or CompleteWithSystem.
+// FakeCall records a single invocation of Complete, CompleteWithSystem, or
+// CompleteWithTool. ToolName is empty for non-tool calls.
 type FakeCall struct {
-	System string
-	Prompt string
+	System   string
+	Prompt   string
+	ToolName string
 }
 
 // Complete records the call and returns the configured response or error.
@@ -34,7 +36,18 @@ func (f *FakeClient) Complete(_ context.Context, prompt string, target any) erro
 // CompleteWithSystem records the call and returns the configured response or error.
 func (f *FakeClient) CompleteWithSystem(_ context.Context, system, prompt string, target any) error {
 	f.Calls = append(f.Calls, FakeCall{System: system, Prompt: prompt})
+	return f.fill(target)
+}
 
+// CompleteWithTool records the call (including the tool name) and returns the
+// configured response or error. The configured Response is marshalled into the
+// target as if the tool had been invoked.
+func (f *FakeClient) CompleteWithTool(_ context.Context, system, prompt string, tool Tool, target any) error {
+	f.Calls = append(f.Calls, FakeCall{System: system, Prompt: prompt, ToolName: tool.Name})
+	return f.fill(target)
+}
+
+func (f *FakeClient) fill(target any) error {
 	if f.Err != nil {
 		return f.Err
 	}

--- a/internal/agents/claudecli/client.go
+++ b/internal/agents/claudecli/client.go
@@ -19,6 +19,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/vairdict/vairdict/internal/agents/claude"
 )
 
 // NotInstalledError is returned when the `claude` binary cannot be found on
@@ -126,6 +128,25 @@ func IsAvailable() bool {
 // interface that expects both methods.
 func (c *Client) Complete(ctx context.Context, prompt string, target any) error {
 	return c.CompleteWithSystem(ctx, "", prompt, target)
+}
+
+// CompleteWithTool is the CLI-path implementation of the tool-use API.
+// The Claude Code CLI does not expose native tool-use with a forced schema,
+// so this falls back to embedding the tool's JSON Schema into the system
+// prompt and reusing the prose-to-JSON parser. The API client's
+// implementation enforces the schema strictly; this one is best-effort
+// structural. Judges therefore behave the same way from the caller side
+// regardless of which transport is resolved.
+func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error {
+	augmented := system
+	if augmented != "" {
+		augmented += "\n\n"
+	}
+	augmented += fmt.Sprintf(
+		"## Response tool: %s\n%s\n\nRespond with a single JSON object that conforms to this JSON Schema (no markdown, no prose outside the object):\n%s",
+		tool.Name, tool.Description, string(tool.InputSchema),
+	)
+	return c.CompleteWithSystem(ctx, augmented, prompt, target)
 }
 
 // envelope is the subset of Claude Code's `--output-format json` result that

--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -1,6 +1,7 @@
 // Package plan implements the plan phase judge, which evaluates whether a
 // generated plan sufficiently covers the stated intent. It uses the Claude API
-// to score the plan and identify gaps at varying severity levels.
+// to identify gaps and questions, then computes a deterministic score from the
+// gap severities rather than asking the model for a number.
 package plan
 
 import (
@@ -8,14 +9,16 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/state"
+	"github.com/vairdict/vairdict/internal/judges/verdictschema"
 )
 
-// Completer is the interface for sending prompts to an LLM and receiving
-// typed responses. Both claude.Client and claude.FakeClient satisfy this.
+// Completer is the interface for sending prompts to an LLM. Plan judge uses
+// tool-use exclusively so responses conform to a strict schema.
 type Completer interface {
-	CompleteWithSystem(ctx context.Context, system, prompt string, target any) error
+	CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
 }
 
 // PlanJudge evaluates a plan against an intent and returns a typed Verdict.
@@ -35,7 +38,9 @@ func New(client Completer, cfg config.PlanPhaseConfig) *PlanJudge {
 const systemPrompt = `You are a plan judge for a software development process engine.
 Your job is to evaluate whether a proposed plan adequately covers the stated intent.
 
-You MUST respond with valid JSON only — no markdown, no explanation outside the JSON.
+You respond by invoking the submit_verdict tool. The tool's schema is the
+single source of truth for the response shape — do not emit free-form JSON,
+markdown fences, or prose outside the tool call.
 
 Severity levels for gaps:
 - P0: next steps cannot proceed without resolving this — critical blocker
@@ -43,10 +48,8 @@ Severity levels for gaps:
 - P2: ambiguous, agent will document assumption and proceed — not blocking
 - P3: nice to have, deferred to future issue — not blocking
 
-For each gap, set "blocking" to true only for P0 and P1 severity.
-
-Score is a float from 0 to 100 representing how well the plan covers the intent.
-Higher scores mean better coverage.
+Do NOT set "blocking" on gaps and do NOT estimate a score — the orchestrator
+computes both deterministically from severities.
 
 The "summary" field is a short human-readable narrative in markdown-ish form
 that will be rendered under the plan phase header in the CLI. Use these exact
@@ -63,68 +66,91 @@ sub-section headers (omit a section if empty), with "- " bullet items:
 
 Keep each bullet to one line. Do not include any other sections or prose.
 
-Respond with this exact JSON structure:
+A concern goes in EXACTLY ONE of "gaps" or "questions". A "question" is only
+for genuine uncertainty you cannot resolve from the plan; if you can state it
+as a finding, use a gap.
+
+## Examples
+
+### Example 1 — clear pass
+
+Intent: "Add a CLI flag --quiet that suppresses non-error output."
+Plan: "Add a BoolP flag 'quiet' to the run command in cmd/vairdict/run.go.
+When set, route the renderer constructor through ui.NewQuiet() instead of
+ui.NewCLI(). Tests: new test case in run_test.go covering --quiet."
+
+submit_verdict input:
 {
-  "score": <float 0-100>,
-  "pass": <bool>,
-  "summary": "<markdown-ish narrative as described above>",
+  "summary": "## Decided\n- Thread --quiet through the existing renderer factory\n## Files to touch\n- cmd/vairdict/run.go — flag plumbing\n- cmd/vairdict/run_test.go — quiet-mode coverage",
+  "gaps": [],
+  "questions": []
+}
+
+### Example 2 — clear fail
+
+Intent: "Persist task state across restarts."
+Plan: "We will store tasks in memory and print them on exit."
+
+submit_verdict input:
+{
+  "summary": "## Risks\n- Plan does not satisfy the persistence requirement",
   "gaps": [
-    {
-      "severity": "<P0|P1|P2|P3>",
-      "description": "<what is missing or wrong>",
-      "blocking": <bool>
-    }
+    {"severity": "P0", "description": "In-memory storage is lost on restart — intent explicitly requires persistence across restarts."},
+    {"severity": "P1", "description": "No mention of a storage backend, schema, or migration strategy."}
   ],
-  "questions": [
-    {
-      "text": "<question for the planner>",
-      "priority": "<high|medium|low>"
-    }
-  ]
+  "questions": []
 }`
 
 // Judge evaluates a plan against an intent and returns a Verdict.
-// Pass is determined by whether the score meets the configured coverage threshold.
-// Blocking gaps are set based on the configured severity block-on list.
+// Pass is determined by whether the score meets the configured coverage
+// threshold AND there are no blocking gaps. Blocking is assigned from the
+// configured severity block-on list, not the LLM's opinion.
 func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string) (*state.Verdict, error) {
 	prompt := fmt.Sprintf("## Intent\n%s\n\n## Plan\n%s", intent, plan)
 
 	var verdict state.Verdict
-	if err := j.client.CompleteWithSystem(ctx, systemPrompt, prompt, &verdict); err != nil {
+	tool := verdictschema.VerdictTool("Submit the plan judge verdict as a structured object. Omit score, pass, and blocking — they are computed from the gap severities.")
+	if err := j.client.CompleteWithTool(ctx, systemPrompt, prompt, tool, &verdict); err != nil {
 		return nil, fmt.Errorf("judging plan: %w", err)
 	}
 
-	// Build lookup sets from config.
+	// Always pass a non-nil map — empty BlockOn must mean "nothing blocks",
+	// not "fall back to default P0+P1".
 	blockSet := toSet(j.cfg.Severity.BlockOn)
+	if blockSet == nil {
+		blockSet = map[string]bool{}
+	}
 	assumeSet := toSet(j.cfg.Severity.AssumeOn)
 	deferSet := toSet(j.cfg.Severity.DeferOn)
 
-	// Enforce blocking based on config, not the LLM's opinion.
-	for i := range verdict.Gaps {
-		sev := string(verdict.Gaps[i].Severity)
-		verdict.Gaps[i].Blocking = blockSet[sev]
+	verdictschema.ApplyBlocking(verdict.Gaps, blockSet)
 
+	for _, g := range verdict.Gaps {
+		sev := string(g.Severity)
 		if assumeSet[sev] {
 			slog.Info("gap logged as assumption, not blocking",
 				"severity", sev,
-				"description", verdict.Gaps[i].Description,
+				"description", g.Description,
 			)
 		}
 		if deferSet[sev] {
 			slog.Info("gap deferred to future issue",
 				"severity", sev,
-				"description", verdict.Gaps[i].Description,
+				"description", g.Description,
 			)
 		}
 	}
 
-	// Enforce pass based on config threshold, not the LLM's opinion.
-	verdict.Pass = verdict.Score >= j.cfg.CoverageThreshold
+	verdict.Score = verdictschema.ComputeScore(verdict.Gaps)
+	verdict.Pass = verdict.Score >= j.cfg.CoverageThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
 
 	return &verdict, nil
 }
 
 func toSet(items []string) map[string]bool {
+	if len(items) == 0 {
+		return nil
+	}
 	s := make(map[string]bool, len(items))
 	for _, item := range items {
 		s[item] = true

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -307,28 +307,3 @@ func TestJudge_SystemPromptIncludesFewShotExamples(t *testing.T) {
 	}
 }
 
-func TestJudge_DeterministicVerdictShape(t *testing.T) {
-	// Issue #85: same input must produce the same verdict structure across
-	// runs. Because scoring is computed from gap severities, two invocations
-	// with identical fake responses must yield identical Score/Pass.
-	resp := state.Verdict{
-		Gaps: []state.Gap{
-			{Severity: state.SeverityP1, Description: "gap a"},
-			{Severity: state.SeverityP2, Description: "gap b"},
-		},
-	}
-	judge := New(&claude.FakeClient{Response: resp}, defaultCfg())
-
-	v1, err := judge.Judge(context.Background(), "intent", "plan")
-	if err != nil {
-		t.Fatal(err)
-	}
-	v2, err := judge.Judge(context.Background(), "intent", "plan")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if v1.Score != v2.Score || v1.Pass != v2.Pass {
-		t.Errorf("verdict not deterministic: %+v vs %+v", v1, v2)
-	}
-}

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/judges/verdictschema"
 	"github.com/vairdict/vairdict/internal/state"
 )
 
@@ -23,12 +24,10 @@ func defaultCfg() config.PlanPhaseConfig {
 	}
 }
 
-func TestJudge_Pass(t *testing.T) {
+func TestJudge_Pass_NoGapsScoresFull(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 90,
-			Pass:  true,
-			Gaps:  []state.Gap{},
+			Gaps: []state.Gap{},
 		},
 	}
 
@@ -39,32 +38,29 @@ func TestJudge_Pass(t *testing.T) {
 	}
 
 	if !verdict.Pass {
-		t.Error("expected pass=true for score 90 with threshold 80")
+		t.Error("expected pass=true for 0 gaps (score 100)")
 	}
-	if verdict.Score != 90 {
-		t.Errorf("expected score 90, got %f", verdict.Score)
-	}
-	if len(verdict.Gaps) != 0 {
-		t.Errorf("expected no gaps, got %d", len(verdict.Gaps))
+	if verdict.Score != 100 {
+		t.Errorf("expected score 100 for 0 gaps, got %f", verdict.Score)
 	}
 
-	// Verify prompt was sent correctly.
 	if len(fake.Calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
+	}
+	if fake.Calls[0].ToolName != verdictschema.ToolName {
+		t.Errorf("expected tool name %q, got %q", verdictschema.ToolName, fake.Calls[0].ToolName)
 	}
 	if fake.Calls[0].System == "" {
 		t.Error("expected system prompt to be set")
 	}
 }
 
-func TestJudge_Fail(t *testing.T) {
+func TestJudge_Fail_BlockingGapsDriveScoreDown(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 50,
-			Pass:  false,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "no error handling", Blocking: true},
-				{Severity: state.SeverityP1, Description: "missing auth", Blocking: true},
+				{Severity: state.SeverityP0, Description: "no error handling"},
+				{Severity: state.SeverityP1, Description: "missing auth"},
 			},
 			Questions: []state.Question{
 				{Text: "What database?", Priority: "high"},
@@ -78,32 +74,25 @@ func TestJudge_Fail(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// P0 (-40) + P1 (-20) = 40.
+	if verdict.Score != 40 {
+		t.Errorf("expected deterministic score 40, got %f", verdict.Score)
+	}
 	if verdict.Pass {
-		t.Error("expected pass=false for score 50 with threshold 80")
+		t.Error("expected pass=false with blocking gaps")
 	}
-	if verdict.Score != 50 {
-		t.Errorf("expected score 50, got %f", verdict.Score)
-	}
-	if len(verdict.Gaps) != 2 {
-		t.Fatalf("expected 2 gaps, got %d", len(verdict.Gaps))
-	}
-	if !verdict.Gaps[0].Blocking {
-		t.Error("expected P0 gap to be blocking")
-	}
-	if !verdict.Gaps[1].Blocking {
-		t.Error("expected P1 gap to be blocking")
+	if !verdict.Gaps[0].Blocking || !verdict.Gaps[1].Blocking {
+		t.Error("expected P0 and P1 gaps to be blocking")
 	}
 	if len(verdict.Questions) != 1 {
 		t.Errorf("expected 1 question, got %d", len(verdict.Questions))
 	}
 }
 
-func TestJudge_BlockingEnforcedByConfig(t *testing.T) {
-	// LLM returns P0 as non-blocking and P2 as blocking — judge overrides both.
+func TestJudge_BlockingIgnoresLLMOpinion(t *testing.T) {
+	// LLM returns stray Blocking flags — judge recomputes from severity.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 75,
-			Pass:  false,
 			Gaps: []state.Gap{
 				{Severity: state.SeverityP0, Description: "critical gap", Blocking: false},
 				{Severity: state.SeverityP2, Description: "ambiguous gap", Blocking: true},
@@ -125,12 +114,16 @@ func TestJudge_BlockingEnforcedByConfig(t *testing.T) {
 	}
 }
 
-func TestJudge_PassEnforcedByConfig(t *testing.T) {
-	// LLM says pass=true but score is below threshold.
+func TestJudge_AccumulatedP2sDragScoreBelowThreshold(t *testing.T) {
+	// Three P2 gaps: 100 - 3*10 = 70, below threshold 80.
+	// P2 is non-blocking, so pass is gated purely on the score.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 70,
-			Pass:  true,
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP2, Description: "a"},
+				{Severity: state.SeverityP2, Description: "b"},
+				{Severity: state.SeverityP2, Description: "c"},
+			},
 		},
 	}
 
@@ -140,16 +133,22 @@ func TestJudge_PassEnforcedByConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if verdict.Score != 70 {
+		t.Errorf("expected score 70, got %f", verdict.Score)
+	}
 	if verdict.Pass {
-		t.Error("expected pass=false when score 70 < threshold 80, regardless of LLM opinion")
+		t.Error("expected pass=false when accumulated non-blocking gaps drag score below threshold")
 	}
 }
 
 func TestJudge_PassTrueAtExactThreshold(t *testing.T) {
+	// Two P2 gaps: 100 - 20 = 80, exactly equal to threshold.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 80,
-			Pass:  false,
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP2, Description: "a"},
+				{Severity: state.SeverityP2, Description: "b"},
+			},
 		},
 	}
 
@@ -159,6 +158,9 @@ func TestJudge_PassTrueAtExactThreshold(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if verdict.Score != 80 {
+		t.Errorf("expected score 80, got %f", verdict.Score)
+	}
 	if !verdict.Pass {
 		t.Error("expected pass=true when score equals threshold exactly")
 	}
@@ -167,9 +169,8 @@ func TestJudge_PassTrueAtExactThreshold(t *testing.T) {
 func TestJudge_P3GapsDeferred(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 85,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP3, Description: "nice to have", Blocking: true},
+				{Severity: state.SeverityP3, Description: "nice to have"},
 			},
 		},
 	}
@@ -183,8 +184,9 @@ func TestJudge_P3GapsDeferred(t *testing.T) {
 	if verdict.Gaps[0].Blocking {
 		t.Error("expected P3 gap to be non-blocking (deferred)")
 	}
+	// 100 - 5 = 95, above threshold.
 	if !verdict.Pass {
-		t.Error("expected pass=true for score 85 with threshold 80")
+		t.Error("expected pass=true for one P3 gap (score 95)")
 	}
 }
 
@@ -212,12 +214,12 @@ func TestJudge_CustomSeverityConfig(t *testing.T) {
 		},
 	}
 
+	// Only a P1 gap — with custom config it is non-blocking.
+	// Score: 100 - 20 = 80, above threshold 60, so pass.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 65,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "critical", Blocking: true},
-				{Severity: state.SeverityP1, Description: "important", Blocking: true},
+				{Severity: state.SeverityP1, Description: "important"},
 			},
 		},
 	}
@@ -228,22 +230,17 @@ func TestJudge_CustomSeverityConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !verdict.Gaps[0].Blocking {
-		t.Error("expected P0 gap to be blocking")
-	}
-	if verdict.Gaps[1].Blocking {
+	if verdict.Gaps[0].Blocking {
 		t.Error("expected P1 gap to be non-blocking with custom config")
 	}
 	if !verdict.Pass {
-		t.Error("expected pass=true for score 65 with threshold 60")
+		t.Errorf("expected pass=true (score %f, threshold 60, non-blocking)", verdict.Score)
 	}
 }
 
 func TestJudge_EmptyGapsAndQuestions(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score:     95,
-			Pass:      true,
 			Gaps:      nil,
 			Questions: nil,
 		},
@@ -272,8 +269,6 @@ func TestJudge_SummaryRoundTrip(t *testing.T) {
 	want := "## Decided\n- Use cobra for CLI\n\n## Risks\n- dependency on gh CLI"
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score:   90,
-			Pass:    true,
 			Summary: want,
 		},
 	}
@@ -298,5 +293,42 @@ func TestJudge_SystemPromptMentionsSummary(t *testing.T) {
 		if !strings.Contains(systemPrompt, section) {
 			t.Errorf("system prompt missing summary sub-section %q", section)
 		}
+	}
+}
+
+func TestJudge_SystemPromptIncludesFewShotExamples(t *testing.T) {
+	// Issue #85 requires at least 2 few-shot examples (one pass, one fail)
+	// to keep the model's output stable across runs.
+	examples := []string{"Example 1", "Example 2", "submit_verdict"}
+	for _, needle := range examples {
+		if !strings.Contains(systemPrompt, needle) {
+			t.Errorf("system prompt missing few-shot anchor %q", needle)
+		}
+	}
+}
+
+func TestJudge_DeterministicVerdictShape(t *testing.T) {
+	// Issue #85: same input must produce the same verdict structure across
+	// runs. Because scoring is computed from gap severities, two invocations
+	// with identical fake responses must yield identical Score/Pass.
+	resp := state.Verdict{
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP1, Description: "gap a"},
+			{Severity: state.SeverityP2, Description: "gap b"},
+		},
+	}
+	judge := New(&claude.FakeClient{Response: resp}, defaultCfg())
+
+	v1, err := judge.Judge(context.Background(), "intent", "plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := judge.Judge(context.Background(), "intent", "plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v1.Score != v2.Score || v1.Pass != v2.Pass {
+		t.Errorf("verdict not deterministic: %+v vs %+v", v1, v2)
 	}
 }

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -1,6 +1,7 @@
 // Package quality implements the quality phase judge, which evaluates whether
 // completed code fulfills the original task intent and optionally runs e2e tests.
-// It uses the Claude API for intent verification and produces a typed Verdict.
+// It uses the Claude API for intent verification via tool-use and produces a
+// typed Verdict with a deterministic score computed from gap severities.
 package quality
 
 import (
@@ -11,14 +12,16 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/judges/verdictschema"
 	"github.com/vairdict/vairdict/internal/state"
 )
 
-// Completer is the interface for sending prompts to an LLM and receiving
-// typed responses. Both claude.Client and claude.FakeClient satisfy this.
+// Completer is the interface for sending prompts to an LLM. Quality judge uses
+// tool-use exclusively so responses conform to a strict schema.
 type Completer interface {
-	CompleteWithSystem(ctx context.Context, system, prompt string, target any) error
+	CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
 }
 
 // CommandRunner executes a command and returns its output and error.
@@ -41,13 +44,19 @@ func (e *ExecRunner) Run(ctx context.Context, workDir string, name string, args 
 	return out.Bytes(), err
 }
 
+// PassThreshold is the minimum score a quality verdict must reach to pass.
+// Because scores are computed deterministically from gap severities, this is
+// a fixed tuning knob rather than a config value.
+const PassThreshold = 70.0
+
 // QualityJudge evaluates whether completed code fulfills the original task
 // intent and optionally runs e2e tests. It combines AI-based intent
 // verification with command-based e2e testing to produce a comprehensive Verdict.
 type QualityJudge struct {
-	client Completer
-	runner CommandRunner
-	cfg    config.Config
+	client    Completer
+	runner    CommandRunner
+	cfg       config.Config
+	codeFacts string
 }
 
 // New creates a QualityJudge with the given client, command runner, and config.
@@ -59,15 +68,38 @@ func New(client Completer, runner CommandRunner, cfg config.Config) *QualityJudg
 	}
 }
 
+// WithCodeFacts returns a judge that will inject the given facts block into
+// the prompt. Facts come from the preceding code phase (lint/test/build via
+// spm ship) so the LLM does not re-evaluate objective checks.
+func (j *QualityJudge) WithCodeFacts(facts string) *QualityJudge {
+	cp := *j
+	cp.codeFacts = facts
+	return &cp
+}
+
 const systemPrompt = `You are a quality judge for a software development process engine.
 Your job is to evaluate whether implemented code fulfills the original task intent.
+
+You respond by invoking the submit_verdict tool. The tool's schema is the
+single source of truth for the response shape — do not emit free-form JSON,
+markdown fences, or prose outside the tool call.
 
 You are given the original intent, the approved plan, and the unified diff
 of the changes that were made. Evaluate whether the diff actually
 implements the intent and plan. Base every observation on what the diff
 shows — never invent file contents that are not in the diff.
 
-You MUST respond with valid JSON only — no markdown, no explanation outside the JSON.
+## Do NOT re-evaluate objective checks
+
+Tests, lint, format, and build have already been verified by the code judge
+(spm ship). If a "## Facts (from code judge)" section is provided in the user
+message, trust it. Do NOT:
+- raise gaps about tests failing / not compiling / formatting
+- speculate whether the code builds
+- suggest running the test suite
+
+Focus on: intent fulfillment, plan alignment, correctness bugs,
+security, code reuse, and style — things the code judge does not check.
 
 ## Critical: the diff is PARTIAL
 
@@ -84,7 +116,8 @@ You MUST NOT:
 
 These are NOT bugs. They are existing code that was not modified.
 
-Severity levels for gaps:
+## Severity levels for gaps
+
 - P0: intent mismatch — the code does not solve the stated problem or is fundamentally wrong
 - P1: significant gap — major feature or requirement is missing or broken.
   This includes any correctness bug in production code OR test code, such as:
@@ -96,14 +129,13 @@ Severity levels for gaps:
 - P2: minor issue — style, naming, docs, minor edge cases that do not affect correctness
 - P3: nice to have — deferred to future work
 
-For each gap, set "blocking" to true only for P0 and P1 severity.
+Do NOT set "blocking" on gaps and do NOT estimate a score — the orchestrator
+computes both deterministically from severities.
 A correctness bug is ALWAYS at least P1, never P2 — even if it is in test code.
 
 ## Additional checks
 
 In addition to intent/plan alignment, scan the diff for the following.
-These are supplementary to the intent/plan check above. Security issues
-are blocking (P1). Code-reuse and style issues are non-blocking (P2/P3).
 
 ### Security (P1 blocking)
 Flag any of these patterns visible in the diff:
@@ -118,19 +150,13 @@ Flag any of these patterns visible in the diff:
 - Use of known-insecure crypto (MD5, SHA1 for security purposes, DES, RC4)
 - Disabled TLS verification or certificate checks
 
-Security issues are blocking — set severity to P1 and blocking to true.
-Only flag what is actually visible in the diff. Do not speculate about code
-outside the diff.
+Only flag what is actually visible in the diff.
 
 ### Code reuse (P2 non-blocking)
 Flag duplicated or copy-pasted logic visible in the diff:
 - Two or more new functions/methods with near-identical bodies (>5 lines)
 - Copy-pasted blocks that differ only in variable names or literals
 - Re-implementation of logic that clearly exists in the same diff
-  (e.g. a helper is defined but not used, and the same logic is inlined)
-
-Only flag duplication within the diff itself — do not assume what exists
-in the rest of the codebase.
 
 ### Style & maintainability (P3 non-blocking)
 Flag readability and maintainability issues visible in the diff:
@@ -140,12 +166,7 @@ Flag readability and maintainability issues visible in the diff:
 - Deeply nested control flow (>3 levels) that could be simplified
 - Missing error handling where errors are silently discarded (e.g. _ = fn())
 
-These are suggestions, not requirements. Use P3 severity.
-
----
-
-Score is a float from 0 to 100 representing how well the implementation fulfills the intent.
-Set pass to true if the implementation adequately fulfills the intent (score >= 70).
+## Summary
 
 The "summary" field is a short human-readable narrative in markdown-ish form
 that will be rendered under the quality phase header in the CLI. Use these
@@ -162,38 +183,41 @@ Keep each bullet to one line. Do not include any other sections or prose.
 ## Output rules
 
 1. Each concern goes in EXACTLY ONE array — either "gaps" or "questions", never both.
-   After drafting your response, remove any question that covers the same topic as a gap.
-2. A "question" is ONLY for genuine uncertainty you cannot resolve from the diff
-   (e.g. "is this called from a hot path?"). If you can state it as a finding, use a gap.
+2. A "question" is ONLY for genuine uncertainty you cannot resolve from the diff.
 3. Never create a gap or question about a symbol not defined in the diff — it exists.
+4. For gaps tied to a specific diff line, set "file" (b/ side) and "line" (+ side).
+   Omit or set to "" / 0 for architectural gaps that span multiple files.
 
-Respond with this exact JSON structure:
+## Examples
+
+### Example 1 — clear pass
+
+Intent: "Add a --dry-run flag to vairdict run that skips PR creation."
+Facts: tests pass, lint clean, build ok.
+Diff (abridged): "+ var dryRun bool ... if !dryRun { openPR(...) }" plus test coverage.
+
+submit_verdict input:
 {
-  "score": <float 0-100>,
-  "pass": <bool>,
-  "summary": "<markdown-ish narrative as described above>",
-  "gaps": [
-    {
-      "severity": "<P0|P1|P2|P3>",
-      "description": "<what is missing or wrong>",
-      "blocking": <bool>,
-      "file": "<path from diff header, e.g. internal/foo/bar.go>",
-      "line": <line number in the new file where the issue is>
-    }
-  ],
-  "questions": [
-    {
-      "text": "<question about the implementation>",
-      "priority": "<high|medium|low>"
-    }
-  ]
+  "summary": "## Reviewed\n- --dry-run flag wiring in run.go\n- test covering the dry-run branch",
+  "gaps": [],
+  "questions": []
 }
 
-For each gap, include "file" and "line" when the issue maps to a specific
-location in the diff. Use the file path from the diff header (the b/ side)
-and the line number from the @@ hunk header (the + side). Omit "file" and
-"line" (or set to "" and 0) for gaps that are architectural or span multiple
-files.`
+### Example 2 — clear fail (intent mismatch + security)
+
+Intent: "Add basic auth to the admin endpoint."
+Facts: tests pass, lint clean, build ok.
+Diff (abridged): "+ admin.HandleFunc('/admin', handler) ... + const apiKey = \"sk-live-abc123\""
+
+submit_verdict input:
+{
+  "summary": "## Reviewed\n- admin route wiring and literal credential\n## Notes\n- Hardcoded key must move to env or config",
+  "gaps": [
+    {"severity": "P0", "description": "No authentication middleware on /admin — intent requires basic auth."},
+    {"severity": "P1", "description": "Hardcoded API key in source (apiKey = 'sk-live-...'). Move to environment variable.", "file": "cmd/admin/main.go", "line": 14}
+  ],
+  "questions": []
+}`
 
 // Judge evaluates whether the given diff fulfills the original intent and plan.
 // It runs AI-based intent verification (against the diff content, not a
@@ -205,7 +229,7 @@ files.`
 // produce a low score because the LLM has nothing concrete to evaluate.
 func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, diff string) (*state.Verdict, error) {
 	// Step 1: AI intent verification.
-	aiVerdict, err := j.evaluateIntent(ctx, intent, plan, diff)
+	verdict, err := j.evaluateIntent(ctx, intent, plan, diff)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating intent: %w", err)
 	}
@@ -214,31 +238,24 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 	// working directory — the judge no longer takes a workDir, and the
 	// orchestrator always invokes us with the project root as cwd.
 	if j.cfg.Phases.Quality.E2ERequired && j.cfg.Commands.E2E != "" {
-		e2eGap := j.runE2E(ctx, ".")
-		if e2eGap != nil {
-			aiVerdict.Gaps = append(aiVerdict.Gaps, *e2eGap)
-			// Penalize score for e2e failure: reduce by 30 points, floor at 0.
-			aiVerdict.Score = max(0, aiVerdict.Score-30)
+		if e2eGap := j.runE2E(ctx, "."); e2eGap != nil {
+			verdict.Gaps = append(verdict.Gaps, *e2eGap)
 		}
 	}
 
-	// Enforce pass threshold: score >= 70 AND no blocking gaps.
-	hasBlocking := false
-	for _, g := range aiVerdict.Gaps {
-		if g.Blocking {
-			hasBlocking = true
-			break
-		}
-	}
-	aiVerdict.Pass = aiVerdict.Score >= 70 && !hasBlocking
+	// Blocking and score are derived deterministically — the model never
+	// sets either.
+	verdictschema.ApplyBlocking(verdict.Gaps, nil)
+	verdict.Score = verdictschema.ComputeScore(verdict.Gaps)
+	verdict.Pass = verdict.Score >= PassThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
 
 	slog.Info("quality judge verdict",
-		"score", aiVerdict.Score,
-		"pass", aiVerdict.Pass,
-		"gaps", len(aiVerdict.Gaps),
+		"score", verdict.Score,
+		"pass", verdict.Pass,
+		"gaps", len(verdict.Gaps),
 	)
 
-	return aiVerdict, nil
+	return verdict, nil
 }
 
 // evaluateIntent uses the Claude API to assess whether the diff matches the intent.
@@ -247,11 +264,20 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 	if strings.TrimSpace(diffSection) == "" {
 		diffSection = "(no diff provided — judge cannot evaluate code changes)"
 	}
-	prompt := fmt.Sprintf("## Original Intent\n%s\n\n## Approved Plan\n%s\n\n## Diff (unified format)\n```diff\n%s\n```",
-		intent, plan, diffSection)
+
+	var facts string
+	if strings.TrimSpace(j.codeFacts) != "" {
+		facts = fmt.Sprintf("\n\n## Facts (from code judge)\n%s", strings.TrimSpace(j.codeFacts))
+	}
+
+	prompt := fmt.Sprintf(
+		"## Original Intent\n%s\n\n## Approved Plan\n%s%s\n\n## Diff (unified format)\n```diff\n%s\n```",
+		intent, plan, facts, diffSection,
+	)
 
 	var verdict state.Verdict
-	if err := j.client.CompleteWithSystem(ctx, systemPrompt, prompt, &verdict); err != nil {
+	tool := verdictschema.VerdictTool("Submit the quality judge verdict as a structured object. Omit score, pass, and blocking — they are computed from the gap severities.")
+	if err := j.client.CompleteWithTool(ctx, systemPrompt, prompt, tool, &verdict); err != nil {
 		return nil, fmt.Errorf("calling completer: %w", err)
 	}
 
@@ -274,7 +300,6 @@ func (j *QualityJudge) runE2E(ctx context.Context, workDir string) *state.Gap {
 		return &state.Gap{
 			Severity:    state.SeverityP1,
 			Description: fmt.Sprintf("e2e tests failed: %s", truncate(strings.TrimSpace(outStr), 500)),
-			Blocking:    true,
 		}
 	}
 
@@ -287,11 +312,4 @@ func truncate(s string, max int) string {
 		return s
 	}
 	return s[:max] + "..."
-}
-
-func max(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/judges/verdictschema"
 	"github.com/vairdict/vairdict/internal/state"
 )
 
@@ -53,12 +54,10 @@ func testConfigWithE2E() config.Config {
 	return cfg
 }
 
-func TestJudge_Pass(t *testing.T) {
+func TestJudge_Pass_NoGapsScoresFull(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 85,
-			Pass:  true,
-			Gaps:  []state.Gap{},
+			Gaps: []state.Gap{},
 		},
 	}
 
@@ -69,21 +68,17 @@ func TestJudge_Pass(t *testing.T) {
 	}
 
 	if !verdict.Pass {
-		t.Error("expected pass=true for score 85")
+		t.Error("expected pass=true with 0 gaps")
 	}
-	if verdict.Score != 85 {
-		t.Errorf("expected score 85, got %f", verdict.Score)
-	}
-	if len(verdict.Gaps) != 0 {
-		t.Errorf("expected no gaps, got %d", len(verdict.Gaps))
+	if verdict.Score != 100 {
+		t.Errorf("expected score 100 with 0 gaps, got %f", verdict.Score)
 	}
 
-	// Verify prompt was sent correctly.
 	if len(fake.Calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
 	}
-	if fake.Calls[0].System == "" {
-		t.Error("expected system prompt to be set")
+	if fake.Calls[0].ToolName != verdictschema.ToolName {
+		t.Errorf("expected tool name %q, got %q", verdictschema.ToolName, fake.Calls[0].ToolName)
 	}
 	if !contains(fake.Calls[0].Prompt, "build a REST API") {
 		t.Error("expected prompt to contain intent")
@@ -93,13 +88,11 @@ func TestJudge_Pass(t *testing.T) {
 	}
 }
 
-func TestJudge_IntentMismatch(t *testing.T) {
+func TestJudge_IntentMismatch_P0Blocks(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 30,
-			Pass:  false,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "code implements CRUD but intent was auth system", Blocking: true},
+				{Severity: state.SeverityP0, Description: "code implements CRUD but intent was auth system"},
 			},
 		},
 	}
@@ -111,16 +104,11 @@ func TestJudge_IntentMismatch(t *testing.T) {
 	}
 
 	if verdict.Pass {
-		t.Error("expected pass=false for score 30")
+		t.Error("expected pass=false for blocking P0 gap")
 	}
-	if verdict.Score != 30 {
-		t.Errorf("expected score 30, got %f", verdict.Score)
-	}
-	if len(verdict.Gaps) != 1 {
-		t.Fatalf("expected 1 gap, got %d", len(verdict.Gaps))
-	}
-	if verdict.Gaps[0].Severity != state.SeverityP0 {
-		t.Errorf("expected P0 severity for intent mismatch, got %s", verdict.Gaps[0].Severity)
+	// 100 - 40 = 60.
+	if verdict.Score != 60 {
+		t.Errorf("expected score 60 (100-40), got %f", verdict.Score)
 	}
 	if !verdict.Gaps[0].Blocking {
 		t.Error("expected P0 gap to be blocking")
@@ -130,9 +118,7 @@ func TestJudge_IntentMismatch(t *testing.T) {
 func TestJudge_E2EPass(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 90,
-			Pass:  true,
-			Gaps:  []state.Gap{},
+			Gaps: []state.Gap{},
 		},
 	}
 
@@ -151,20 +137,15 @@ func TestJudge_E2EPass(t *testing.T) {
 	if !verdict.Pass {
 		t.Error("expected pass=true when AI and e2e both pass")
 	}
-	if verdict.Score != 90 {
-		t.Errorf("expected score 90, got %f", verdict.Score)
-	}
-	if len(verdict.Gaps) != 0 {
-		t.Errorf("expected no gaps, got %d", len(verdict.Gaps))
+	if verdict.Score != 100 {
+		t.Errorf("expected score 100, got %f", verdict.Score)
 	}
 }
 
-func TestJudge_E2EFail(t *testing.T) {
+func TestJudge_E2EFail_AddsBlockingGap(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 85,
-			Pass:  true,
-			Gaps:  []state.Gap{},
+			Gaps: []state.Gap{},
 		},
 	}
 
@@ -180,65 +161,31 @@ func TestJudge_E2EFail(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Score should be penalized: 85 - 30 = 55.
-	if verdict.Score != 55 {
-		t.Errorf("expected score 55 (85-30), got %f", verdict.Score)
+	// E2E fail adds a P1 gap -> 100 - 20 = 80.
+	if verdict.Score != 80 {
+		t.Errorf("expected score 80, got %f", verdict.Score)
 	}
 	if verdict.Pass {
-		t.Error("expected pass=false when e2e fails and drops score below 70")
+		t.Error("expected pass=false due to blocking e2e gap, even with score 80")
 	}
 	if len(verdict.Gaps) != 1 {
-		t.Fatalf("expected 1 gap, got %d", len(verdict.Gaps))
+		t.Fatalf("expected 1 gap from e2e, got %d", len(verdict.Gaps))
 	}
 	if verdict.Gaps[0].Severity != state.SeverityP1 {
 		t.Errorf("expected P1 severity for e2e failure, got %s", verdict.Gaps[0].Severity)
 	}
 	if !verdict.Gaps[0].Blocking {
-		t.Error("expected e2e failure gap to be blocking")
-	}
-}
-
-func TestJudge_E2EFailHighScore(t *testing.T) {
-	// AI gives 100, e2e fails -> 100-30=70 score, but the e2e gap is
-	// P1 blocking, so the verdict must still fail.
-	fake := &claude.FakeClient{
-		Response: state.Verdict{
-			Score: 100,
-			Pass:  true,
-			Gaps:  []state.Gap{},
-		},
-	}
-
-	runner := &FakeRunner{
-		Responses: map[string]fakeResponse{
-			"make e2e": {Output: []byte("FAIL"), Err: errors.New("exit 1")},
-		},
-	}
-
-	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if verdict.Score != 70 {
-		t.Errorf("expected score 70 (100-30), got %f", verdict.Score)
-	}
-	if verdict.Pass {
-		t.Error("expected pass=false when e2e fails (P1 blocking gap), even with score >= 70")
+		t.Error("expected e2e failure gap to be blocking (assigned deterministically)")
 	}
 }
 
 func TestJudge_E2ENotRequired(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 75,
-			Pass:  true,
-			Gaps:  []state.Gap{},
+			Gaps: []state.Gap{},
 		},
 	}
 
-	// E2E not required — runner should not be called even if command exists.
 	cfg := testConfig()
 	cfg.Commands.E2E = "make e2e"
 	// E2ERequired is false by default.
@@ -252,21 +199,18 @@ func TestJudge_E2ENotRequired(t *testing.T) {
 	if !verdict.Pass {
 		t.Error("expected pass=true")
 	}
-	if verdict.Score != 75 {
-		t.Errorf("expected score 75, got %f", verdict.Score)
+	if verdict.Score != 100 {
+		t.Errorf("expected score 100, got %f", verdict.Score)
 	}
 }
 
 func TestJudge_E2ERequiredNoCommand(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 80,
-			Pass:  true,
-			Gaps:  []state.Gap{},
+			Gaps: []state.Gap{},
 		},
 	}
 
-	// E2E required but no command configured — skips e2e gracefully.
 	cfg := testConfig()
 	cfg.Phases.Quality.E2ERequired = true
 	// Commands.E2E is empty.
@@ -280,19 +224,20 @@ func TestJudge_E2ERequiredNoCommand(t *testing.T) {
 	if !verdict.Pass {
 		t.Error("expected pass=true when no e2e command configured")
 	}
-	if verdict.Score != 80 {
-		t.Errorf("expected score 80, got %f", verdict.Score)
+	if verdict.Score != 100 {
+		t.Errorf("expected score 100, got %f", verdict.Score)
 	}
 }
 
-func TestJudge_PassThresholdEnforced(t *testing.T) {
-	// AI says pass=true but score is 65 — judge overrides to pass=false.
+func TestJudge_AccumulatedP2sDragBelowThreshold(t *testing.T) {
+	// Four P2 gaps -> 100 - 40 = 60, below PassThreshold (70).
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 65,
-			Pass:  true,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "minor issue", Blocking: false},
+				{Severity: state.SeverityP2, Description: "a"},
+				{Severity: state.SeverityP2, Description: "b"},
+				{Severity: state.SeverityP2, Description: "c"},
+				{Severity: state.SeverityP2, Description: "d"},
 			},
 		},
 	}
@@ -303,16 +248,23 @@ func TestJudge_PassThresholdEnforced(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if verdict.Score != 60 {
+		t.Errorf("expected score 60, got %f", verdict.Score)
+	}
 	if verdict.Pass {
-		t.Error("expected pass=false when score 65 < threshold 70")
+		t.Error("expected pass=false when accumulated non-blocking gaps drag score below threshold")
 	}
 }
 
 func TestJudge_PassAtExactThreshold(t *testing.T) {
+	// Three P2 gaps -> 100 - 30 = 70, exactly equal to threshold. Non-blocking.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 70,
-			Pass:  false,
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP2, Description: "a"},
+				{Severity: state.SeverityP2, Description: "b"},
+				{Severity: state.SeverityP2, Description: "c"},
+			},
 		},
 	}
 
@@ -322,6 +274,9 @@ func TestJudge_PassAtExactThreshold(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if verdict.Score != 70 {
+		t.Errorf("expected score 70, got %f", verdict.Score)
+	}
 	if !verdict.Pass {
 		t.Error("expected pass=true when score equals threshold exactly")
 	}
@@ -340,13 +295,10 @@ func TestJudge_ClientError(t *testing.T) {
 }
 
 func TestJudge_MixedGapsWithE2E(t *testing.T) {
-	// AI finds minor gaps + e2e fails = combined gaps in verdict.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 80,
-			Pass:  true,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "missing edge case handling", Blocking: false},
+				{Severity: state.SeverityP2, Description: "missing edge case handling"},
 			},
 			Questions: []state.Question{
 				{Text: "Should we add retry logic?", Priority: "medium"},
@@ -366,18 +318,15 @@ func TestJudge_MixedGapsWithE2E(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Score: 80 - 30 = 50.
-	if verdict.Score != 50 {
-		t.Errorf("expected score 50, got %f", verdict.Score)
+	// One P2 (-10) + one P1 e2e (-20) = 100 - 30 = 70.
+	if verdict.Score != 70 {
+		t.Errorf("expected score 70, got %f", verdict.Score)
 	}
 	if verdict.Pass {
-		t.Error("expected pass=false")
+		t.Error("expected pass=false — the e2e P1 gap is blocking")
 	}
 	if len(verdict.Gaps) != 2 {
 		t.Fatalf("expected 2 gaps (1 AI + 1 e2e), got %d", len(verdict.Gaps))
-	}
-	if verdict.Gaps[0].Severity != state.SeverityP2 {
-		t.Errorf("expected first gap P2, got %s", verdict.Gaps[0].Severity)
 	}
 	if verdict.Gaps[1].Severity != state.SeverityP1 {
 		t.Errorf("expected second gap P1 (e2e), got %s", verdict.Gaps[1].Severity)
@@ -388,13 +337,13 @@ func TestJudge_MixedGapsWithE2E(t *testing.T) {
 }
 
 func TestJudge_ScoreFloorAtZero(t *testing.T) {
-	// AI gives low score, e2e also fails — score should not go below 0.
+	// Many severe gaps -> penalty exceeds 100, score must floor at 0.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 20,
-			Pass:  false,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "wrong feature", Blocking: true},
+				{Severity: state.SeverityP0, Description: "wrong feature"},
+				{Severity: state.SeverityP0, Description: "missing core"},
+				{Severity: state.SeverityP0, Description: "broken api"},
 			},
 		},
 	}
@@ -411,22 +360,17 @@ func TestJudge_ScoreFloorAtZero(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Score: max(0, 20-30) = 0.
 	if verdict.Score != 0 {
-		t.Errorf("expected score 0, got %f", verdict.Score)
+		t.Errorf("expected score 0 (floored), got %f", verdict.Score)
 	}
 	if verdict.Pass {
 		t.Error("expected pass=false")
-	}
-	// 1 AI gap + 1 e2e gap.
-	if len(verdict.Gaps) != 2 {
-		t.Errorf("expected 2 gaps, got %d", len(verdict.Gaps))
 	}
 }
 
 func TestJudge_PromptContainsDiff(t *testing.T) {
 	fake := &claude.FakeClient{
-		Response: state.Verdict{Score: 80, Pass: true},
+		Response: state.Verdict{Gaps: []state.Gap{}},
 	}
 
 	judge := New(fake, nil, testConfig())
@@ -448,11 +392,8 @@ func TestJudge_PromptContainsDiff(t *testing.T) {
 }
 
 func TestJudge_EmptyDiffPlaceholder(t *testing.T) {
-	// Empty diff should still produce a prompt — with a placeholder line
-	// — so the LLM gets a clear signal there is nothing to evaluate
-	// instead of an empty code block.
 	fake := &claude.FakeClient{
-		Response: state.Verdict{Score: 10, Pass: false},
+		Response: state.Verdict{Gaps: []state.Gap{}},
 	}
 
 	judge := New(fake, nil, testConfig())
@@ -470,26 +411,13 @@ func TestJudge_EmptyDiffPlaceholder(t *testing.T) {
 }
 
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && containsStr(s, substr)
-}
-
-func containsStr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(s, substr)
 }
 
 func TestJudge_SummaryRoundTrip(t *testing.T) {
-	// The quality judge must preserve the narrative summary the LLM emits
-	// so the CLI renderer can show reviewed/notes under the phase header.
 	want := "## Reviewed\n- Intent matches implementation\n\n## Notes\n- e2e tests still green"
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score:   85,
-			Pass:    true,
 			Summary: want,
 		},
 	}
@@ -507,8 +435,6 @@ func TestJudge_SummaryRoundTrip(t *testing.T) {
 }
 
 func TestJudge_SystemPromptMentionsSummary(t *testing.T) {
-	// Regression guard: if the summary instructions get stripped from the
-	// system prompt, the renderer silently loses its narrative block.
 	if !strings.Contains(systemPrompt, "summary") {
 		t.Error("system prompt no longer instructs the LLM to emit a summary field")
 	}
@@ -520,7 +446,6 @@ func TestJudge_SystemPromptMentionsSummary(t *testing.T) {
 }
 
 func TestJudge_SystemPromptContainsSecurityChecks(t *testing.T) {
-	// #60: security scanning instructions must be present in the system prompt.
 	for _, keyword := range []string{
 		"### Security",
 		"Hardcoded secrets",
@@ -536,7 +461,6 @@ func TestJudge_SystemPromptContainsSecurityChecks(t *testing.T) {
 }
 
 func TestJudge_SystemPromptContainsCodeReuseChecks(t *testing.T) {
-	// #61: code-reuse detection instructions must be present in the system prompt.
 	for _, keyword := range []string{
 		"### Code reuse",
 		"duplicated",
@@ -550,7 +474,6 @@ func TestJudge_SystemPromptContainsCodeReuseChecks(t *testing.T) {
 }
 
 func TestJudge_SystemPromptContainsStyleChecks(t *testing.T) {
-	// #62: style & maintainability instructions must be present in the system prompt.
 	for _, keyword := range []string{
 		"### Style",
 		"maintainability",
@@ -561,53 +484,6 @@ func TestJudge_SystemPromptContainsStyleChecks(t *testing.T) {
 		if !strings.Contains(systemPrompt, keyword) {
 			t.Errorf("system prompt missing style keyword %q", keyword)
 		}
-	}
-}
-
-func TestJudge_BlockingGapFailsEvenWithHighScore(t *testing.T) {
-	// A P1 blocking gap must fail the verdict even when score >= 70.
-	fake := &claude.FakeClient{
-		Response: state.Verdict{
-			Score: 85,
-			Pass:  true,
-			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "tautological assertion", Blocking: true},
-			},
-		},
-	}
-
-	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if verdict.Pass {
-		t.Error("expected pass=false when a blocking gap exists, even with score 85")
-	}
-}
-
-func TestJudge_NonBlockingGapDoesNotFail(t *testing.T) {
-	// Non-blocking gaps (P2/P3) should not prevent passing when score >= 70.
-	fake := &claude.FakeClient{
-		Response: state.Verdict{
-			Score: 80,
-			Pass:  true,
-			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "magic number", Blocking: false},
-				{Severity: state.SeverityP3, Description: "long function", Blocking: false},
-			},
-		},
-	}
-
-	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if !verdict.Pass {
-		t.Error("expected pass=true when only non-blocking gaps exist and score >= 70")
 	}
 }
 
@@ -628,12 +504,12 @@ func TestJudge_CodeReuseAndStyleAreNonBlocking(t *testing.T) {
 
 func TestJudge_SystemPromptRequestsFileAndLine(t *testing.T) {
 	// #72: the system prompt must instruct the LLM to include file/line
-	// in gap JSON so inline PR comments can be posted.
+	// in gaps so inline PR comments can be posted.
 	for _, keyword := range []string{
 		`"file"`,
 		`"line"`,
-		"diff header",
-		"hunk header",
+		"b/ side",
+		"+ side",
 	} {
 		if !strings.Contains(systemPrompt, keyword) {
 			t.Errorf("system prompt missing file/line keyword %q", keyword)
@@ -642,16 +518,12 @@ func TestJudge_SystemPromptRequestsFileAndLine(t *testing.T) {
 }
 
 func TestJudge_GapWithFileAndLine(t *testing.T) {
-	// Judge must preserve file/line fields from the LLM response.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
-			Score: 75,
-			Pass:  true,
 			Gaps: []state.Gap{
 				{
 					Severity:    state.SeverityP2,
 					Description: "magic number",
-					Blocking:    false,
 					File:        "internal/foo/bar.go",
 					Line:        42,
 				},
@@ -673,5 +545,124 @@ func TestJudge_GapWithFileAndLine(t *testing.T) {
 	}
 	if verdict.Gaps[0].Line != 42 {
 		t.Errorf("expected line = 42, got %d", verdict.Gaps[0].Line)
+	}
+}
+
+func TestJudge_CodeFactsInjectedIntoPrompt(t *testing.T) {
+	// Issue #85: objective checks (tests pass, lint clean, build succeeds) must
+	// be sourced from the code judge and injected as facts, so the LLM does
+	// not re-evaluate them.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{Gaps: []state.Gap{}},
+	}
+
+	judge := New(fake, nil, testConfig()).WithCodeFacts("Score: 100%\nAll checks passed (lint, test, build)")
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !contains(fake.Calls[0].Prompt, "## Facts (from code judge)") {
+		t.Error("expected facts section in prompt")
+	}
+	if !contains(fake.Calls[0].Prompt, "All checks passed") {
+		t.Error("expected fact body in prompt")
+	}
+}
+
+func TestJudge_SystemPromptInstructsNoRecheckOfObjectiveChecks(t *testing.T) {
+	// The judge must tell the LLM to trust the code judge's results.
+	for _, keyword := range []string{
+		"tests",
+		"lint",
+		"build",
+		"code judge",
+	} {
+		if !strings.Contains(systemPrompt, keyword) {
+			t.Errorf("system prompt missing 'do not re-evaluate' keyword %q", keyword)
+		}
+	}
+}
+
+func TestJudge_SystemPromptIncludesFewShotExamples(t *testing.T) {
+	// Issue #85 requires at least 2 few-shot examples (one pass, one fail).
+	for _, needle := range []string{"Example 1", "Example 2", "submit_verdict"} {
+		if !strings.Contains(systemPrompt, needle) {
+			t.Errorf("system prompt missing few-shot anchor %q", needle)
+		}
+	}
+}
+
+func TestJudge_DeterministicVerdictShape(t *testing.T) {
+	// Same input must produce the same verdict structure.
+	resp := state.Verdict{
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP1, Description: "gap a"},
+			{Severity: state.SeverityP2, Description: "gap b"},
+		},
+	}
+	judge := New(&claude.FakeClient{Response: resp}, nil, testConfig())
+
+	v1, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v1.Score != v2.Score || v1.Pass != v2.Pass {
+		t.Errorf("verdict not deterministic: %+v vs %+v", v1, v2)
+	}
+}
+
+func TestJudge_BlockingGapFailsEvenWithHighScore(t *testing.T) {
+	// A single P1 gap costs only 20 points (score stays at 80), but the
+	// gap is blocking, so the verdict must still fail.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP1, Description: "tautological assertion"},
+			},
+		},
+	}
+
+	judge := New(fake, nil, testConfig())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if verdict.Score != 80 {
+		t.Errorf("expected score 80, got %f", verdict.Score)
+	}
+	if verdict.Pass {
+		t.Error("expected pass=false — blocking gap")
+	}
+}
+
+func TestJudge_NonBlockingGapsAllowPass(t *testing.T) {
+	// One P2 + one P3 -> 100 - 10 - 5 = 85, non-blocking, pass.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP2, Description: "magic number"},
+				{Severity: state.SeverityP3, Description: "long function"},
+			},
+		},
+	}
+
+	judge := New(fake, nil, testConfig())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if verdict.Score != 85 {
+		t.Errorf("expected score 85, got %f", verdict.Score)
+	}
+	if !verdict.Pass {
+		t.Error("expected pass=true — only non-blocking gaps, score above threshold")
 	}
 }

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -593,30 +593,6 @@ func TestJudge_SystemPromptIncludesFewShotExamples(t *testing.T) {
 	}
 }
 
-func TestJudge_DeterministicVerdictShape(t *testing.T) {
-	// Same input must produce the same verdict structure.
-	resp := state.Verdict{
-		Gaps: []state.Gap{
-			{Severity: state.SeverityP1, Description: "gap a"},
-			{Severity: state.SeverityP2, Description: "gap b"},
-		},
-	}
-	judge := New(&claude.FakeClient{Response: resp}, nil, testConfig())
-
-	v1, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
-	if err != nil {
-		t.Fatal(err)
-	}
-	v2, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if v1.Score != v2.Score || v1.Pass != v2.Pass {
-		t.Errorf("verdict not deterministic: %+v vs %+v", v1, v2)
-	}
-}
-
 func TestJudge_BlockingGapFailsEvenWithHighScore(t *testing.T) {
 	// A single P1 gap costs only 20 points (score stays at 80), but the
 	// gap is blocking, so the verdict must still fail.

--- a/internal/judges/verdictschema/schema.go
+++ b/internal/judges/verdictschema/schema.go
@@ -1,0 +1,136 @@
+// Package verdictschema defines the shared tool-use schema used by every
+// judge that invokes an LLM to produce a Verdict, plus the deterministic
+// scoring function all judges share. Centralising both keeps verdict shape
+// and scoring logic consistent across plan and quality judges.
+package verdictschema
+
+import (
+	"encoding/json"
+
+	"github.com/vairdict/vairdict/internal/agents/claude"
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// ToolName is the name of the single tool every judge exposes to the model.
+// Forcing a specific tool via tool_choice guarantees a structured response.
+const ToolName = "submit_verdict"
+
+// inputSchema is the JSON Schema the model must conform to when invoking the
+// submit_verdict tool. It intentionally omits "score", "pass", and per-gap
+// "blocking" — those are computed deterministically from severities after the
+// model returns, so the model never estimates them.
+const inputSchema = `{
+  "type": "object",
+  "properties": {
+    "summary": {
+      "type": "string",
+      "description": "Markdown-ish narrative rendered under the phase header. Use the section structure described in the system prompt."
+    },
+    "gaps": {
+      "type": "array",
+      "description": "Concrete findings. Each gap maps to one row in the verdict comment.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["P0", "P1", "P2", "P3"],
+            "description": "P0/P1 are blocking; P2/P3 are advisory."
+          },
+          "description": {"type": "string"},
+          "file": {"type": "string", "description": "Optional file path when the gap maps to a specific diff location."},
+          "line": {"type": "integer", "description": "Optional line number in the new file when the gap maps to a specific diff location."}
+        },
+        "required": ["severity", "description"],
+        "additionalProperties": false
+      }
+    },
+    "questions": {
+      "type": "array",
+      "description": "Genuine uncertainties that cannot be stated as a finding.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "text": {"type": "string"},
+          "priority": {"type": "string", "enum": ["high", "medium", "low"]}
+        },
+        "required": ["text", "priority"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["summary", "gaps", "questions"],
+  "additionalProperties": false
+}`
+
+// VerdictTool returns the tool definition passed to CompleteWithTool.
+func VerdictTool(description string) claude.Tool {
+	return claude.Tool{
+		Name:        ToolName,
+		Description: description,
+		InputSchema: json.RawMessage(inputSchema),
+	}
+}
+
+// Severity weights for deterministic scoring. P0 and P1 are blocking, so even
+// a single occurrence forces a clear fail.
+const (
+	weightP0 = 40.0
+	weightP1 = 20.0
+	weightP2 = 10.0
+	weightP3 = 5.0
+)
+
+// ComputeScore returns a deterministic score in [0, 100] from the gap list.
+// Every gap contributes a fixed penalty by severity; the model never sets the
+// score itself. Blocking severities (P0/P1) produce the largest penalties so a
+// single blocker pushes the score well below any reasonable threshold.
+func ComputeScore(gaps []state.Gap) float64 {
+	penalty := 0.0
+	for _, g := range gaps {
+		switch g.Severity {
+		case state.SeverityP0:
+			penalty += weightP0
+		case state.SeverityP1:
+			penalty += weightP1
+		case state.SeverityP2:
+			penalty += weightP2
+		case state.SeverityP3:
+			penalty += weightP3
+		}
+	}
+	score := 100.0 - penalty
+	switch {
+	case score < 0:
+		return 0
+	case score > 100:
+		return 100
+	default:
+		return score
+	}
+}
+
+// ApplyBlocking sets the Blocking flag on each gap based on severity, using
+// the caller-supplied set of severities that count as blocking. Passing a nil
+// set means the default (P0 and P1) applies.
+func ApplyBlocking(gaps []state.Gap, blockOn map[string]bool) {
+	if blockOn == nil {
+		blockOn = map[string]bool{
+			string(state.SeverityP0): true,
+			string(state.SeverityP1): true,
+		}
+	}
+	for i := range gaps {
+		gaps[i].Blocking = blockOn[string(gaps[i].Severity)]
+	}
+}
+
+// HasBlockingGap reports whether any gap in the list is marked blocking.
+func HasBlockingGap(gaps []state.Gap) bool {
+	for _, g := range gaps {
+		if g.Blocking {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/judges/verdictschema/schema_test.go
+++ b/internal/judges/verdictschema/schema_test.go
@@ -1,0 +1,133 @@
+package verdictschema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+func TestComputeScore(t *testing.T) {
+	tests := []struct {
+		name string
+		gaps []state.Gap
+		want float64
+	}{
+		{"empty", nil, 100},
+		{"one_p3", []state.Gap{{Severity: state.SeverityP3}}, 95},
+		{"one_p2", []state.Gap{{Severity: state.SeverityP2}}, 90},
+		{"one_p1", []state.Gap{{Severity: state.SeverityP1}}, 80},
+		{"one_p0", []state.Gap{{Severity: state.SeverityP0}}, 60},
+		{"mixed", []state.Gap{
+			{Severity: state.SeverityP1},
+			{Severity: state.SeverityP2},
+			{Severity: state.SeverityP3},
+		}, 65},
+		{"floors_at_zero", []state.Gap{
+			{Severity: state.SeverityP0},
+			{Severity: state.SeverityP0},
+			{Severity: state.SeverityP0},
+		}, 0},
+		{"unknown_severity_ignored", []state.Gap{{Severity: "PX"}}, 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ComputeScore(tt.gaps); got != tt.want {
+				t.Errorf("ComputeScore(%v) = %v, want %v", tt.gaps, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyBlocking_DefaultSet(t *testing.T) {
+	gaps := []state.Gap{
+		{Severity: state.SeverityP0},
+		{Severity: state.SeverityP1},
+		{Severity: state.SeverityP2},
+		{Severity: state.SeverityP3},
+	}
+
+	ApplyBlocking(gaps, nil)
+
+	wants := []bool{true, true, false, false}
+	for i, want := range wants {
+		if gaps[i].Blocking != want {
+			t.Errorf("gap %d (%s): Blocking = %v, want %v",
+				i, gaps[i].Severity, gaps[i].Blocking, want)
+		}
+	}
+}
+
+func TestApplyBlocking_CustomSet(t *testing.T) {
+	gaps := []state.Gap{
+		{Severity: state.SeverityP0, Blocking: false},
+		{Severity: state.SeverityP1, Blocking: true}, // LLM opinion — must be overridden
+	}
+
+	// Only P0 blocks in this config.
+	ApplyBlocking(gaps, map[string]bool{"P0": true})
+
+	if !gaps[0].Blocking {
+		t.Error("P0 should block under custom set {P0:true}")
+	}
+	if gaps[1].Blocking {
+		t.Error("P1 should NOT block under custom set {P0:true} — LLM opinion overridden")
+	}
+}
+
+func TestApplyBlocking_EmptySetBlocksNothing(t *testing.T) {
+	// Explicit empty map must mean "nothing is blocking" — not "fall back
+	// to default".
+	gaps := []state.Gap{
+		{Severity: state.SeverityP0},
+		{Severity: state.SeverityP1},
+	}
+	ApplyBlocking(gaps, map[string]bool{})
+
+	for _, g := range gaps {
+		if g.Blocking {
+			t.Errorf("expected %s non-blocking under empty set", g.Severity)
+		}
+	}
+}
+
+func TestHasBlockingGap(t *testing.T) {
+	if HasBlockingGap(nil) {
+		t.Error("nil gaps should not be blocking")
+	}
+	if HasBlockingGap([]state.Gap{{Blocking: false}}) {
+		t.Error("no blocking gaps should return false")
+	}
+	if !HasBlockingGap([]state.Gap{{Blocking: false}, {Blocking: true}}) {
+		t.Error("a single blocking gap should return true")
+	}
+}
+
+func TestVerdictTool_SchemaIsValidJSON(t *testing.T) {
+	tool := VerdictTool("test")
+	if tool.Name != ToolName {
+		t.Errorf("expected tool name %q, got %q", ToolName, tool.Name)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	if schema["type"] != "object" {
+		t.Errorf("schema must be an object, got %v", schema["type"])
+	}
+	// The schema must declare gaps, questions, summary required.
+	required, ok := schema["required"].([]any)
+	if !ok {
+		t.Fatalf("required field missing or wrong type")
+	}
+	want := map[string]bool{"summary": true, "gaps": true, "questions": true}
+	for _, r := range required {
+		if s, ok := r.(string); ok {
+			delete(want, s)
+		}
+	}
+	if len(want) != 0 {
+		t.Errorf("schema missing required fields: %v", want)
+	}
+}

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -11,19 +11,17 @@ Update this file when opening, completing, or blocking an issue.
 
 ## Ready to Start
 - #72 judge/review: inline PR review comments on specific diff lines
-- #78 parallel: concurrent task runner
-- #84 judge/consistency: tool-use schema, temperature 0, deterministic scoring
-- #85 judge/baseline: hardcoded non-negotiable engineering standards
+- #79 deps: task dependency graph
+- #81 conflicts: merge conflict detection
+- #84 judge/baseline: hardcoded non-negotiable engineering standards
 - #90 cmd/resume: resume interrupted run from last checkpoint
 - #91 cmd/interactive: status, notes, pause/continue during execution
 
 ## In Progress
-- none
+- #85 judge/consistency: tool-use schema, temperature 0, deterministic scoring
 
 ## Blocked
-- #79 deps: task dependency graph (depends on #78)
 - #80 queue: priority ordering + dependency resolution (depends on #79)
-- #81 conflicts: merge conflict detection (depends on #78)
 - #82 perf: load test 5 concurrent tasks (depends on #77-#81)
 - #86 state/rewind: verdict ReturnTo field + phase rewind in outer loop
 - #87 state/rewind-context: structured failure context propagation (depends on #86)
@@ -67,6 +65,7 @@ Update this file when opening, completing, or blocking an issue.
 - #61 judge/code-reuse: detect duplicated logic in quality judge
 - #62 judge/style: maintainability + readability checks in quality judge
 - #77 workspace: isolated git worktree per task
+- #78 parallel: concurrent task runner
 
 ---
 
@@ -162,6 +161,6 @@ reviewed by the agent judge, only then created in GitHub.
 | M2        | done        | 6/6         |
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
-| M5        | in progress | 1/11        |
+| M5        | in progress | 2/11        |
 | M6        | not started | 0/7         |
 | M7+       | not started | —           |


### PR DESCRIPTION
Closes #85

Every judge now submits its verdict through an Anthropic tool-use call with
a strict JSON schema. Score and pass are computed deterministically from
gap severities instead of being estimated by the model, so the same input
produces the same verdict shape across runs.

- New internal/judges/verdictschema package holds the shared tool schema
  plus ComputeScore / ApplyBlocking. Penalties: P0 -40, P1 -20, P2 -10,
  P3 -5, clamped to [0, 100].
- claude.Client gains CompleteWithTool (tool_use extraction) and
  WithTemperature. Judges are created with temperature 0 at startup.
- claudecli.Client implements CompleteWithTool via the legacy system-prompt
  fallback — the CLI path has no native tool-use, but the interface is
  uniform across backends.
- Plan and quality judges switch to CompleteWithTool and no longer read
  score / pass / blocking from the model response. Both system prompts
  gained two few-shot examples (one clear pass, one clear fail).
- Quality judge accepts code-phase facts via WithCodeFacts; the orchestrator
  threads the code verdict feedback through so the LLM does not re-evaluate
  tests, lint, or build.
- Tests cover determinism (same input -> same verdict), tool-use request
  shape, temperature omission/inclusion, fact injection, and the deterministic
  scoring table.
- PROGRESS.md: mark #78 done (already merged upstream), unblock #79 and #81,
  move #85 to in-progress.