### PR TITLE
feat(judge): thread diff through run path for inline PR review comments (#72)

### DIFF
--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -151,7 +151,7 @@ type qualityRunner interface {
 type ghOrchestrator interface {
 	CreateBranch(ctx context.Context, taskID, intent string) (string, error)
 	CreatePR(ctx context.Context, opts github.CreatePROpts) (*github.PR, error)
-	PostVerdict(ctx context.Context, prNumber int, v *state.Verdict, phase state.Phase, loop int) error
+	PostVerdictWithDiff(ctx context.Context, prNumber int, v *state.Verdict, phase state.Phase, loop int, diff string) error
 	MergePR(ctx context.Context, prNumber int) error
 }
 
@@ -591,7 +591,7 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 	if pr.Number > 0 {
 		lastVerdict := lastVerdictForPhase(task, state.PhaseQuality)
 		if lastVerdict != nil {
-			if err := deps.gh.PostVerdict(ctx, pr.Number, lastVerdict, state.PhaseQuality, qualityResult.Loops); err != nil {
+			if err := deps.gh.PostVerdictWithDiff(ctx, pr.Number, lastVerdict, state.PhaseQuality, qualityResult.Loops, qualityResult.Diff); err != nil {
 				// Log but don't fail the whole run for a comment posting failure.
 				slog.Warn("failed to post verdict comment", "error", err)
 			} else {

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -522,6 +522,7 @@ type fakeGHOrch struct {
 	prCalled      bool
 	verdictCalled bool
 	mergeCalled   bool
+	verdictDiff   string // captured diff argument
 }
 
 func (f *fakeGHOrch) CreateBranch(context.Context, string, string) (string, error) {
@@ -534,8 +535,9 @@ func (f *fakeGHOrch) CreatePR(context.Context, github.CreatePROpts) (*github.PR,
 	return f.pr, f.prErr
 }
 
-func (f *fakeGHOrch) PostVerdict(context.Context, int, *state.Verdict, state.Phase, int) error {
+func (f *fakeGHOrch) PostVerdictWithDiff(_ context.Context, _ int, _ *state.Verdict, _ state.Phase, _ int, diff string) error {
 	f.verdictCalled = true
+	f.verdictDiff = diff
 	return f.verdictErr
 }
 
@@ -567,7 +569,7 @@ func newOrchBundle() *orchBundle {
 			Pass: true, Loops: 1, LastScore: 100,
 		}},
 		quality: &fakeQualityRunner{result: &qualityphase.PhaseResult{
-			Pass: true, Loops: 1, LastScore: 95,
+			Pass: true, Loops: 1, LastScore: 95, Diff: "fake-diff",
 		}},
 		gh: &fakeGHOrch{
 			branchName: "vairdict/test-abc",
@@ -633,6 +635,11 @@ func TestRunOrchestration_HappyPath(t *testing.T) {
 	}
 	if !b.gh.verdictCalled {
 		t.Error("PostVerdict not called")
+	}
+	// #72: the quality phase's diff must be threaded through so inline
+	// review comments can be posted. Verify it reaches PostVerdictWithDiff.
+	if b.gh.verdictDiff != "fake-diff" {
+		t.Errorf("PostVerdictWithDiff got diff %q, want %q", b.gh.verdictDiff, "fake-diff")
 	}
 	if b.escalationCalled {
 		t.Error("escalation should not be called on happy path")

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -420,10 +420,24 @@ func (c *Client) PostVerdictWithDiff(ctx context.Context, prNumber int, verdict 
 	return nil
 }
 
-// postInlineReview creates a single GitHub review with inline comments
-// for gaps that have resolvable file:line positions. Best-effort — errors
-// are logged but do not block the summary verdict from being posted.
-func (c *Client) postInlineReview(ctx context.Context, prNumber int, verdict *state.Verdict, diff string) {
+// InlineReviewPayload is the JSON body sent to GitHub's
+// POST /repos/{owner}/{repo}/pulls/{n}/reviews endpoint. Kept as a named
+// type (instead of an anonymous struct inside postInlineReview) so unit
+// tests can assert its shape directly, and so operators reading slogs see
+// a meaningful type name.
+type InlineReviewPayload struct {
+	Event    string          `json:"event"`
+	Body     string          `json:"body"`
+	Comments []InlineComment `json:"comments"`
+}
+
+// BuildInlineReview turns a verdict + diff into a review payload whose
+// comments point only at lines present in the diff. Gaps without File/Line
+// and gaps whose line does not appear in the diff are dropped — they
+// still appear in the summary comment rendered by FormatVerdictComment.
+// Returns nil when no gap resolves to a diff position; callers should
+// skip the API call in that case.
+func BuildInlineReview(verdict *state.Verdict, diff string) *InlineReviewPayload {
 	positions := ParseDiffPositions(diff)
 
 	var comments []InlineComment
@@ -445,19 +459,23 @@ func (c *Client) postInlineReview(ctx context.Context, prNumber int, verdict *st
 	}
 
 	if len(comments) == 0 {
-		return
+		return nil
 	}
 
-	// Build the review payload. Use COMMENT event to batch all inline
-	// comments into a single review (avoids notification spam).
-	review := struct {
-		Event    string          `json:"event"`
-		Body     string          `json:"body"`
-		Comments []InlineComment `json:"comments"`
-	}{
+	return &InlineReviewPayload{
 		Event:    "COMMENT",
 		Body:     fmt.Sprintf("VAIrdict inline review: %d comment(s)", len(comments)),
 		Comments: comments,
+	}
+}
+
+// postInlineReview creates a single GitHub review with inline comments
+// for gaps that have resolvable file:line positions. Best-effort — errors
+// are logged but do not block the summary verdict from being posted.
+func (c *Client) postInlineReview(ctx context.Context, prNumber int, verdict *state.Verdict, diff string) {
+	review := BuildInlineReview(verdict, diff)
+	if review == nil {
+		return
 	}
 
 	payload, err := json.Marshal(review)
@@ -492,7 +510,7 @@ func (c *Client) postInlineReview(ctx context.Context, prNumber int, verdict *st
 		slog.Debug("failed to post inline review", "pr", prNumber, "error", err)
 		return
 	}
-	slog.Info("inline review posted", "pr", prNumber, "comments", len(comments))
+	slog.Info("inline review posted", "pr", prNumber, "comments", len(review.Comments))
 }
 
 // formatInlineComment builds the markdown body for a single inline comment.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -760,6 +760,111 @@ func TestPostVerdictWithDiff_EmptyDiffSkipsInline(t *testing.T) {
 	}
 }
 
+func TestBuildInlineReview_FiltersByResolvability(t *testing.T) {
+	// #72: only gaps with file+line resolvable to a diff position become
+	// inline comments. Gaps without file/line, or with file/line that
+	// don't map into the diff, are dropped from the review but still
+	// surface via FormatVerdictComment's summary table.
+	diff := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -10,3 +10,5 @@
+ ctx0
++added11
++added12
+ ctx1
+`
+	verdict := &state.Verdict{
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP1, Description: "in diff", Blocking: true, File: "foo.go", Line: 11},
+			{Severity: state.SeverityP2, Description: "no file info"},
+			{Severity: state.SeverityP3, Description: "line outside diff", File: "foo.go", Line: 999},
+			{Severity: state.SeverityP0, Description: "wrong file", File: "bar.go", Line: 11},
+		},
+	}
+
+	review := BuildInlineReview(verdict, diff)
+	if review == nil {
+		t.Fatal("expected review payload, got nil")
+	}
+	if review.Event != "COMMENT" {
+		t.Errorf("expected event=COMMENT (batched, no notification spam), got %q", review.Event)
+	}
+	if len(review.Comments) != 1 {
+		t.Fatalf("expected 1 inline comment, got %d", len(review.Comments))
+	}
+	only := review.Comments[0]
+	if only.Path != "foo.go" {
+		t.Errorf("expected path foo.go, got %q", only.Path)
+	}
+	if only.Position <= 0 {
+		t.Errorf("expected positive diff position, got %d", only.Position)
+	}
+	if !contains(only.Body, "in diff") {
+		t.Errorf("expected body to include gap description, got %q", only.Body)
+	}
+}
+
+func TestBuildInlineReview_NilWhenNoResolvableGap(t *testing.T) {
+	// If every gap is either location-less or out-of-diff, we return nil
+	// so the client skips the gh api call entirely.
+	diff := `diff --git a/x.go b/x.go
+--- a/x.go
++++ b/x.go
+@@ -1,3 +1,4 @@
+ a
++b
+ c
+`
+	verdict := &state.Verdict{
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP2, Description: "no location"},
+			{Severity: state.SeverityP3, Description: "out of diff", File: "x.go", Line: 99},
+		},
+	}
+
+	if review := BuildInlineReview(verdict, diff); review != nil {
+		t.Errorf("expected nil review when no gap resolves, got %+v", review)
+	}
+}
+
+func TestBuildInlineReview_MixedInlineAndSummary(t *testing.T) {
+	// A gap with a resolvable location produces an inline comment; a
+	// location-less gap alongside is dropped from the inline payload but
+	// still appears in the summary rendered by FormatVerdictComment. This
+	// test pins both halves to guard the "additive, not replacement" rule
+	// in the issue.
+	diff := `diff --git a/p.go b/p.go
+--- a/p.go
++++ b/p.go
+@@ -1,2 +1,3 @@
+ a
++b
+ c
+`
+	verdict := &state.Verdict{
+		Score: 60,
+		Pass:  false,
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP1, Description: "bad on added line", Blocking: true, File: "p.go", Line: 2},
+			{Severity: state.SeverityP2, Description: "architectural concern"},
+		},
+	}
+
+	review := BuildInlineReview(verdict, diff)
+	if review == nil || len(review.Comments) != 1 {
+		t.Fatalf("expected exactly 1 inline comment, got %+v", review)
+	}
+
+	summary := FormatVerdictComment(verdict, state.PhaseQuality, 1)
+	if !contains(summary, "bad on added line") {
+		t.Error("summary must still list the inline-eligible gap")
+	}
+	if !contains(summary, "architectural concern") {
+		t.Error("summary must list the location-less gap that has no inline counterpart")
+	}
+}
+
 func TestFormatInlineComment_Blocking(t *testing.T) {
 	g := state.Gap{Severity: state.SeverityP1, Description: "security issue", Blocking: true}
 	body := formatInlineComment(g)

--- a/internal/phases/quality/phase.go
+++ b/internal/phases/quality/phase.go
@@ -26,6 +26,10 @@ type PhaseResult struct {
 	Loops         int
 	LastScore     float64
 	Feedback      string
+	// Diff is the unified diff the judge evaluated. The orchestrator
+	// threads it through to PostVerdictWithDiff so gaps with file/line
+	// can be rendered as inline PR review comments (#72).
+	Diff string
 }
 
 // Judge is the interface for the quality judge. The real implementation lives
@@ -110,6 +114,7 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 				Loops:     loop + 1,
 				LastScore: lastScore,
 				Feedback:  buildQualityFeedback(verdict),
+				Diff:      p.diff,
 			}, nil
 		}
 
@@ -130,6 +135,7 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 				Loops:         loop + 1,
 				LastScore:     lastScore,
 				Feedback:      lastFeedback,
+				Diff:          p.diff,
 			}, nil
 		}
 
@@ -145,6 +151,7 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 					Loops:     loop + 1,
 					LastScore: lastScore,
 					Feedback:  lastFeedback,
+					Diff:      p.diff,
 				}, nil
 			}
 			return nil, fmt.Errorf("requeueing quality phase: %w", err)
@@ -156,6 +163,7 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 		Loops:     p.cfg.MaxLoops,
 		LastScore: lastScore,
 		Feedback:  lastFeedback,
+		Diff:      p.diff,
 	}, nil
 }
 

--- a/internal/phases/quality/phase_test.go
+++ b/internal/phases/quality/phase_test.go
@@ -324,6 +324,28 @@ func TestNeedsCodeRework(t *testing.T) {
 	}
 }
 
+func TestRun_DiffExposedOnResult(t *testing.T) {
+	// #72: PhaseResult must expose the diff the judge evaluated so the
+	// orchestrator can forward it to PostVerdictWithDiff for inline
+	// review comments. The diff field is stable across the pass, escalate,
+	// and requeue paths.
+	const diff = "diff --git a/foo.go b/foo.go\n+hello\n"
+	judge := &fakeJudge{verdicts: []*state.Verdict{
+		{Score: 95, Pass: true},
+	}}
+
+	task := qualityTask(t)
+	phase := New(judge, defaultCfg(), diff)
+
+	result, err := phase.Run(context.Background(), task, "plan")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Diff != diff {
+		t.Errorf("expected result.Diff to round-trip the phase diff, got %q", result.Diff)
+	}
+}
+
 func TestBuildQualityFeedback(t *testing.T) {
 	v := &state.Verdict{
 		Score: 72.5,

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -10,7 +10,6 @@ Update this file when opening, completing, or blocking an issue.
 ---
 
 ## Ready to Start
-- #72 judge/review: inline PR review comments on specific diff lines
 - #79 deps: task dependency graph
 - #81 conflicts: merge conflict detection
 - #84 judge/baseline: hardcoded non-negotiable engineering standards
@@ -18,7 +17,7 @@ Update this file when opening, completing, or blocking an issue.
 - #91 cmd/interactive: status, notes, pause/continue during execution
 
 ## In Progress
-- #85 judge/consistency: tool-use schema, temperature 0, deterministic scoring
+- #72 judge/review: inline PR review comments on specific diff lines
 
 ## Blocked
 - #80 queue: priority ordering + dependency resolution (depends on #79)
@@ -66,6 +65,7 @@ Update this file when opening, completing, or blocking an issue.
 - #62 judge/style: maintainability + readability checks in quality judge
 - #77 workspace: isolated git worktree per task
 - #78 parallel: concurrent task runner
+- #85 judge/consistency: tool-use schema, temperature 0, deterministic scoring
 
 ---
 
@@ -161,6 +161,6 @@ reviewed by the agent judge, only then created in GitHub.
 | M2        | done        | 6/6         |
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
-| M5        | in progress | 2/11        |
+| M5        | in progress | 3/11        |
 | M6        | not started | 0/7         |
 | M7+       | not started | —           |


### PR DESCRIPTION
Closes #72

Gaps carry file+line since #85, and the github client already posts inline
review comments via the batched `POST /reviews` API — but only `vairdict review`
threaded the diff through. The main `vairdict run` path called `PostVerdict`
without a diff, so gaps never became inline comments on production runs.

## What changed

- `qualityphase.PhaseResult` gains a `Diff` field populated from the unified
  diff the judge evaluated. All four return paths (pass, escalate, requeue,
  loop-out) set it so no caller has to guess.
- `ghOrchestrator` switches from `PostVerdict` to `PostVerdictWithDiff`;
  `runOrchestration` forwards `qualityResult.Diff` so the production flow
  matches `vairdict review`.
- `BuildInlineReview` is extracted from `postInlineReview` so the payload
  shape (`COMMENT` event, only-resolvable-gaps) is unit-testable without
  going through `os.CreateTemp` + `gh api`. `postInlineReview` calls it and
  handles the shellout.

## Tests

- `BuildInlineReview` asserts (a) only gaps with resolvable file/line become
  inline comments, (b) nil when nothing resolves, (c) location-less gaps
  still surface in the summary.
- `phase_test` pins `Diff` on `PhaseResult`.
- `run_test` verifies the diff actually reaches `PostVerdictWithDiff` on the
  happy path.

## PROGRESS.md

- `#85` → Done, `#72` → In Progress, M5 count 2/11 → 3/11.

## Test plan

- [ ] CI green
- [ ] VAIrdict quality judge passing verdict
- [ ] Verify on this PR that gaps with file:line appear as inline review comments