### PR TITLE
feat(review): add check_path auxiliary tool for quality judge

### DIFF
--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -29,6 +29,7 @@ import (
 type completer interface {
 	CompleteWithSystem(ctx context.Context, system, prompt string, target any) error
 	CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
+	CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, handlers map[string]claude.ToolHandler, target any) error
 }
 
 // backendKind is the resolved backend identifier returned alongside the

--- a/internal/agents/claude/client.go
+++ b/internal/agents/claude/client.go
@@ -111,10 +111,30 @@ type messagesResponse struct {
 
 type contentBlock struct {
 	Type  string          `json:"type"`
+	ID    string          `json:"id,omitempty"`
 	Text  string          `json:"text,omitempty"`
 	Name  string          `json:"name,omitempty"`
 	Input json.RawMessage `json:"input,omitempty"`
 }
+
+// toolResultBlock is a content block sent in a user message to return the
+// result of a tool call back to the model during a multi-turn conversation.
+type toolResultBlock struct {
+	Type      string `json:"type"`       // always "tool_result"
+	ToolUseID string `json:"tool_use_id"`
+	Content   string `json:"content"`
+}
+
+// anyMessage supports flexible content (string or structured blocks) for
+// multi-turn tool-use conversations.
+type anyMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+}
+
+// ToolHandler resolves an auxiliary tool call during a multi-turn conversation.
+// It receives the raw JSON input from the model and returns a result string.
+type ToolHandler func(ctx context.Context, input json.RawMessage) (string, error)
 
 type usage struct {
 	InputTokens  int `json:"input_tokens"`
@@ -240,6 +260,174 @@ func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, to
 	return c.sendAndParse(ctx, reqBody, func(resp *messagesResponse) error {
 		return unmarshalToolInput(resp, tool.Name, target)
 	})
+}
+
+// maxToolRounds caps the number of auxiliary tool calls in CompleteWithTools.
+const maxToolRounds = 10
+
+// multiTurnRequest is like messagesRequest but uses anyMessage to support
+// structured content (tool results) in the conversation.
+type multiTurnRequest struct {
+	Model       string       `json:"model"`
+	MaxTokens   int          `json:"max_tokens"`
+	System      string       `json:"system,omitempty"`
+	Messages    []anyMessage `json:"messages"`
+	Temperature *float64     `json:"temperature,omitempty"`
+	Tools       []Tool       `json:"tools,omitempty"`
+	ToolChoice  *ToolChoice  `json:"tool_choice,omitempty"`
+}
+
+// CompleteWithTools runs a multi-turn conversation where the model can call
+// auxiliary tools (resolved via handlers) before calling finalTool, whose
+// input is unmarshalled into target.
+func (c *Client) CompleteWithTools(
+	ctx context.Context,
+	system, prompt string,
+	tools []Tool,
+	finalTool string,
+	handlers map[string]ToolHandler,
+	target any,
+) error {
+	messages := []anyMessage{{Role: "user", Content: prompt}}
+
+	for round := range maxToolRounds {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("completing multi-turn request: %w", err)
+		}
+
+		reqBody := multiTurnRequest{
+			Model:       c.model,
+			MaxTokens:   defaultMaxTokens,
+			System:      system,
+			Messages:    messages,
+			Temperature: c.temperature,
+			Tools:       tools,
+			ToolChoice:  &ToolChoice{Type: "any"},
+		}
+
+		body, err := c.doRequestAny(ctx, reqBody)
+		if err != nil {
+			return fmt.Errorf("multi-turn round %d: %w", round, err)
+		}
+
+		var resp messagesResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return &ParseError{Body: string(body), Err: fmt.Errorf("unmarshalling response: %w", err)}
+		}
+
+		// Check if the model called the final tool.
+		for _, block := range resp.Content {
+			if block.Type == "tool_use" && block.Name == finalTool {
+				if len(block.Input) == 0 {
+					return &ParseError{Err: fmt.Errorf("tool_use block %q had empty input", finalTool)}
+				}
+				if err := json.Unmarshal(block.Input, target); err != nil {
+					return &ParseError{Body: string(block.Input), Err: fmt.Errorf("unmarshalling tool input: %w", err)}
+				}
+				return nil
+			}
+		}
+
+		// Resolve auxiliary tool calls.
+		var toolResults []toolResultBlock
+		for _, block := range resp.Content {
+			if block.Type != "tool_use" {
+				continue
+			}
+			handler, ok := handlers[block.Name]
+			if !ok {
+				return fmt.Errorf("model called unknown tool %q", block.Name)
+			}
+			result, err := handler(ctx, block.Input)
+			if err != nil {
+				return fmt.Errorf("handling tool %q: %w", block.Name, err)
+			}
+			slog.Debug("auxiliary tool resolved", "tool", block.Name, "result", result)
+			toolResults = append(toolResults, toolResultBlock{
+				Type:      "tool_result",
+				ToolUseID: block.ID,
+				Content:   result,
+			})
+		}
+
+		if len(toolResults) == 0 {
+			return &ParseError{Err: fmt.Errorf("model did not call any tool in round %d", round)}
+		}
+
+		// Append assistant response + tool results to conversation.
+		messages = append(messages, anyMessage{Role: "assistant", Content: resp.Content})
+		messages = append(messages, anyMessage{Role: "user", Content: toolResults})
+	}
+
+	return fmt.Errorf("multi-turn tool loop exceeded %d rounds", maxToolRounds)
+}
+
+// doRequestAny is like doRequest but accepts any request type for marshalling.
+// It includes retry logic for transient errors.
+func (c *Client) doRequestAny(ctx context.Context, reqBody any) ([]byte, error) {
+	var lastErr error
+	for attempt := range maxRetries {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("completing request: %w", err)
+		}
+
+		payload, err := json.Marshal(reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("marshalling request: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(payload))
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", c.apiKey)
+		req.Header.Set("anthropic-version", defaultAnthropicVersion)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("sending request: %w", err)
+			continue
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			lastErr = fmt.Errorf("reading response: %w", readErr)
+			continue
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusOK:
+			return body, nil
+		case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+			return nil, &AuthError{Message: string(body)}
+		case resp.StatusCode == http.StatusTooManyRequests:
+			lastErr = &RateLimitError{RetryAfter: baseBackoff}
+		case resp.StatusCode >= 500:
+			lastErr = &APIError{StatusCode: resp.StatusCode, Body: string(body)}
+		default:
+			return nil, &APIError{StatusCode: resp.StatusCode, Body: string(body)}
+		}
+
+		if !isRetryable(lastErr) {
+			return nil, lastErr
+		}
+
+		backoff := time.Duration(math.Pow(2, float64(attempt))) * baseBackoff
+		slog.Warn("retrying anthropic request",
+			"attempt", attempt+1,
+			"backoff", backoff,
+			"error", lastErr,
+		)
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("completing request: %w", ctx.Err())
+		case <-time.After(backoff):
+		}
+	}
+	return nil, fmt.Errorf("completing request after %d retries: %w", maxRetries, lastErr)
 }
 
 // sendAndParse drives the retry loop for a single request and hands the

