### PR TITLE
feat(judge): hardcoded non-negotiable engineering standards (#84)

### DIFF
--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
-	"github.com/vairdict/vairdict/internal/state"
 	"github.com/vairdict/vairdict/internal/judges/verdictschema"
+	"github.com/vairdict/vairdict/internal/standards"
+	"github.com/vairdict/vairdict/internal/state"
 )
 
 // Completer is the interface for sending prompts to an LLM. Plan judge uses
@@ -35,7 +36,7 @@ func New(client Completer, cfg config.PlanPhaseConfig) *PlanJudge {
 	}
 }
 
-const systemPrompt = `You are a plan judge for a software development process engine.
+const systemPromptCore = `You are a plan judge for a software development process engine.
 Your job is to evaluate whether a proposed plan adequately covers the stated intent.
 
 You respond by invoking the submit_verdict tool. The tool's schema is the
@@ -101,6 +102,11 @@ submit_verdict input:
   "questions": []
 }`
 
+// systemPrompt is the plan judge system prompt with the non-negotiable
+// engineering standards appended. Baseline rules reach the judge so it
+// flags violations regardless of team config.
+var systemPrompt = systemPromptCore + "\n\n" + standards.Block
+
 // Judge evaluates a plan against an intent and returns a Verdict.
 // Pass is determined by whether the score meets the configured coverage
 // threshold AND there are no blocking gaps. Blocking is assigned from the
@@ -124,6 +130,13 @@ func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string) (*sta
 	deferSet := toSet(j.cfg.Severity.DeferOn)
 
 	verdictschema.ApplyBlocking(verdict.Gaps, blockSet)
+
+	// Baseline violations (#84) are non-negotiable: promote P0/P1 gaps
+	// tagged with the baseline marker to blocking even when team config
+	// would have allowed them through.
+	if promoted := standards.ForceBaselineBlocking(verdict.Gaps); promoted > 0 {
+		slog.Info("baseline rule forced blocking", "gaps_promoted", promoted)
+	}
 
 	for _, g := range verdict.Gaps {
 		sev := string(g.Severity)

--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -37,12 +37,14 @@ func New(client Completer, cfg config.PlanPhaseConfig) *PlanJudge {
 }
 
 const systemPromptCore = `You are an experienced senior engineer reviewing a plan for a software
-change. You care about correctness, clarity, and future maintenance pain.
-You are considered and deliberate — you comment when it matters and stay
-quiet when it does not. Silence on trivia is a feature, not a bug: you
-would rather miss a nit than add noise.
+change while acting as a plan judge for a software development process
+engine. Your job is to evaluate whether a proposed plan adequately covers
+the stated intent.
 
-Your job is to evaluate whether a proposed plan adequately covers the stated intent.
+You care about correctness, clarity, and future maintenance pain. You are
+considered and deliberate — you comment when it matters and stay quiet
+when it does not. Silence on trivia is a feature, not a bug: you would
+rather miss a nit than add noise.
 
 You respond by invoking the submit_verdict tool. The tool's schema is the
 single source of truth for the response shape — do not emit free-form JSON,

--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -36,7 +36,12 @@ func New(client Completer, cfg config.PlanPhaseConfig) *PlanJudge {
 	}
 }
 
-const systemPromptCore = `You are a plan judge for a software development process engine.
+const systemPromptCore = `You are an experienced senior engineer reviewing a plan for a software
+change. You care about correctness, clarity, and future maintenance pain.
+You are considered and deliberate — you comment when it matters and stay
+quiet when it does not. Silence on trivia is a feature, not a bug: you
+would rather miss a nit than add noise.
+
 Your job is to evaluate whether a proposed plan adequately covers the stated intent.
 
 You respond by invoking the submit_verdict tool. The tool's schema is the
@@ -73,7 +78,11 @@ as a finding, use a gap.
 
 ## Examples
 
-### Example 1 — clear pass
+A single, useful P3 observation is preferable to empty gaps when something
+genuinely worth mentioning exists — but never pad with nits just to avoid
+empty gaps. If a plan is genuinely clean, leave gaps empty.
+
+### Example 1 — pass with one considered observation
 
 Intent: "Add a CLI flag --quiet that suppresses non-error output."
 Plan: "Add a BoolP flag 'quiet' to the run command in cmd/vairdict/run.go.
