### PR TITLE
ci: add CI workflow with test, lint, and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,16 @@ jobs:
             exit 1
           fi
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
+      - name: Install golangci-lint
+        env:
+          # Force the project's Go toolchain so the binary is built with a
+          # Go version >= the one targeted by go.mod. The upstream releases
+          # are built with Go 1.25, which cannot analyse code targeting 1.26.
+          GOTOOLCHAIN: go1.26.1
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+
+      - name: Run golangci-lint
+        run: golangci-lint run ./...
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,12 @@ jobs:
 
       - name: Install golangci-lint
         env:
-          # Force the project's Go toolchain so the binary is built with a
-          # Go version >= the one targeted by go.mod. The upstream releases
-          # are built with Go 1.25, which cannot analyse code targeting 1.26.
-          GOTOOLCHAIN: go1.26.1
+          # Force the Go toolchain installed by setup-go (which reads go.mod)
+          # instead of letting Go auto-download golangci-lint's preferred
+          # toolchain. Upstream releases are built with an older Go than this
+          # project targets, and the resulting binary refuses to analyse
+          # newer code. "local" stays version-agnostic as go.mod evolves.
+          GOTOOLCHAIN: local
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
       - name: Run golangci-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "Files not formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binary
+        run: go build -o vairdict ./cmd/vairdict

--- a/cmd/vairdict/manifest_run.go
+++ b/cmd/vairdict/manifest_run.go
@@ -240,4 +240,3 @@ func maybeBlockOnDeps(store *state.Store, t *state.Task, depIDs []string) (bool,
 	}
 	return false, nil
 }
-

--- a/cmd/vairdict/manifest_run.go
+++ b/cmd/vairdict/manifest_run.go
@@ -101,7 +101,7 @@ func runManifest(manifest *Manifest, mode ui.Mode, colors ui.ColorScheme, ascii 
 		return fmt.Errorf("manifest: %w", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "Running %d tasks from manifest (max %d concurrent)\n\n",
+	_, _ = fmt.Fprintf(os.Stdout, "Running %d tasks from manifest (max %d concurrent)\n\n",
 		len(manifest.Tasks), cfg.Parallel.MaxTasks)
 
 	results := make(map[string]taskResult, len(tasks))
@@ -179,7 +179,7 @@ func runManifest(manifest *Manifest, mode ui.Mode, colors ui.ColorScheme, ascii 
 	wg.Wait()
 
 	// Print summary table: manifest name, state, verdict.
-	fmt.Fprintln(os.Stdout, "\n--- Summary ---")
+	_, _ = fmt.Fprintln(os.Stdout, "\n--- Summary ---")
 	var failures []string
 	for _, mt := range manifest.Tasks {
 		id := nameToID[mt.Name]

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -35,14 +35,14 @@ const (
 )
 
 var (
-	issueFlags      []int
-	outputFlag      string
-	colorsFlag      string
-	asciiFlag       bool
-	envFlag         string
-	manifestFlag    string
-	dependsOnFlag   []string
-	priorityFlag    string
+	issueFlags    []int
+	outputFlag    string
+	colorsFlag    string
+	asciiFlag     bool
+	envFlag       string
+	manifestFlag  string
+	dependsOnFlag []string
+	priorityFlag  string
 )
 
 var runCmd = &cobra.Command{

--- a/internal/agents/claude/client.go
+++ b/internal/agents/claude/client.go
@@ -120,7 +120,7 @@ type contentBlock struct {
 // toolResultBlock is a content block sent in a user message to return the
 // result of a tool call back to the model during a multi-turn conversation.
 type toolResultBlock struct {
-	Type      string `json:"type"`       // always "tool_result"
+	Type      string `json:"type"` // always "tool_result"
 	ToolUseID string `json:"tool_use_id"`
 	Content   string `json:"content"`
 }

--- a/internal/deps/graph_test.go
+++ b/internal/deps/graph_test.go
@@ -251,9 +251,9 @@ func TestPriority_HigherGoesFirst(t *testing.T) {
 	g := New()
 	// Add in reverse priority order to confirm the sort doesn't rely on
 	// insertion order.
-	_ = g.AddWithPriority("low",    nil, PriorityLow)
+	_ = g.AddWithPriority("low", nil, PriorityLow)
 	_ = g.AddWithPriority("normal", nil, PriorityNormal)
-	_ = g.AddWithPriority("high",   nil, PriorityHigh)
+	_ = g.AddWithPriority("high", nil, PriorityHigh)
 	if err := g.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestPriority_EqualFallsBackToInsertionOrder(t *testing.T) {
 	// in that order — insertion seq is the stable tiebreaker, not ID
 	// alphabetic order.
 	g := New()
-	_ = g.AddWithPriority("zeta",  nil, PriorityHigh)
+	_ = g.AddWithPriority("zeta", nil, PriorityHigh)
 	_ = g.AddWithPriority("alpha", nil, PriorityHigh)
 	if err := g.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
@@ -287,7 +287,7 @@ func TestPriority_InteractsWithDeps_HighDepOnLowWaitsForLow(t *testing.T) {
 	// Even a high-priority node must wait for its dependency. Priority
 	// sorts within the ready set; it cannot skip the graph structure.
 	g := New()
-	_ = g.AddWithPriority("low_root", nil,                  PriorityLow)
+	_ = g.AddWithPriority("low_root", nil, PriorityLow)
 	_ = g.AddWithPriority("high_dep", []string{"low_root"}, PriorityHigh)
 	if err := g.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -381,4 +381,3 @@ func TestJudge_SystemPromptIncludesFewShotExamples(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with three parallel jobs: **test**, **lint & format**, and **build**
- Runs on every PR targeting `main` and on pushes to `main`
- Each job shows as a separate check on PRs

## Test plan
- [ ] Verify all three jobs run and pass on this PR
- [ ] Confirm each job appears as a distinct status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)