--- a/internal/agents/claude/client_test.go
+++ b/internal/agents/claude/client_test.go
@@ -641,6 +641,125 @@ func TestWithoutTemperature_OmitsField(t *testing.T) {
 	}
 }
 
+// --- CompleteWithTools tests ---
+
+func makeToolUseResponse(id, name string, input json.RawMessage) string {
+	resp := messagesResponse{
+		Content: []contentBlock{{
+			Type:  "tool_use",
+			ID:    id,
+			Name:  name,
+			Input: input,
+		}},
+		StopReason: "tool_use",
+	}
+	data, _ := json.Marshal(resp)
+	return string(data)
+}
+
+func TestCompleteWithTools_DirectFinalTool(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeToolUseResponse("t1", "submit_verdict", json.RawMessage(`{"answer":"done"}`))))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	err = c.CompleteWithTools(context.Background(), "sys", "prompt",
+		[]Tool{{Name: "submit_verdict", InputSchema: json.RawMessage(`{}`)}},
+		"submit_verdict", nil, &result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Answer != "done" {
+		t.Errorf("expected answer 'done', got %q", result.Answer)
+	}
+}
+
+func TestCompleteWithTools_AuxiliaryThenFinal(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		if n == 1 {
+			// First call: model calls check_path
+			_, _ = w.Write([]byte(makeToolUseResponse("t1", "check_path", json.RawMessage(`{"path":"cmd/main.go"}`))))
+			return
+		}
+		// Second call: model calls final tool
+		_, _ = w.Write([]byte(makeToolUseResponse("t2", "submit_verdict", json.RawMessage(`{"answer":"verified"}`))))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handlerCalled := false
+	handlers := map[string]ToolHandler{
+		"check_path": func(_ context.Context, input json.RawMessage) (string, error) {
+			handlerCalled = true
+			return "exists: true, type: file", nil
+		},
+	}
+
+	var result testResult
+	err = c.CompleteWithTools(context.Background(), "sys", "prompt",
+		[]Tool{
+			{Name: "submit_verdict", InputSchema: json.RawMessage(`{}`)},
+			{Name: "check_path", InputSchema: json.RawMessage(`{}`)},
+		},
+		"submit_verdict", handlers, &result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handlerCalled {
+		t.Error("expected handler to be called")
+	}
+	if result.Answer != "verified" {
+		t.Errorf("expected answer 'verified', got %q", result.Answer)
+	}
+	if callCount.Load() != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount.Load())
+	}
+}
+
+func TestCompleteWithTools_UnknownTool(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeToolUseResponse("t1", "unknown_tool", json.RawMessage(`{}`))))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	err = c.CompleteWithTools(context.Background(), "", "prompt",
+		[]Tool{{Name: "submit_verdict", InputSchema: json.RawMessage(`{}`)}},
+		"submit_verdict", nil, &result)
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Errorf("expected 'unknown tool' error, got: %v", err)
+	}
+}
+
 func TestExtractJSON(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/agents/claude/fake.go
+++ b/internal/agents/claude/fake.go
@@ -47,6 +47,13 @@ func (f *FakeClient) CompleteWithTool(_ context.Context, system, prompt string, 
 	return f.fill(target)
 }
 
+// CompleteWithTools records the call (using finalTool as ToolName) and returns
+// the configured response. Does not simulate the multi-turn loop.
+func (f *FakeClient) CompleteWithTools(_ context.Context, system, prompt string, _ []Tool, finalTool string, _ map[string]ToolHandler, target any) error {
+	f.Calls = append(f.Calls, FakeCall{System: system, Prompt: prompt, ToolName: finalTool})
+	return f.fill(target)
+}
+
 func (f *FakeClient) fill(target any) error {
 	if f.Err != nil {
 		return f.Err

--- a/internal/agents/claudecli/client.go
+++ b/internal/agents/claudecli/client.go
@@ -149,6 +149,18 @@ func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, to
 	return c.CompleteWithSystem(ctx, augmented, prompt, target)
 }
 
+// CompleteWithTools falls back to single-turn CompleteWithTool using only the
+// final tool. The CLI backend cannot do multi-turn tool use, so auxiliary tools
+// like check_path are silently unavailable.
+func (c *Client) CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, _ map[string]claude.ToolHandler, target any) error {
+	for _, t := range tools {
+		if t.Name == finalTool {
+			return c.CompleteWithTool(ctx, system, prompt, t, target)
+		}
+	}
+	return fmt.Errorf("final tool %q not found in tools list", finalTool)
+}
+
 // envelope is the subset of Claude Code's `--output-format json` result that
 // we care about. We explicitly decode only the fields we need so the rest
 // (session_id, cost, usage, …) are tolerated as extras.

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -7,9 +7,12 @@ package quality
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
@@ -20,9 +23,10 @@ import (
 )
 
 // Completer is the interface for sending prompts to an LLM. Quality judge uses
-// tool-use exclusively so responses conform to a strict schema.
+// multi-turn tool-use so the model can call auxiliary tools (like check_path)
+// before submitting the final verdict.
 type Completer interface {
-	CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
+	CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, handlers map[string]claude.ToolHandler, target any) error
 }
 
 // CommandRunner executes a command and returns its output and error.