@@ -83,7 +92,9 @@ ui.NewCLI(). Tests: new test case in run_test.go covering --quiet."
 submit_verdict input:
 {
   "summary": "## Decided\n- Thread --quiet through the existing renderer factory\n## Files to touch\n- cmd/vairdict/run.go — flag plumbing\n- cmd/vairdict/run_test.go — quiet-mode coverage",
-  "gaps": [],
+  "gaps": [
+    {"severity": "P3", "description": "Plan does not specify behavior when both --quiet and --verbose are set — worth deciding explicitly."}
+  ],
   "questions": []
 }
 

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -9,8 +9,83 @@ import (
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/judges/verdictschema"
+	"github.com/vairdict/vairdict/internal/standards"
 	"github.com/vairdict/vairdict/internal/state"
 )
+
+func TestSystemPrompt_IncludesBaseline(t *testing.T) {
+	// #84: the judge must see the non-negotiable standards so it can flag
+	// baseline violations with the correct marker.
+	if !strings.Contains(systemPrompt, standards.Block) {
+		t.Error("plan judge system prompt must include the baseline standards block")
+	}
+	for _, tag := range standards.AllRules {
+		if !strings.Contains(systemPrompt, string(tag)) {
+			t.Errorf("plan judge system prompt missing baseline rule tag %q", tag)
+		}
+	}
+}
+
+func TestJudge_BaselineViolationForcedBlocking_UnderPermissiveConfig(t *testing.T) {
+	// Simulate a team config that only blocks P0. A baseline P1 gap would
+	// normally slip through — the judge must force it blocking anyway.
+	cfg := config.PlanPhaseConfig{
+		CoverageThreshold: 60,
+		MaxLoops:          3,
+		Severity: config.SeverityConfig{
+			BlockOn:  []string{"P0"},
+			AssumeOn: []string{"P2"},
+			DeferOn:  []string{"P3"},
+		},
+	}
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP1, Description: "BASELINE: no-secrets: literal token"},
+			},
+		},
+	}
+	judge := New(fake, cfg)
+
+	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Gaps[0].Blocking {
+		t.Error("baseline P1 gap must be blocking even when BlockOn=[P0]")
+	}
+	if verdict.Pass {
+		t.Error("pass must be false when a blocking gap is present")
+	}
+}
+
+func TestJudge_NonBaselineP1StillGovernedByConfig(t *testing.T) {
+	// Control: a plain (non-baseline) P1 under BlockOn=[P0] remains
+	// non-blocking. Guards against ForceBaselineBlocking over-promoting.
+	cfg := config.PlanPhaseConfig{
+		CoverageThreshold: 60,
+		MaxLoops:          3,
+		Severity: config.SeverityConfig{
+			BlockOn: []string{"P0"},
+		},
+	}
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP1, Description: "missing validation"},
+			},
+		},
+	}
+	judge := New(fake, cfg)
+
+	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Gaps[0].Blocking {
+		t.Error("non-baseline P1 should stay non-blocking under BlockOn=[P0]")
+	}
+}
 
 func defaultCfg() config.PlanPhaseConfig {
 	return config.PlanPhaseConfig{

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/judges/verdictschema"
+	"github.com/vairdict/vairdict/internal/standards"
 	"github.com/vairdict/vairdict/internal/state"
 )
 
@@ -77,7 +78,7 @@ func (j *QualityJudge) WithCodeFacts(facts string) *QualityJudge {
 	return &cp
 }
 
-const systemPrompt = `You are a quality judge for a software development process engine.
+const systemPromptCore = `You are a quality judge for a software development process engine.
 Your job is to evaluate whether implemented code fulfills the original task intent.
 
 You respond by invoking the submit_verdict tool. The tool's schema is the
@@ -219,6 +220,11 @@ submit_verdict input:
   "questions": []
 }`
 
+// systemPrompt is the quality judge system prompt with the non-negotiable
+// engineering standards appended. Baseline rules reach the judge so it
+// flags violations regardless of team config.
+var systemPrompt = systemPromptCore + "\n\n" + standards.Block
+
 // Judge evaluates whether the given diff fulfills the original intent and plan.
 // It runs AI-based intent verification (against the diff content, not a
 // directory path) and optionally e2e tests, returning a combined Verdict.
@@ -246,6 +252,14 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 	// Blocking and score are derived deterministically — the model never
 	// sets either.
 	verdictschema.ApplyBlocking(verdict.Gaps, nil)
+	// Baseline violations (#84) are non-negotiable: promote P0/P1 gaps
+	// tagged with the baseline marker to blocking. In the quality judge
+	// the default block set already covers P0/P1, so this is belt-and-
+	// suspenders — but it stays consistent with the plan judge and
+	// guards against a future block set that would exclude P1.
+	if promoted := standards.ForceBaselineBlocking(verdict.Gaps); promoted > 0 {
+		slog.Info("baseline rule forced blocking", "gaps_promoted", promoted)
+	}
 	verdict.Score = verdictschema.ComputeScore(verdict.Gaps)
 	verdict.Pass = verdict.Score >= PassThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
 

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -78,8 +78,15 @@ func (j *QualityJudge) WithCodeFacts(facts string) *QualityJudge {
 	return &cp
 }
 
-const systemPromptCore = `You are a quality judge for a software development process engine.
-Your job is to evaluate whether implemented code fulfills the original task intent.
+const systemPromptCore = `You are an experienced senior code reviewer. You care about correctness,
+clarity, and future maintenance pain. You are considered and deliberate —
+you comment when it matters and stay quiet when it does not. Silence on
+trivia is a feature, not a bug: you would rather miss a nit than add noise.
+Flag things that would cause a bug, a regression, or real maintenance
+pain; don't flag things a thoughtful reviewer would let slide.
+
+Your job is to evaluate whether the implemented code fulfills the original
+task intent.
 
 You respond by invoking the submit_verdict tool. The tool's schema is the
 single source of truth for the response shape — do not emit free-form JSON,
@@ -191,7 +198,7 @@ Keep each bullet to one line. Do not include any other sections or prose.
 
 ## Examples
 
-### Example 1 — clear pass
+### Example 1 — pass with one considered observation
 
 Intent: "Add a --dry-run flag to vairdict run that skips PR creation."
 Facts: tests pass, lint clean, build ok.
@@ -200,9 +207,15 @@ Diff (abridged): "+ var dryRun bool ... if !dryRun { openPR(...) }" plus test co
 submit_verdict input:
 {
   "summary": "## Reviewed\n- --dry-run flag wiring in run.go\n- test covering the dry-run branch",
-  "gaps": [],
+  "gaps": [
+    {"severity": "P3", "description": "The --dry-run logging prints 'would open PR' but no URL preview; a reader running dry-run gets a weaker signal than they could.", "file": "cmd/vairdict/run.go", "line": 588}
+  ],
   "questions": []
 }
+
+Note: a single, useful P3 observation is preferable to empty gaps when
+something genuinely worth mentioning exists — but never pad with nits
+just to avoid empty gaps. If a diff is genuinely clean, leave gaps empty.
 
 ### Example 2 — clear fail (intent mismatch + security)
 

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -78,15 +78,16 @@ func (j *QualityJudge) WithCodeFacts(facts string) *QualityJudge {
 	return &cp
 }
 
-const systemPromptCore = `You are an experienced senior code reviewer. You care about correctness,
-clarity, and future maintenance pain. You are considered and deliberate —
-you comment when it matters and stay quiet when it does not. Silence on
-trivia is a feature, not a bug: you would rather miss a nit than add noise.
-Flag things that would cause a bug, a regression, or real maintenance
-pain; don't flag things a thoughtful reviewer would let slide.
+const systemPromptCore = `You are an experienced senior code reviewer acting as a quality judge
+for a software development process engine. Your job is to evaluate
+whether the implemented code fulfills the original task intent.
 
-Your job is to evaluate whether the implemented code fulfills the original
-task intent.
+You care about correctness, clarity, and future maintenance pain. You are
+considered and deliberate — you comment when it matters and stay quiet
+when it does not. Silence on trivia is a feature, not a bug: you would
+rather miss a nit than add noise. Flag things that would cause a bug, a
+regression, or real maintenance pain; don't flag things a thoughtful
+reviewer would let slide.
 
 You respond by invoking the submit_verdict tool. The tool's schema is the
 single source of truth for the response shape — do not emit free-form JSON,

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -10,8 +10,50 @@ import (
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/judges/verdictschema"
+	"github.com/vairdict/vairdict/internal/standards"
 	"github.com/vairdict/vairdict/internal/state"
 )
+
+func TestQualitySystemPrompt_IncludesBaseline(t *testing.T) {
+	// #84: the quality judge prompt must include the non-negotiable
+	// standards so violations can be flagged with the baseline marker.
+	if !strings.Contains(systemPrompt, standards.Block) {
+		t.Error("quality judge system prompt must include the baseline standards block")
+	}
+	for _, tag := range standards.AllRules {
+		if !strings.Contains(systemPrompt, string(tag)) {
+			t.Errorf("quality judge system prompt missing baseline rule tag %q", tag)
+		}
+	}
+}
+
+func TestQualityJudge_BaselineMarkerForcesBlocking(t *testing.T) {
+	// A P1 baseline gap is already blocking under the quality judge's
+	// default block set (P0+P1), so this test primarily guards the wiring
+	// — a regression where ForceBaselineBlocking stops being called would
+	// not show up here, but the unit test in the standards package covers
+	// the promotion logic itself. The observable behavior here is: the
+	// gap must end up Blocking=true regardless of what the LLM said.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP1, Description: "BASELINE: no-secrets: hardcoded token", Blocking: false},
+			},
+		},
+	}
+	judge := New(fake, nil, testConfig())
+
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Gaps[0].Blocking {
+		t.Error("baseline-marked gap must be blocking")
+	}
+	if verdict.Pass {
+		t.Error("pass must be false when a blocking baseline gap is present")
+	}
+}
 
 // FakeRunner returns configurable output for testing e2e commands.
 type FakeRunner struct {

--- a/internal/phases/code/phase.go
+++ b/internal/phases/code/phase.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/standards"
 	"github.com/vairdict/vairdict/internal/state"
 )
 
@@ -156,6 +157,9 @@ func buildCoderPrompt(intent string, plan string, feedback string, assumptions [
 	b.WriteString("## Approved Plan\n")
 	b.WriteString(plan)
 	b.WriteString("\n")
+
+	b.WriteString("\n")
+	b.WriteString(standards.Block)
 
 	b.WriteString("\n## Guidelines\n")
 	b.WriteString("- Avoid duplicating logic. Before writing a new helper, check if one already exists.\n")

--- a/internal/phases/code/phase_test.go
+++ b/internal/phases/code/phase_test.go
@@ -3,11 +3,27 @@ package code
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/standards"
 	"github.com/vairdict/vairdict/internal/state"
 )
+
+func TestBuildCoderPrompt_IncludesBaseline(t *testing.T) {
+	// #84: the coder must see the non-negotiable standards so it doesn't
+	// write code that would be flagged during quality.
+	prompt := buildCoderPrompt("do stuff", "step 1", "", nil)
+	if !strings.Contains(prompt, standards.Block) {
+		t.Error("coder prompt must include the baseline standards block")
+	}
+	for _, tag := range standards.AllRules {
+		if !strings.Contains(prompt, string(tag)) {
+			t.Errorf("coder prompt missing baseline rule tag %q", tag)
+		}
+	}
+}
 
 // fakeCoder returns configurable results.
 type fakeCoder struct {

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/standards"
 	"github.com/vairdict/vairdict/internal/state"
 )
 
@@ -56,7 +57,7 @@ func New(planner Planner, judge Judge, cfg config.PlanPhaseConfig) *PlanPhase {
 	}
 }
 
-const plannerSystemPrompt = `You are a software development planner. Your job is to take a task intent and produce a detailed requirements document and implementation plan.
+const plannerSystemPromptCore = `You are a software development planner. Your job is to take a task intent and produce a detailed requirements document and implementation plan.
 
 You MUST respond with valid JSON only — no markdown, no explanation outside the JSON.
 
@@ -67,6 +68,12 @@ Respond with this exact JSON structure:
 }
 
 If you receive feedback from a previous attempt, address every piece of feedback in your revised plan.`
+
+// plannerSystemPrompt is the planner prompt with the non-negotiable
+// engineering standards appended. Baseline rules reach the planner so it
+// plans around them from the start (e.g. names a config loader rather
+// than leaving "TODO: load secrets").
+var plannerSystemPrompt = plannerSystemPromptCore + "\n\n" + standards.Block
 
 // Run executes the plan phase for the given task. It loops up to MaxLoops
 // times, running the planner and judge on each iteration. It updates task

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -8,8 +8,22 @@ import (
 	"testing"
 
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/standards"
 	"github.com/vairdict/vairdict/internal/state"
 )
+
+func TestPlannerSystemPrompt_IncludesBaseline(t *testing.T) {
+	// #84: every agent prompt must carry the non-negotiable standards. A
+	// missing block would let the planner design around violations silently.
+	if !strings.Contains(plannerSystemPrompt, standards.Block) {
+		t.Error("planner system prompt must include the baseline standards block")
+	}
+	for _, tag := range standards.AllRules {
+		if !strings.Contains(plannerSystemPrompt, string(tag)) {
+			t.Errorf("planner system prompt missing baseline rule tag %q", tag)
+		}
+	}
+}
 
 // multiResponseClient is a test double that returns different responses on
 // successive calls. It wraps a slice of responses and an optional slice of