@@ -78,6 +82,51 @@ func (j *QualityJudge) WithCodeFacts(facts string) *QualityJudge {
 	return &cp
 }
 
+// checkPathSchema is the JSON Schema for the check_path auxiliary tool.
+const checkPathSchema = `{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Relative path from the project root to check (e.g. 'cmd/vairdict', 'internal/config/config.go')."
+    }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}`
+
+// checkPathTool returns the tool definition for the check_path auxiliary tool.
+func checkPathTool() claude.Tool {
+	return claude.Tool{
+		Name:        "check_path",
+		Description: "Check whether a file or directory exists in the project repository. Returns existence status and type (file or directory).",
+		InputSchema: json.RawMessage(checkPathSchema),
+	}
+}
+
+// checkPathHandler resolves a check_path tool call by stat-ing the path
+// relative to the current working directory (project root).
+func checkPathHandler(_ context.Context, input json.RawMessage) (string, error) {
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(input, &req); err != nil {
+		return "", fmt.Errorf("parsing check_path input: %w", err)
+	}
+	cleaned := filepath.Clean(req.Path)
+	if filepath.IsAbs(cleaned) || strings.HasPrefix(cleaned, "..") {
+		return "error: path must be relative and within the project", nil
+	}
+	info, err := os.Stat(cleaned)
+	if err != nil {
+		return "exists: false", nil
+	}
+	if info.IsDir() {
+		return "exists: true, type: directory", nil
+	}
+	return "exists: true, type: file", nil
+}
+
 const systemPromptCore = `You are an experienced senior code reviewer acting as a quality judge
 for a software development process engine. Your job is to evaluate
 whether the implemented code fulfills the original task intent.
@@ -131,6 +180,15 @@ You MUST NOT:
 - Treat a missing-from-diff symbol as a gap of ANY severity
 
 These are NOT bugs. They are existing code that was not modified.
+
+## Verifying file or directory existence
+
+If you are genuinely uncertain whether a file or directory referenced in the
+diff exists in the project, call the check_path tool with the relative path
+BEFORE raising a gap or question about it. Do NOT guess — verify first.
+Do NOT call check_path for:
+- Code symbols (functions, types, variables) — they exist if referenced in the diff
+- Paths that appear in the diff itself — they obviously exist
 
 ## Severity levels for gaps
 
@@ -351,8 +409,12 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 	)
 
 	var verdict state.Verdict
-	tool := verdictschema.VerdictTool("Submit the quality judge verdict as a structured object. Omit score, pass, and blocking — they are computed from the gap severities.")
-	if err := j.client.CompleteWithTool(ctx, systemPrompt, prompt, tool, &verdict); err != nil {
+	verdictTool := verdictschema.VerdictTool("Submit the quality judge verdict as a structured object. Omit score, pass, and blocking — they are computed from the gap severities.")
+	tools := []claude.Tool{verdictTool, checkPathTool()}
+	handlers := map[string]claude.ToolHandler{
+		"check_path": checkPathHandler,
+	}
+	if err := j.client.CompleteWithTools(ctx, systemPrompt, prompt, tools, verdictschema.ToolName, handlers, &verdict); err != nil {
 		return nil, fmt.Errorf("calling completer: %w", err)
 	}
 

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -704,5 +705,97 @@ func TestJudge_NonBlockingGapsAllowPass(t *testing.T) {
 	}
 	if !verdict.Pass {
 		t.Error("expected pass=true — only non-blocking gaps, score above threshold")
+	}
+}
+
+func TestCheckPathHandler_ExistingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir+"/sub/dir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// chdir so the handler resolves relative to our temp dir.
+	orig, _ := os.Getwd()
+	defer func() { _ = os.Chdir(orig) }()
+	_ = os.Chdir(dir)
+
+	result, err := checkPathHandler(context.Background(), []byte(`{"path":"sub/dir"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "exists: true, type: directory" {
+		t.Errorf("expected directory exists, got %q", result)
+	}
+}
+
+func TestCheckPathHandler_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/test.txt", []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig, _ := os.Getwd()
+	defer func() { _ = os.Chdir(orig) }()
+	_ = os.Chdir(dir)
+
+	result, err := checkPathHandler(context.Background(), []byte(`{"path":"test.txt"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "exists: true, type: file" {
+		t.Errorf("expected file exists, got %q", result)
+	}
+}
+
+func TestCheckPathHandler_NonExistent(t *testing.T) {
+	result, err := checkPathHandler(context.Background(), []byte(`{"path":"does/not/exist"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "exists: false" {
+		t.Errorf("expected not exists, got %q", result)
+	}
+}
+
+func TestCheckPathHandler_PathTraversal(t *testing.T) {
+	result, err := checkPathHandler(context.Background(), []byte(`{"path":"../../../etc/passwd"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(result, "error") {
+		t.Errorf("expected error for path traversal, got %q", result)
+	}
+}
+
+func TestCheckPathHandler_AbsolutePath(t *testing.T) {
+	result, err := checkPathHandler(context.Background(), []byte(`{"path":"/etc/passwd"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(result, "error") {
+		t.Errorf("expected error for absolute path, got %q", result)
+	}
+}
+
+func TestJudge_SystemPromptMentionsCheckPath(t *testing.T) {
+	if !strings.Contains(systemPrompt, "check_path") {
+		t.Error("system prompt must mention the check_path tool")
+	}
+}
+
+func TestJudge_UsesCompleteWithTools(t *testing.T) {
+	fake := &claude.FakeClient{
+		Response: state.Verdict{Gaps: []state.Gap{}},
+	}
+
+	judge := New(fake, nil, testConfig())
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.Calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
+	}
+	if fake.Calls[0].ToolName != verdictschema.ToolName {
+		t.Errorf("expected final tool %q, got %q", verdictschema.ToolName, fake.Calls[0].ToolName)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds multi-turn `CompleteWithTools` to the Claude API client, supporting auxiliary tool calls before the final tool
- Quality judge now has a `check_path` tool that verifies file/directory existence via `os.Stat` before raising gaps or questions
- System prompt updated to instruct the judge to call `check_path` instead of guessing about repo structure
- CLI backend gracefully falls back to single-turn (auxiliary tools unavailable)
- Path traversal and absolute path injection are rejected by the handler

## Context
The review judge was raising false questions like "Does the `cmd/vairdict` directory exist?" because it only saw the diff, not the repo. Instead of bloating context with a full file tree, the judge can now ask on-demand.

## Test plan
- [x] All existing tests pass (full suite green)
- [x] `CompleteWithTools` tested: direct final tool, auxiliary→final, unknown tool error
- [x] `checkPathHandler` tested: existing dir, existing file, non-existent, path traversal, absolute path
- [x] Integration test verifies judge calls `CompleteWithTools` with correct final tool
- [ ] Manual: trigger a review on a CI-only PR and verify no false path-existence questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)