--- a/internal/standards/baseline.go
+++ b/internal/standards/baseline.go
@@ -1,0 +1,113 @@
+// Package standards defines hardcoded, non-negotiable engineering standards
+// that every VAIrdict run enforces. The baseline block is injected verbatim
+// into the planner, coder, plan judge, and quality judge prompts. It is a
+// Go-level constant — not a config knob — so teams cannot silently lower
+// the bar by editing vairdict.yaml.
+//
+// Why a separate package: the same text must reach four different prompt
+// builders that otherwise don't share code, and keeping the rule list in
+// one place makes it easy to audit what agents are actually being told.
+package standards
+
+import "github.com/vairdict/vairdict/internal/state"
+
+// RuleTag is the short, machine-friendly identifier for a baseline rule.
+// Gaps the judge emits for baseline violations are expected to prefix the
+// Description with the marker plus the tag so the judge post-processor can
+// force Blocking=true regardless of team config.
+type RuleTag string
+
+const (
+	RuleNoSecrets     RuleTag = "no-secrets"
+	RuleHandleErrors  RuleTag = "handle-errors"
+	RuleNoDeadCode    RuleTag = "no-dead-code"
+	RuleSelfDocNames  RuleTag = "self-doc-names"
+	RuleNoDuplication RuleTag = "no-duplication"
+	RuleNoTodoFixme   RuleTag = "no-todo-fixme"
+)
+
+// BaselineMarker is the exact prefix judges must place on the gap
+// Description when a baseline rule is violated. The post-processor looks
+// for this marker (case-sensitive) to force blocking on P0/P1 baseline
+// gaps even when config.BlockOn would have allowed them through.
+const BaselineMarker = "BASELINE:"
+
+// Block is the non-negotiable rule list injected into every agent prompt.
+// Exported as a bare string constant (not a builder) so tests can assert
+// its presence verbatim without any evaluation-order concerns.
+//
+// The markdown layout mirrors the other sections already used by the
+// planner, coder, and judge prompts ("## …" headings, "- " bullets) so
+// Claude sees a familiar structure.
+const Block = `## Non-negotiable engineering standards
+
+These rules are hardcoded into VAIrdict and cannot be disabled by config.
+All three agents (planner, coder, judge) must uphold them. When the judge
+finds a violation it MUST prefix the gap description with "BASELINE: <tag>"
+so the orchestrator can force the gap blocking regardless of team config.
+
+### P1 (blocking)
+
+- ` + "`" + string(RuleNoSecrets) + "`" + ` — No hardcoded secrets or credentials.
+  Examples: API keys, tokens, passwords, private keys, DB connection strings
+  containing credentials. Load them from env vars or a secrets manager.
+- ` + "`" + string(RuleHandleErrors) + "`" + ` — All errors must be handled and wrapped with context
+  (` + "`" + `fmt.Errorf("doing thing: %w", err)` + "`" + `). Never silently discard an error
+  with ` + "`" + `_ = fn()` + "`" + ` — if you intentionally drop one, add a one-line comment
+  explaining why.
+- ` + "`" + string(RuleNoDeadCode) + "`" + ` — No unreachable branches, unused imports, or unused
+  symbols. Delete code the moment it stops being referenced; do not keep
+  “just in case” paths.
+- ` + "`" + string(RuleNoTodoFixme) + "`" + ` — No ` + "`TODO`, `FIXME`, `XXX`" + ` left in code that reaches
+  a passing verdict. Either file an issue and link it in a regular comment,
+  or fix it before the verdict.
+
+### P2 (non-blocking but required)
+
+- ` + "`" + string(RuleSelfDocNames) + "`" + ` — Names are self-documenting. No single-letter
+  or unexplained abbreviations (` + "`" + `tmp` + "`" + `, ` + "`" + `i` + "`" + ` in a loop body that spans more
+  than a couple of lines, ad-hoc ` + "`" + `mgr` + "`" + `/` + "`" + `hdlr` + "`" + `/` + "`" + `proc` + "`" + ` abbreviations).
+  Prefer full words; if an abbreviation is standard in the domain, that is
+  fine.
+- ` + "`" + string(RuleNoDuplication) + "`" + ` — No copy-pasted logic. Before writing a new
+  helper, check for an existing one; if you find yourself pasting a block
+  and tweaking a literal, extract a shared function instead.
+`
+
+// AllRules is the canonical list of baseline rules. Tests and the judge
+// post-processor iterate it; the baseline Block above must mention each
+// tag by name, and the tests enforce that invariant.
+var AllRules = []RuleTag{
+	RuleNoSecrets,
+	RuleHandleErrors,
+	RuleNoDeadCode,
+	RuleSelfDocNames,
+	RuleNoDuplication,
+	RuleNoTodoFixme,
+}
+
+// ForceBaselineBlocking promotes P0/P1 baseline gaps to Blocking=true even
+// when team config (e.g. BlockOn=[P0] only) would have left them
+// non-blocking. P2/P3 baseline gaps keep their original Blocking flag so
+// naming/duplication advisories don't halt the run. Returns the number of
+// gaps that had Blocking promoted, for logging.
+func ForceBaselineBlocking(gaps []state.Gap) int {
+	promoted := 0
+	for i := range gaps {
+		if !isBaselineDescription(gaps[i].Description) {
+			continue
+		}
+		if gaps[i].Severity != state.SeverityP0 && gaps[i].Severity != state.SeverityP1 {
+			continue
+		}
+		if !gaps[i].Blocking {
+			gaps[i].Blocking = true
+			promoted++
+		}
+	}
+	return promoted
+}
+
+func isBaselineDescription(desc string) bool {
+	return len(desc) >= len(BaselineMarker) && desc[:len(BaselineMarker)] == BaselineMarker
+}

--- a/internal/standards/baseline_test.go
+++ b/internal/standards/baseline_test.go
@@ -1,0 +1,146 @@
+package standards
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+func TestBlock_MentionsEveryRuleTag(t *testing.T) {
+	// Every rule in AllRules must appear by tag in the baseline Block,
+	// otherwise the judge has no way to reference it when flagging
+	// violations. Guards against silent drift when new rules are added.
+	for _, tag := range AllRules {
+		if !strings.Contains(Block, string(tag)) {
+			t.Errorf("baseline Block missing rule tag %q — update Block when adding a rule", tag)
+		}
+	}
+}
+
+func TestBlock_MentionsMarker(t *testing.T) {
+	// The marker is the anchor the judge post-processor looks for.
+	if !strings.Contains(Block, BaselineMarker) {
+		t.Errorf("baseline Block must instruct the judge to prefix violations with %q", BaselineMarker)
+	}
+}
+
+func TestBlock_DeclaresNonNegotiable(t *testing.T) {
+	// Prompt wording matters: the phrase "non-negotiable" is the signal
+	// to the agent that these rules override team config. Case-insensitive
+	// match so a Title-Case heading still counts.
+	lower := strings.ToLower(Block)
+	if !strings.Contains(lower, "non-negotiable") {
+		t.Error("baseline Block must explicitly call the standards non-negotiable")
+	}
+	if !strings.Contains(lower, "cannot be disabled") {
+		t.Error("baseline Block must state rules cannot be disabled by config")
+	}
+}
+
+func TestForceBaselineBlocking_PromotesP0AndP1(t *testing.T) {
+	gaps := []state.Gap{
+		{Severity: state.SeverityP0, Description: "BASELINE: no-secrets: API key committed", Blocking: false},
+		{Severity: state.SeverityP1, Description: "BASELINE: handle-errors: _ = fn()", Blocking: false},
+	}
+
+	n := ForceBaselineBlocking(gaps)
+	if n != 2 {
+		t.Errorf("expected 2 promotions, got %d", n)
+	}
+	for i, g := range gaps {
+		if !g.Blocking {
+			t.Errorf("gap %d (%s) should have been promoted to blocking", i, g.Severity)
+		}
+	}
+}
+
+func TestForceBaselineBlocking_LeavesP2AndP3Alone(t *testing.T) {
+	gaps := []state.Gap{
+		{Severity: state.SeverityP2, Description: "BASELINE: self-doc-names: tmp is unclear", Blocking: false},
+		{Severity: state.SeverityP3, Description: "BASELINE: no-duplication: tiny repetition", Blocking: false},
+	}
+
+	n := ForceBaselineBlocking(gaps)
+	if n != 0 {
+		t.Errorf("expected 0 promotions for P2/P3 baseline gaps, got %d", n)
+	}
+	for _, g := range gaps {
+		if g.Blocking {
+			t.Error("P2/P3 baseline gap should remain non-blocking")
+		}
+	}
+}
+
+func TestForceBaselineBlocking_IgnoresNonBaselineGaps(t *testing.T) {
+	// Unmarked P1 gaps are governed by team config, not baseline.
+	gaps := []state.Gap{
+		{Severity: state.SeverityP1, Description: "missing request validation", Blocking: false},
+	}
+
+	n := ForceBaselineBlocking(gaps)
+	if n != 0 {
+		t.Errorf("expected 0 promotions for non-baseline gaps, got %d", n)
+	}
+	if gaps[0].Blocking {
+		t.Error("non-baseline gap should not be force-promoted")
+	}
+}
+
+func TestForceBaselineBlocking_AlreadyBlockingNotDoubleCounted(t *testing.T) {
+	// A config that already blocks P1 leaves the baseline gap already
+	// flagged. Force does not need to promote — it should report 0.
+	gaps := []state.Gap{
+		{Severity: state.SeverityP1, Description: "BASELINE: no-dead-code: unreachable branch", Blocking: true},
+	}
+
+	if n := ForceBaselineBlocking(gaps); n != 0 {
+		t.Errorf("expected 0 promotions when gap already blocking, got %d", n)
+	}
+	if !gaps[0].Blocking {
+		t.Error("gap should remain blocking")
+	}
+}
+
+func TestForceBaselineBlocking_OverridesPermissiveConfig(t *testing.T) {
+	// Simulate a team config that only blocks P0 (BlockOn=[P0]). Baseline
+	// P1 gaps would slip through; ForceBaselineBlocking must catch them.
+	// This is the whole point of the override: baseline is non-negotiable
+	// regardless of config.
+	gaps := []state.Gap{
+		// Team config already dropped Blocking=false for the P1 secret.
+		{Severity: state.SeverityP1, Description: "BASELINE: no-secrets: literal token in config.go", Blocking: false},
+	}
+
+	if n := ForceBaselineBlocking(gaps); n != 1 {
+		t.Errorf("expected baseline to override permissive config (1 promotion), got %d", n)
+	}
+	if !gaps[0].Blocking {
+		t.Error("baseline P1 gap must be blocking even under BlockOn=[P0] config")
+	}
+}
+
+func TestAllRules_Comprehensive(t *testing.T) {
+	// The rule list must cover the six minimum categories from the issue
+	// description. Catches accidental deletions during refactors.
+	wanted := map[RuleTag]bool{
+		RuleNoSecrets:     false,
+		RuleHandleErrors:  false,
+		RuleNoDeadCode:    false,
+		RuleSelfDocNames:  false,
+		RuleNoDuplication: false,
+		RuleNoTodoFixme:   false,
+	}
+	for _, tag := range AllRules {
+		if _, ok := wanted[tag]; !ok {
+			t.Errorf("AllRules contains unexpected tag %q", tag)
+			continue
+		}
+		wanted[tag] = true
+	}
+	for tag, seen := range wanted {
+		if !seen {
+			t.Errorf("AllRules missing required baseline rule %q", tag)
+		}
+	}
+}

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -12,12 +12,11 @@ Update this file when opening, completing, or blocking an issue.
 ## Ready to Start
 - #79 deps: task dependency graph
 - #81 conflicts: merge conflict detection
-- #84 judge/baseline: hardcoded non-negotiable engineering standards
 - #90 cmd/resume: resume interrupted run from last checkpoint
 - #91 cmd/interactive: status, notes, pause/continue during execution
 
 ## In Progress
-- #72 judge/review: inline PR review comments on specific diff lines
+- #84 judge/baseline: hardcoded non-negotiable engineering standards
 
 ## Blocked
 - #80 queue: priority ordering + dependency resolution (depends on #79)
@@ -66,6 +65,7 @@ Update this file when opening, completing, or blocking an issue.
 - #77 workspace: isolated git worktree per task
 - #78 parallel: concurrent task runner
 - #85 judge/consistency: tool-use schema, temperature 0, deterministic scoring
+- #72 judge/review: inline PR review comments on specific diff lines
 
 ---
 
@@ -161,6 +161,6 @@ reviewed by the agent judge, only then created in GitHub.
 | M2        | done        | 6/6         |
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
-| M5        | in progress | 3/11        |
+| M5        | in progress | 4/11        |
 | M6        | not started | 0/7         |
 | M7+       | not started | —           |


### PR DESCRIPTION
Closes #84

Two complementary changes that give the judge both stricter rules **and** a
more thoughtful voice. Prompts live in Go for now; they move into skills
once skillpkg runtime loading lands (M11).

## 1. Baseline standards (#84)

Introduce a baseline block of engineering standards that every agent sees
and every judge enforces. Standards live in code (`internal/standards`),
not config — teams cannot silently lower the bar via `vairdict.yaml`.

- New `internal/standards` package with `BaselineMarker`, `Block`, `AllRules`,
  and `ForceBaselineBlocking`. Six rules total: `no-secrets`,
  `handle-errors`, `no-dead-code`, `no-todo-fixme` (P1 blocking);
  `self-doc-names`, `no-duplication` (P2 non-blocking).
- The `Block` text is injected into four prompts: planner system prompt,
  coder user prompt, plan-judge system prompt, quality-judge system prompt.
  It tells the judge to prefix violation descriptions with
  `BASELINE: <tag>` so post-processing can recognise them.
- Plan and quality judges call `standards.ForceBaselineBlocking` after
  `verdictschema.ApplyBlocking`. This promotes P0/P1 baseline gaps to
  `Blocking=true` even under a permissive team config like `BlockOn=[P0]`.
  P2/P3 baseline gaps keep their original flag so naming/duplication
  advisories don't halt a run.

## 2. Reviewer persona (tone fix)

The judge was too quiet — zero gaps on genuinely reviewable PRs. Root
cause was a mix of defensive post-#85 guardrails and a "clear pass"
few-shot that anchored toward empty gaps.

- Plan + quality judge system prompts now open with a senior-reviewer
  persona: cares about correctness and maintenance pain, stays quiet on
  trivia. Explicit: "Silence on trivia is a feature. Flag things that
  would cause a bug, a regression, or real maintenance pain; don't flag
  things a thoughtful reviewer would let slide."
- "Clear pass" few-shots in both prompts now carry a single useful P3
  observation plus a note that padding is worse than silence — so zero
  gaps stops being the anchor, but nit-padding isn't encouraged either.
- Post-#85 partial-diff guardrails are preserved.

## Tests

- `TestBlock_MentionsEveryRuleTag`, `TestBlock_MentionsMarker`,
  `TestBlock_DeclaresNonNegotiable`, `TestAllRules_Comprehensive` —
  prompt wording + rule coverage.
- `TestForceBaselineBlocking_*` — promotes P0/P1, leaves P2/P3 alone,
  ignores non-baseline gaps, doesn't double-count, overrides permissive
  config.
- Presence checks on all four prompts (planner, coder, plan judge,
  quality judge) — each asserts the full `Block` and every rule tag.
- `TestJudge_BaselineViolationForcedBlocking_UnderPermissiveConfig` pins
  the end-to-end behaviour under `BlockOn=[P0]`.
- `TestJudge_NonBaselineP1StillGovernedByConfig` is the control — a plain
  P1 under the same config stays non-blocking.

## PROGRESS.md

- `#72` → Done, `#84` → In Progress, M5 count 3/11 → 4/11.

## Test plan

- [ ] CI green
- [ ] VAIrdict quality judge passing verdict on the PR
- [ ] Does the new reviewer persona produce a more substantive verdict on
      this PR's own diff? (organic validation)