### PR TITLE
feat(state/rewind): verdict ReturnTo + phase rewind in outer loop

### DIFF
--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -557,79 +557,165 @@ func runSingleTask(
 	return res
 }
 
+// maxOuterCycles bounds the number of plan→code→quality outer loops a
+// task may go through. Each cycle gives every phase its own fresh
+// per-phase budget (see state.Task.Rewind); this constant only exists to
+// stop pathological verdicts from looping forever. Three cycles is enough
+// to exercise every rewind path (quality→code, quality→plan→code→quality)
+// with one spare attempt.
+const maxOuterCycles = 3
+
 // runOrchestration is the testable core of runTask. It receives all
 // dependencies via deps so tests can substitute fakes for every
 // external interaction (phases, GitHub, git commit, escalation).
+//
+// The outer loop runs plan → code → quality up to maxOuterCycles times.
+// Each cycle re-uses the previous plan unless the quality judge rewound
+// to Plan, in which case HardConstraints capture the quality failure and
+// the plan phase runs again to produce a new plan that addresses them.
 func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.Renderer) error {
-	// --- Plan phase ---
-	planResult, err := deps.plan.Run(ctx, task)
-	if err != nil {
-		r.Error(err)
-		return err
-	}
+	var (
+		planResult    *planphase.PhaseResult
+		branch        string
+		branchCreated bool
+		qualityResult *qualityphase.PhaseResult
+	)
 
-	if planResult.Escalate {
-		gaps := lastGapsForPhase(task, state.PhasePlan)
-		r.Escalation(task.ID, state.PhasePlan, planResult.Loops, planResult.LastScore, gaps)
-		return deps.onEscalation(ctx, task, escalation.Result{
-			Phase:     state.PhasePlan,
-			Loops:     planResult.Loops,
-			LastScore: planResult.LastScore,
-			Gaps:      gaps,
-		})
-	}
+	for cycle := 0; cycle < maxOuterCycles; cycle++ {
+		// --- Plan phase (first cycle, or after rewind to plan) ---
+		if planResult == nil {
+			pr, err := deps.plan.Run(ctx, task)
+			if err != nil {
+				r.Error(err)
+				return err
+			}
+			planResult = pr
 
-	// --- Create branch before code phase so commits land on it ---
-	branch, err := deps.gh.CreateBranch(ctx, task.ID, task.Intent)
-	if err != nil {
-		r.Error(err)
-		return fmt.Errorf("creating branch: %w", err)
-	}
-	r.Note("branch", branch)
+			if planResult.Escalate {
+				gaps := lastGapsForPhase(task, state.PhasePlan)
+				r.Escalation(task.ID, state.PhasePlan, planResult.Loops, planResult.LastScore, gaps)
+				return deps.onEscalation(ctx, task, escalation.Result{
+					Phase:     state.PhasePlan,
+					Loops:     planResult.Loops,
+					LastScore: planResult.LastScore,
+					Gaps:      gaps,
+				})
+			}
+		}
 
-	// --- Code phase ---
-	codeResult, err := deps.code.Run(ctx, task, planResult.Plan)
-	if err != nil {
-		r.Error(err)
-		return err
-	}
+		// --- Create branch once, before the first code phase ---
+		if !branchCreated {
+			b, err := deps.gh.CreateBranch(ctx, task.ID, task.Intent)
+			if err != nil {
+				r.Error(err)
+				return fmt.Errorf("creating branch: %w", err)
+			}
+			branch = b
+			r.Note("branch", branch)
+			branchCreated = true
+		}
 
-	if codeResult.Escalate {
-		gaps := lastGapsForPhase(task, state.PhaseCode)
-		r.Escalation(task.ID, state.PhaseCode, codeResult.Loops, codeResult.LastScore, gaps)
-		return deps.onEscalation(ctx, task, escalation.Result{
-			Phase:     state.PhaseCode,
-			Loops:     codeResult.Loops,
-			LastScore: codeResult.LastScore,
-			Gaps:      gaps,
-		})
-	}
+		// --- Code phase ---
+		codeResult, err := deps.code.Run(ctx, task, planResult.Plan)
+		if err != nil {
+			r.Error(err)
+			return err
+		}
 
-	// --- Commit any changes the coder made ---
-	if err := deps.commit(ctx, task); err != nil {
-		r.Error(err)
-		return err
-	}
+		if codeResult.Escalate {
+			gaps := lastGapsForPhase(task, state.PhaseCode)
+			r.Escalation(task.ID, state.PhaseCode, codeResult.Loops, codeResult.LastScore, gaps)
+			return deps.onEscalation(ctx, task, escalation.Result{
+				Phase:     state.PhaseCode,
+				Loops:     codeResult.Loops,
+				LastScore: codeResult.LastScore,
+				Gaps:      gaps,
+			})
+		}
 
-	// --- Quality phase (gates the PR) ---
-	qualityResult, err := deps.quality.Run(ctx, task, planResult.Plan, codeResult.Feedback)
-	if err != nil {
-		r.Error(err)
-		return err
-	}
+		// --- Commit any changes the coder made ---
+		if err := deps.commit(ctx, task); err != nil {
+			r.Error(err)
+			return err
+		}
 
-	if qualityResult.Escalate || qualityResult.RequeueToCode {
-		// RequeueToCode is currently treated as escalation: cross-phase
-		// routing back into the code phase is intentionally deferred to
-		// a follow-up issue (see plans/PROGRESS.md). The escalation summary
-		// includes the blocking gaps so the human knows code rework is
-		// needed.
+		// --- Quality phase (gates the PR) ---
+		qResult, err := deps.quality.Run(ctx, task, planResult.Plan, codeResult.Feedback)
+		if err != nil {
+			r.Error(err)
+			return err
+		}
+		qualityResult = qResult
+
+		if qualityResult.Pass {
+			break
+		}
+
+		// Quality failed. Route based on the judge's root-cause
+		// diagnosis. ReturnToEscalate and the judge's own Escalate flag
+		// (local loop budget exhausted) both terminate the outer loop.
+		if qualityResult.Escalate || qualityResult.ReturnTo == state.ReturnToEscalate {
+			gaps := lastGapsForPhase(task, state.PhaseQuality)
+			r.Escalation(task.ID, state.PhaseQuality, qualityResult.Loops, qualityResult.LastScore, gaps)
+			return deps.onEscalation(ctx, task, escalation.Result{
+				Phase:     state.PhaseQuality,
+				Loops:     qualityResult.Loops,
+				LastScore: qualityResult.LastScore,
+				Gaps:      gaps,
+			})
+		}
+
+		switch qualityResult.ReturnTo {
+		case state.ReturnToCode:
+			if err := task.Rewind(state.PhaseCode); err != nil {
+				r.Error(err)
+				return fmt.Errorf("rewinding to code: %w", err)
+			}
+			slog.Info("outer loop rewinding to code",
+				"task_id", task.ID, "cycle", cycle+1,
+			)
+			continue
+		case state.ReturnToPlan:
+			task.HardConstraints = append(task.HardConstraints,
+				buildQualityHardConstraints(lastVerdictForPhase(task, state.PhaseQuality))...)
+			if err := task.Rewind(state.PhasePlan); err != nil {
+				r.Error(err)
+				return fmt.Errorf("rewinding to plan: %w", err)
+			}
+			planResult = nil
+			slog.Info("outer loop rewinding to plan",
+				"task_id", task.ID, "cycle", cycle+1,
+				"hard_constraints", len(task.HardConstraints),
+			)
+			continue
+		}
+
+		// ReturnTo is empty on a non-blocking quality failure — the
+		// quality phase exhausted its own budget without finding a
+		// rewind target, so escalate.
 		gaps := lastGapsForPhase(task, state.PhaseQuality)
 		r.Escalation(task.ID, state.PhaseQuality, qualityResult.Loops, qualityResult.LastScore, gaps)
 		return deps.onEscalation(ctx, task, escalation.Result{
 			Phase:     state.PhaseQuality,
 			Loops:     qualityResult.Loops,
 			LastScore: qualityResult.LastScore,
+			Gaps:      gaps,
+		})
+	}
+
+	if qualityResult == nil || !qualityResult.Pass {
+		// Exceeded maxOuterCycles without a passing verdict — escalate.
+		gaps := lastGapsForPhase(task, state.PhaseQuality)
+		loops, lastScore := 0, 0.0
+		if qualityResult != nil {
+			loops = qualityResult.Loops
+			lastScore = qualityResult.LastScore
+		}
+		r.Escalation(task.ID, state.PhaseQuality, loops, lastScore, gaps)
+		return deps.onEscalation(ctx, task, escalation.Result{
+			Phase:     state.PhaseQuality,
+			Loops:     loops,
+			LastScore: lastScore,
 			Gaps:      gaps,
 		})
 	}
@@ -704,6 +790,32 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 	return nil
 }
 
+// buildQualityHardConstraints extracts the blocking gaps from the last
+// quality verdict and turns each into a single-line constraint for the
+// planner. The planner uses them as non-negotiable requirements on the
+// next plan — it must call out concrete steps to resolve each one.
+func buildQualityHardConstraints(v *state.Verdict) []string {
+	if v == nil {
+		return nil
+	}
+	constraints := make([]string, 0, len(v.Gaps))
+	for _, g := range v.Gaps {
+		if !g.Blocking {
+			continue
+		}
+		c := fmt.Sprintf("[quality judge, %s] %s", g.Severity, g.Description)
+		if g.File != "" {
+			if g.Line > 0 {
+				c = fmt.Sprintf("%s (ref: %s:%d)", c, g.File, g.Line)
+			} else {
+				c = fmt.Sprintf("%s (ref: %s)", c, g.File)
+			}
+		}
+		constraints = append(constraints, c)
+	}
+	return constraints
+}
+
 // dispatchEscalation routes a phase failure through the escalation module
 // without touching the process exit code. Pure-ish wrapper that exists
 // purely so escalateAndExit's behavior can be unit-tested in isolation
@@ -769,7 +881,7 @@ func runPlanPhase(ctx context.Context, cfg *config.Config, client completer, sto
 	}
 
 	emitPhaseAttempts(r, task, state.PhasePlan, cfg.Phases.Plan.MaxLoops)
-	emitPhaseDone(r, task, state.PhasePlan, result.Pass, result.Escalate, false, result.LastScore, result.Loops)
+	emitPhaseDone(r, task, state.PhasePlan, result.Pass, result.Escalate, state.ReturnToNone, result.LastScore, result.Loops)
 	return result, nil
 }
 
@@ -803,7 +915,7 @@ func runCodePhase(ctx context.Context, cfg *config.Config, store *state.Store, t
 	}
 
 	emitPhaseAttempts(r, task, state.PhaseCode, cfg.Phases.Code.MaxLoops)
-	emitPhaseDone(r, task, state.PhaseCode, result.Pass, result.Escalate, false, result.LastScore, result.Loops)
+	emitPhaseDone(r, task, state.PhaseCode, result.Pass, result.Escalate, state.ReturnToNone, result.LastScore, result.Loops)
 	return result, nil
 }
 
@@ -882,15 +994,19 @@ func emitPhaseAttempts(r ui.Renderer, task *state.Task, phase state.Phase, maxLo
 
 // emitPhaseDone emits the closing block for a phase, pulling the summary
 // and gaps from the last verdict. Outcome is derived from the phase
-// result flags.
-func emitPhaseDone(r ui.Renderer, task *state.Task, phase state.Phase, pass, escalate, requeueToCode bool, score float64, loops int) {
+// result flags; returnTo (quality phase only) selects between rewind
+// outcomes and wins over `escalate` so a ReturnToPlan shows as a
+// plan-rewind rather than a generic fail.
+func emitPhaseDone(r ui.Renderer, task *state.Task, phase state.Phase, pass, escalate bool, returnTo state.ReturnTo, score float64, loops int) {
 	outcome := ui.OutcomeFail
 	switch {
 	case pass:
 		outcome = ui.OutcomePass
-	case requeueToCode:
+	case returnTo == state.ReturnToCode:
 		outcome = ui.OutcomeRequeueToCode
-	case escalate:
+	case returnTo == state.ReturnToPlan:
+		outcome = ui.OutcomeRequeueToPlan
+	case escalate, returnTo == state.ReturnToEscalate:
 		outcome = ui.OutcomeEscalate
 	}
 	v := lastVerdictForPhase(task, phase)
@@ -980,7 +1096,7 @@ func runQualityPhase(
 	}
 
 	emitPhaseAttempts(r, task, state.PhaseQuality, cfg.Phases.Quality.MaxLoops)
-	emitPhaseDone(r, task, state.PhaseQuality, result.Pass, result.Escalate, result.RequeueToCode, result.LastScore, result.Loops)
+	emitPhaseDone(r, task, state.PhaseQuality, result.Pass, result.Escalate, result.ReturnTo, result.LastScore, result.Loops)
 
 	return result, nil
 }

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -373,23 +373,27 @@ func TestEmitPhaseDone_OutcomeMapping(t *testing.T) {
 	}
 
 	cases := []struct {
-		name          string
-		pass          bool
-		escalate      bool
-		requeueToCode bool
-		want          ui.PhaseOutcome
+		name     string
+		pass     bool
+		escalate bool
+		returnTo state.ReturnTo
+		want     ui.PhaseOutcome
 	}{
-		{"pass", true, false, false, ui.OutcomePass},
-		{"fail", false, false, false, ui.OutcomeFail},
-		{"escalate", false, true, false, ui.OutcomeEscalate},
-		{"requeue_to_code", false, false, true, ui.OutcomeRequeueToCode},
-		// requeue_to_code wins over escalate when both are set
-		{"requeue_before_escalate", false, true, true, ui.OutcomeRequeueToCode},
+		{"pass", true, false, state.ReturnToNone, ui.OutcomePass},
+		{"fail", false, false, state.ReturnToNone, ui.OutcomeFail},
+		{"escalate", false, true, state.ReturnToNone, ui.OutcomeEscalate},
+		{"return_to_code", false, false, state.ReturnToCode, ui.OutcomeRequeueToCode},
+		{"return_to_plan", false, false, state.ReturnToPlan, ui.OutcomeRequeueToPlan},
+		{"return_to_escalate", false, false, state.ReturnToEscalate, ui.OutcomeEscalate},
+		// rewind wins over the escalate flag when both are set — a
+		// plan-level diagnosis outranks "local loops exhausted" because
+		// retrying the same phase would just reproduce the failure.
+		{"rewind_before_escalate", false, true, state.ReturnToPlan, ui.OutcomeRequeueToPlan},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &fakeRenderer{}
-			emitPhaseDone(r, task, state.PhasePlan, tc.pass, tc.escalate, tc.requeueToCode, 92, 1)
+			emitPhaseDone(r, task, state.PhasePlan, tc.pass, tc.escalate, tc.returnTo, 92, 1)
 			if len(r.dones) != 1 {
 				t.Fatalf("expected 1 done event, got %d", len(r.dones))
 			}
@@ -410,7 +414,7 @@ func TestEmitPhaseDone_NoVerdictEmitsEmpty(t *testing.T) {
 	task := state.NewTask("t-1", "intent")
 	r := &fakeRenderer{}
 
-	emitPhaseDone(r, task, state.PhasePlan, false, true, false, 0, 3)
+	emitPhaseDone(r, task, state.PhasePlan, false, true, state.ReturnToNone, 0, 3)
 
 	if len(r.dones) != 1 {
 		t.Fatalf("expected 1 done event, got %d", len(r.dones))
@@ -449,66 +453,227 @@ func TestDispatchEscalation_AlreadyEscalatedNoOp(t *testing.T) {
 	}
 }
 
+func TestBuildQualityHardConstraints_OnlyBlockingGaps(t *testing.T) {
+	// HardConstraints are what the planner must satisfy on the next
+	// cycle — non-blocking observations would dilute that signal, so
+	// the builder must filter them out.
+	v := &state.Verdict{
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP0, Description: "critical gap", Blocking: true},
+			{Severity: state.SeverityP1, Description: "another gap", Blocking: true, File: "foo.go", Line: 42},
+			{Severity: state.SeverityP3, Description: "just a nit", Blocking: false},
+		},
+	}
+	got := buildQualityHardConstraints(v)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 blocking constraints, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "P0") || !strings.Contains(got[0], "critical gap") {
+		t.Errorf("first constraint should carry severity + description, got %q", got[0])
+	}
+	// File/line anchor should be preserved so the planner can reference
+	// the specific site the quality judge flagged.
+	if !strings.Contains(got[1], "foo.go") || !strings.Contains(got[1], "42") {
+		t.Errorf("second constraint should carry file:line anchor, got %q", got[1])
+	}
+}
+
+func TestBuildQualityHardConstraints_NilVerdict(t *testing.T) {
+	if got := buildQualityHardConstraints(nil); got != nil {
+		t.Errorf("nil verdict should yield no constraints, got %v", got)
+	}
+}
+
 // --- Orchestration test fakes ---
+//
+// Each fake runner supports a default single-result mode (via `result`
+// and `gaps`) and a sequential mode (via `results` + `gapsByCall`) so
+// rewind tests can assert that a phase returns different outcomes across
+// outer cycles. `calls` is incremented on every invocation; when
+// `results` is set, the i-th call returns results[i], falling back to
+// the last entry once exhausted.
 
 type fakePlanRunner struct {
-	result *planphase.PhaseResult
-	gaps   []state.Gap
-	err    error
-	called bool
+	result     *planphase.PhaseResult
+	gaps       []state.Gap
+	results    []*planphase.PhaseResult
+	gapsByCall [][]state.Gap
+	err        error
+	called     bool
+	calls      int
+	lastTask   *state.Task
 }
 
 func (f *fakePlanRunner) Run(_ context.Context, task *state.Task) (*planphase.PhaseResult, error) {
 	f.called = true
-	if f.result != nil {
+	f.calls++
+	f.lastTask = task
+	result, gaps := f.pick()
+	if result != nil {
+		// Mimic the production plan phase's state transitions so the
+		// state machine stays realistic across rewind-driven calls.
+		advancePhaseState(task, state.PhasePlan, result.Pass, result.Escalate)
 		task.Attempts = append(task.Attempts, state.Attempt{
-			Phase: state.PhasePlan, Loop: f.result.Loops,
-			Verdict: &state.Verdict{Score: f.result.LastScore, Pass: f.result.Pass, Gaps: f.gaps},
+			Phase: state.PhasePlan, Loop: result.Loops,
+			Verdict: &state.Verdict{Score: result.LastScore, Pass: result.Pass, Gaps: gaps},
 		})
 	}
-	return f.result, f.err
+	return result, f.err
+}
+
+func (f *fakePlanRunner) pick() (*planphase.PhaseResult, []state.Gap) {
+	if len(f.results) > 0 {
+		idx := f.calls - 1
+		if idx >= len(f.results) {
+			idx = len(f.results) - 1
+		}
+		var g []state.Gap
+		if idx < len(f.gapsByCall) {
+			g = f.gapsByCall[idx]
+		}
+		return f.results[idx], g
+	}
+	return f.result, f.gaps
 }
 
 type fakeCodeRunner struct {
-	result *codephase.PhaseResult
-	gaps   []state.Gap
-	err    error
-	called bool
-	plan   string
+	result     *codephase.PhaseResult
+	gaps       []state.Gap
+	results    []*codephase.PhaseResult
+	gapsByCall [][]state.Gap
+	err        error
+	called     bool
+	calls      int
+	plan       string
+	plans      []string
 }
 
 func (f *fakeCodeRunner) Run(_ context.Context, task *state.Task, plan string) (*codephase.PhaseResult, error) {
 	f.called = true
+	f.calls++
 	f.plan = plan
-	if f.result != nil {
+	f.plans = append(f.plans, plan)
+	result, gaps := f.pick()
+	if result != nil {
+		advancePhaseState(task, state.PhaseCode, result.Pass, result.Escalate)
 		task.Attempts = append(task.Attempts, state.Attempt{
-			Phase: state.PhaseCode, Loop: f.result.Loops,
-			Verdict: &state.Verdict{Score: f.result.LastScore, Pass: f.result.Pass, Gaps: f.gaps},
+			Phase: state.PhaseCode, Loop: result.Loops,
+			Verdict: &state.Verdict{Score: result.LastScore, Pass: result.Pass, Gaps: gaps},
 		})
 	}
-	return f.result, f.err
+	return result, f.err
+}
+
+func (f *fakeCodeRunner) pick() (*codephase.PhaseResult, []state.Gap) {
+	if len(f.results) > 0 {
+		idx := f.calls - 1
+		if idx >= len(f.results) {
+			idx = len(f.results) - 1
+		}
+		var g []state.Gap
+		if idx < len(f.gapsByCall) {
+			g = f.gapsByCall[idx]
+		}
+		return f.results[idx], g
+	}
+	return f.result, f.gaps
 }
 
 type fakeQualityRunner struct {
-	result    *qualityphase.PhaseResult
-	gaps      []state.Gap
-	err       error
-	called    bool
-	plan      string
-	codeFacts string
+	result     *qualityphase.PhaseResult
+	gaps       []state.Gap
+	results    []*qualityphase.PhaseResult
+	gapsByCall [][]state.Gap
+	err        error
+	called     bool
+	calls      int
+	plan       string
+	plans      []string
+	codeFacts  string
 }
 
 func (f *fakeQualityRunner) Run(_ context.Context, task *state.Task, plan string, codeFacts string) (*qualityphase.PhaseResult, error) {
 	f.called = true
+	f.calls++
 	f.plan = plan
+	f.plans = append(f.plans, plan)
 	f.codeFacts = codeFacts
-	if f.result != nil {
+	result, gaps := f.pick()
+	if result != nil {
+		// Quality phase advances into QualityReview on entry; on pass
+		// it goes to Done, on failure it stays in QualityReview so the
+		// orchestrator can Rewind from there.
+		escalate := result.Escalate
+		advancePhaseState(task, state.PhaseQuality, result.Pass, escalate)
 		task.Attempts = append(task.Attempts, state.Attempt{
-			Phase: state.PhaseQuality, Loop: f.result.Loops,
-			Verdict: &state.Verdict{Score: f.result.LastScore, Pass: f.result.Pass, Gaps: f.gaps},
+			Phase: state.PhaseQuality, Loop: result.Loops,
+			Verdict: &state.Verdict{
+				Score: result.LastScore, Pass: result.Pass, Gaps: gaps,
+				ReturnTo: result.ReturnTo,
+			},
 		})
 	}
-	return f.result, f.err
+	return result, f.err
+}
+
+// advancePhaseState mimics the state transitions that the production
+// phase runners apply as they progress. The orchestration tests never
+// exercise the real producer agents, so the fakes handle state machine
+// bookkeeping themselves to keep tests grounded in realistic state.
+func advancePhaseState(task *state.Task, phase state.Phase, pass, escalate bool) {
+	switch phase {
+	case state.PhasePlan:
+		if task.State == state.StatePending {
+			_ = task.Transition(state.StatePlanning)
+		}
+		if task.State == state.StatePlanning {
+			_ = task.Transition(state.StatePlanReview)
+		}
+		if escalate {
+			_ = task.Transition(state.StateEscalated)
+			return
+		}
+		if pass && task.State == state.StatePlanReview {
+			_ = task.Transition(state.StateCoding)
+		}
+	case state.PhaseCode:
+		if task.State == state.StateCoding {
+			_ = task.Transition(state.StateCodeReview)
+		}
+		if escalate {
+			_ = task.Transition(state.StateEscalated)
+			return
+		}
+		if pass && task.State == state.StateCodeReview {
+			_ = task.Transition(state.StateQuality)
+		}
+	case state.PhaseQuality:
+		if task.State == state.StateQuality {
+			_ = task.Transition(state.StateQualityReview)
+		}
+		if escalate {
+			_ = task.Transition(state.StateEscalated)
+			return
+		}
+		if pass && task.State == state.StateQualityReview {
+			_ = task.Transition(state.StateDone)
+		}
+	}
+}
+
+func (f *fakeQualityRunner) pick() (*qualityphase.PhaseResult, []state.Gap) {
+	if len(f.results) > 0 {
+		idx := f.calls - 1
+		if idx >= len(f.results) {
+			idx = len(f.results) - 1
+		}
+		var g []state.Gap
+		if idx < len(f.gapsByCall) {
+			g = f.gapsByCall[idx]
+		}
+		return f.results[idx], g
+	}
+	return f.result, f.gaps
 }
 
 type fakeGHOrch struct {
@@ -730,11 +895,108 @@ func TestRunOrchestration_QualityEscalates(t *testing.T) {
 	}
 }
 
-func TestRunOrchestration_QualityRequeueToCode(t *testing.T) {
+func TestRunOrchestration_QualityReturnToCode_RetriesAndPasses(t *testing.T) {
 	t.Parallel()
+	// Cycle 1: quality says ReturnTo=code. The outer loop rewinds, the
+	// code phase runs again, then quality passes on cycle 2.
 	b := newOrchBundle()
-	b.quality.result = &qualityphase.PhaseResult{RequeueToCode: true, Loops: 2, LastScore: 50}
-	b.quality.gaps = []state.Gap{{Severity: state.SeverityP0, Description: "code broken", Blocking: true}}
+	b.quality.results = []*qualityphase.PhaseResult{
+		{ReturnTo: state.ReturnToCode, Loops: 1, LastScore: 50, Diff: "diff-1"},
+		{Pass: true, Loops: 1, LastScore: 95, Diff: "diff-2"},
+	}
+	b.quality.gapsByCall = [][]state.Gap{
+		{{Severity: state.SeverityP0, Description: "code broken", Blocking: true}},
+		nil,
+	}
+	b.code.results = []*codephase.PhaseResult{
+		{Pass: true, Loops: 1, LastScore: 100},
+		{Pass: true, Loops: 1, LastScore: 100},
+	}
+	task := state.NewTask("t-1", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.escalationCalled {
+		t.Error("should not escalate — quality passed on cycle 2")
+	}
+	if b.code.calls != 2 {
+		t.Errorf("code should have run twice (once per cycle), got %d calls", b.code.calls)
+	}
+	if b.quality.calls != 2 {
+		t.Errorf("quality should have run twice, got %d calls", b.quality.calls)
+	}
+	if b.plan.calls != 1 {
+		t.Errorf("plan should run once — rewind was to code, not plan; got %d", b.plan.calls)
+	}
+	if !b.gh.prCalled {
+		t.Error("PR should be created after quality passes")
+	}
+	if b.gh.verdictDiff != "diff-2" {
+		t.Errorf("PostVerdictWithDiff should receive the latest cycle's diff, got %q", b.gh.verdictDiff)
+	}
+}
+
+func TestRunOrchestration_QualityReturnToPlan_Replans(t *testing.T) {
+	t.Parallel()
+	// Cycle 1: quality rewinds to plan with a blocking P0 gap. The
+	// orchestrator must: (a) call plan again, (b) inject the quality
+	// gap as a HardConstraint before the replanning, (c) let the
+	// following code+quality pass.
+	b := newOrchBundle()
+	b.plan.results = []*planphase.PhaseResult{
+		{Pass: true, Loops: 1, LastScore: 90, Plan: "plan v1"},
+		{Pass: true, Loops: 1, LastScore: 92, Plan: "plan v2"},
+	}
+	b.quality.results = []*qualityphase.PhaseResult{
+		{ReturnTo: state.ReturnToPlan, Loops: 1, LastScore: 30, Diff: "diff-1"},
+		{Pass: true, Loops: 1, LastScore: 95, Diff: "diff-2"},
+	}
+	b.quality.gapsByCall = [][]state.Gap{
+		{{Severity: state.SeverityP0, Description: "plan too narrow", Blocking: true}},
+		nil,
+	}
+	task := state.NewTask("t-rewind-plan", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.plan.calls != 2 {
+		t.Errorf("plan should run twice (once + rewind), got %d", b.plan.calls)
+	}
+	if b.code.calls != 2 {
+		t.Errorf("code should run twice, got %d", b.code.calls)
+	}
+	if len(task.HardConstraints) == 0 {
+		t.Fatal("expected task.HardConstraints populated from quality verdict")
+	}
+	joined := strings.Join(task.HardConstraints, "\n")
+	if !strings.Contains(joined, "plan too narrow") {
+		t.Errorf("expected quality gap description in HardConstraints, got %v", task.HardConstraints)
+	}
+	// Second code call must see the replanned plan.
+	if len(b.code.plans) < 2 || b.code.plans[1] != "plan v2" {
+		t.Errorf("code's second invocation should receive replanned plan, got plans=%v", b.code.plans)
+	}
+	if !b.gh.prCalled {
+		t.Error("PR should be created after replan+quality pass")
+	}
+}
+
+func TestRunOrchestration_QualityReturnToEscalate(t *testing.T) {
+	t.Parallel()
+	// ReturnTo=escalate stops the loop immediately — no rewind.
+	b := newOrchBundle()
+	b.quality.result = &qualityphase.PhaseResult{
+		ReturnTo: state.ReturnToEscalate,
+		Escalate: true,
+		Loops:    1, LastScore: 10,
+	}
+	b.quality.gaps = []state.Gap{{Severity: state.SeverityP0, Description: "intent ambiguous", Blocking: true}}
 	task := state.NewTask("t-1", "intent")
 	r := &fakeRenderer{}
 
@@ -746,8 +1008,40 @@ func TestRunOrchestration_QualityRequeueToCode(t *testing.T) {
 	if b.escalationResult.Phase != state.PhaseQuality {
 		t.Errorf("escalation phase = %s, want quality", b.escalationResult.Phase)
 	}
+	if b.code.calls != 1 {
+		t.Errorf("code should only run once before escalate, got %d", b.code.calls)
+	}
 	if b.gh.prCalled {
-		t.Error("PR should not be created on requeue")
+		t.Error("PR should not be created on escalate")
+	}
+}
+
+func TestRunOrchestration_CycleBudgetExhausted(t *testing.T) {
+	t.Parallel()
+	// Every cycle's quality says ReturnTo=code. After maxOuterCycles
+	// the orchestrator escalates rather than looping forever.
+	b := newOrchBundle()
+	b.quality.result = &qualityphase.PhaseResult{
+		ReturnTo: state.ReturnToCode,
+		Loops:    1, LastScore: 40,
+	}
+	b.quality.gaps = []state.Gap{{Severity: state.SeverityP0, Description: "still broken", Blocking: true}}
+	task := state.NewTask("t-budget", "intent")
+	r := &fakeRenderer{}
+
+	err := runOrchestration(context.Background(), b.deps(), task, r)
+
+	if !errors.Is(err, errEscalated) {
+		t.Fatalf("expected errEscalated after cycle budget exhausted, got %v", err)
+	}
+	if b.code.calls != maxOuterCycles {
+		t.Errorf("code should run maxOuterCycles (%d) times, got %d", maxOuterCycles, b.code.calls)
+	}
+	if b.quality.calls != maxOuterCycles {
+		t.Errorf("quality should run maxOuterCycles (%d) times, got %d", maxOuterCycles, b.quality.calls)
+	}
+	if b.gh.prCalled {
+		t.Error("PR should not be created when cycle budget is exhausted")
 	}
 }
 

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -254,6 +254,33 @@ exact sub-section headers (omit a section if empty), with "- " bullet items:
 
 Keep each bullet to one line. Do not include any other sections or prose.
 
+## Root-cause diagnosis (return_to)
+
+On a FAILING verdict you MUST set "return_to" so the outer loop can rewind
+to the phase that can actually fix it. Diagnose the root cause, not the
+symptom:
+
+- "code" — the plan is fine but the code doesn't realise it. Tests fail,
+  acceptance criteria aren't met, the diff implements something other
+  than what the plan called for, a bug slipped in. Re-running the code
+  phase can fix it.
+- "plan" — the code faithfully implements the plan, but the plan itself
+  was too shallow to catch this class of problem (missing a requirement,
+  wrong architecture, no handling for a whole category of input). A
+  code retry against the same plan will reproduce the failure. The
+  quality failure will be injected as a hard constraint into replanning.
+- "escalate" — the task intent is fundamentally ambiguous or requires
+  judgement this process cannot make. Neither replanning nor recoding
+  can resolve it without human input.
+
+On a PASSING verdict, omit "return_to" or set it to "". Never set
+"return_to" to a value that is not one of {code, plan, escalate, ""}.
+
+If a failing verdict has only non-blocking (P2/P3) gaps, it may get
+another in-phase retry; in that case omit "return_to" or set it to "".
+If ANY gap is P0 or P1 blocking, "return_to" must be one of code/plan/
+escalate.
+
 ## Output rules
 
 1. Each concern goes in EXACTLY ONE array — either "gaps" or "questions", never both.
@@ -294,7 +321,8 @@ submit_verdict input:
     {"severity": "P2", "description": "queryHelpers.go now has 6 near-identical 'WHERE tenant_id = ?' clauses — extract a tenantScope() helper once a second table needs the same pattern.", "file": "internal/db/queryHelpers.go", "line": 18},
     {"severity": "P3", "description": "Tenant is threaded through function signatures rather than context.Context; fine for now, but as the set of tenant-scoped calls grows, context propagation will reduce parameter churn."}
   ],
-  "questions": []
+  "questions": [],
+  "return_to": ""
 }
 
 Note: on a substantive diff, 2–3 design observations (P3/P2) is normal —
@@ -315,8 +343,12 @@ submit_verdict input:
     {"severity": "P0", "description": "No authentication middleware on /admin — intent requires basic auth."},
     {"severity": "P1", "description": "Hardcoded API key in source (apiKey = 'sk-live-...'). Move to environment variable.", "file": "cmd/admin/main.go", "line": 14, "suggestion": "\tapiKey := os.Getenv(\"ADMIN_API_KEY\")"}
   ],
-  "questions": []
+  "questions": [],
+  "return_to": "code"
 }
+
+Note: return_to is "code" because the plan called for basic auth — the
+code just didn't wire it. A code retry against the same plan can fix it.
 
 ### Example 3 — mistake to avoid: flagging a symbol that is not in the diff
 
@@ -346,8 +378,34 @@ CORRECT submit_verdict for this diff:
 {
   "summary": "## Reviewed\n- runSingleTask invocation wired into the new scheduler path",
   "gaps": [],
-  "questions": []
-}`
+  "questions": [],
+  "return_to": ""
+}
+
+### Example 4 — rewind to plan (root cause is plan-level)
+
+Intent: "Add basic auth to the admin endpoint. Must protect every
+admin route."
+Plan (abridged): "1. Wrap /admin with a basic-auth handler."
+Facts: tests pass, lint clean, build ok.
+Diff (abridged): correctly wraps /admin with basic-auth middleware.
+But the repo also exposes /admin/users and /admin/logs under separate
+handlers that are NOT covered by the wrapper.
+
+submit_verdict input:
+{
+  "summary": "## Reviewed\n- /admin wrap is correct\n## Notes\n- /admin/users and /admin/logs are unprotected sibling routes",
+  "gaps": [
+    {"severity": "P0", "description": "Plan only covered /admin, but the intent says 'every admin route' — /admin/users and /admin/logs remain unauthenticated. The plan is too narrow to satisfy the intent."}
+  ],
+  "questions": [],
+  "return_to": "plan"
+}
+
+Note: return_to is "plan" — the code correctly implemented the plan, but
+the plan itself missed the scope. Re-running code against the same plan
+would just re-produce the same gap. Replanning with the intent re-read
+will add the missing routes.`
 
 // systemPrompt is the quality judge system prompt with the non-negotiable
 // engineering standards appended. Baseline rules reach the judge so it
@@ -391,6 +449,7 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 	}
 	verdict.Score = verdictschema.ComputeScore(verdict.Gaps)
 	verdict.Pass = verdict.Score >= PassThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
+	verdict.ReturnTo = normaliseReturnTo(verdict.ReturnTo, verdict.Pass, verdict.Gaps)
 
 	slog.Info("quality judge verdict",
 		"score", verdict.Score,
@@ -452,6 +511,34 @@ func (j *QualityJudge) runE2E(ctx context.Context, workDir string) *state.Gap {
 
 	slog.Debug("e2e tests passed")
 	return nil
+}
+
+// normaliseReturnTo clamps the LLM-supplied ReturnTo to a sane value given
+// the final (deterministic) verdict shape. The LLM emits ReturnTo as a
+// best-effort diagnosis, but scoring and blocking are decided here — so
+// we enforce the invariants the outer loop relies on:
+//
+//   - A passing verdict never rewinds; clear ReturnTo.
+//   - A failing verdict with a blocking gap (P0/P1) must rewind. If the
+//     LLM forgot to set ReturnTo we default to ReturnToCode — that matches
+//     the pre-ReturnTo heuristic (see the removed needsCodeRework) and is
+//     the safer default: code retries are cheaper than replans.
+//   - Unknown values collapse to code for the same reason.
+//
+// Non-blocking failures (score below threshold but no P0/P1) keep an
+// empty ReturnTo so the quality phase can retry in-place.
+func normaliseReturnTo(in state.ReturnTo, pass bool, gaps []state.Gap) state.ReturnTo {
+	if pass {
+		return state.ReturnToNone
+	}
+	switch in {
+	case state.ReturnToCode, state.ReturnToPlan, state.ReturnToEscalate:
+		return in
+	}
+	if verdictschema.HasBlockingGap(gaps) {
+		return state.ReturnToCode
+	}
+	return state.ReturnToNone
 }
 
 func truncate(s string, max int) string {

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -781,6 +781,155 @@ func TestJudge_SystemPromptMentionsCheckPath(t *testing.T) {
 	}
 }
 
+func TestJudge_ReturnTo_ClearedOnPass(t *testing.T) {
+	// Even if the LLM erroneously emits a ReturnTo on a passing verdict
+	// (e.g. leftover from a previous response), the judge must clear it
+	// — a passing verdict never rewinds.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps:     []state.Gap{},
+			ReturnTo: state.ReturnToCode,
+		},
+	}
+	judge := New(fake, nil, testConfig())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Pass {
+		t.Fatal("expected pass")
+	}
+	if verdict.ReturnTo != state.ReturnToNone {
+		t.Errorf("ReturnTo must be cleared on passing verdict, got %q", verdict.ReturnTo)
+	}
+}
+
+func TestJudge_ReturnTo_Propagated(t *testing.T) {
+	cases := []struct {
+		name string
+		in   state.ReturnTo
+	}{
+		{"code", state.ReturnToCode},
+		{"plan", state.ReturnToPlan},
+		{"escalate", state.ReturnToEscalate},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &claude.FakeClient{
+				Response: state.Verdict{
+					Gaps: []state.Gap{
+						{Severity: state.SeverityP0, Description: "failing"},
+					},
+					ReturnTo: tc.in,
+				},
+			}
+			judge := New(fake, nil, testConfig())
+			verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if verdict.Pass {
+				t.Error("expected fail with P0 gap")
+			}
+			if verdict.ReturnTo != tc.in {
+				t.Errorf("ReturnTo = %q, want %q", verdict.ReturnTo, tc.in)
+			}
+		})
+	}
+}
+
+func TestJudge_ReturnTo_DefaultsToCodeOnBlockingFailure(t *testing.T) {
+	// The LLM may forget to emit ReturnTo. For a blocking failure we
+	// default to ReturnToCode — the pre-#87 heuristic was to route every
+	// P0/P1 blocking failure back to code, so that's the safest default.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP1, Description: "bug"},
+			},
+			// ReturnTo deliberately empty.
+		},
+	}
+	judge := New(fake, nil, testConfig())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Pass {
+		t.Error("expected fail with blocking P1 gap")
+	}
+	if verdict.ReturnTo != state.ReturnToCode {
+		t.Errorf("ReturnTo default on blocking failure = %q, want code", verdict.ReturnTo)
+	}
+}
+
+func TestJudge_ReturnTo_EmptyForNonBlockingFailure(t *testing.T) {
+	// Non-blocking-but-failing verdict (score dragged below threshold
+	// by P2s) should not request a cross-phase rewind — the quality
+	// phase can retry in place.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP2, Description: "a"},
+				{Severity: state.SeverityP2, Description: "b"},
+				{Severity: state.SeverityP2, Description: "c"},
+				{Severity: state.SeverityP2, Description: "d"},
+			},
+		},
+	}
+	judge := New(fake, nil, testConfig())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Pass {
+		t.Error("expected fail with accumulated P2s")
+	}
+	if verdict.ReturnTo != state.ReturnToNone {
+		t.Errorf("ReturnTo on non-blocking failure should be empty, got %q", verdict.ReturnTo)
+	}
+}
+
+func TestJudge_ReturnTo_UnknownValueCollapsesToCode(t *testing.T) {
+	// Defensive normalisation: if the LLM emits a value outside the
+	// enum (e.g. a typo), treat it as the safe default for a blocking
+	// failure rather than passing it through and surprising the
+	// orchestrator with an unhandled route.
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP0, Description: "bug"},
+			},
+			ReturnTo: state.ReturnTo("rewrite"),
+		},
+	}
+	judge := New(fake, nil, testConfig())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.ReturnTo != state.ReturnToCode {
+		t.Errorf("unknown ReturnTo should collapse to code, got %q", verdict.ReturnTo)
+	}
+}
+
+func TestJudge_SystemPromptExplainsReturnTo(t *testing.T) {
+	// The prompt must instruct the LLM to diagnose the root cause and
+	// emit ReturnTo — otherwise the whole cross-phase rewind machinery
+	// cannot kick in.
+	for _, needle := range []string{
+		"return_to",
+		"\"code\"",
+		"\"plan\"",
+		"\"escalate\"",
+		"root cause",
+	} {
+		if !strings.Contains(systemPrompt, needle) {
+			t.Errorf("system prompt missing ReturnTo instruction %q", needle)
+		}
+	}
+}
+
 func TestJudge_UsesCompleteWithTools(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{Gaps: []state.Gap{}},

--- a/internal/judges/verdictschema/schema.go
+++ b/internal/judges/verdictschema/schema.go
@@ -58,6 +58,11 @@ const inputSchema = `{
         "required": ["text", "priority"],
         "additionalProperties": false
       }
+    },
+    "return_to": {
+      "type": "string",
+      "enum": ["", "code", "plan", "escalate"],
+      "description": "Quality-judge-only. On a failing verdict, the phase the outer loop should rewind to. Omit or leave empty on passing verdicts and on judges that do not drive cross-phase routing."
     }
   },
   "required": ["summary", "gaps", "questions"],

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -102,7 +102,7 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 		}
 
 		// Build the planner prompt.
-		prompt := buildPlannerPrompt(task.Intent, lastFeedback, task.Assumptions)
+		prompt := buildPlannerPrompt(task.Intent, lastFeedback, task.Assumptions, task.HardConstraints)
 
 		// Call the planner agent.
 		var resp plannerResponse
@@ -215,12 +215,21 @@ func (p *PlanPhase) processGaps(task *state.Task, gaps []state.Gap) {
 }
 
 // buildPlannerPrompt constructs the prompt for the planner agent.
-func buildPlannerPrompt(intent string, feedback string, assumptions []state.Assumption) string {
+func buildPlannerPrompt(intent string, feedback string, assumptions []state.Assumption, hardConstraints []string) string {
 	var b strings.Builder
 
 	b.WriteString("## Task Intent\n")
 	b.WriteString(intent)
 	b.WriteString("\n")
+
+	if len(hardConstraints) > 0 {
+		b.WriteString("\n## Hard Constraints (non-negotiable)\n")
+		b.WriteString("These were identified by the quality judge on a previous outer cycle. ")
+		b.WriteString("Your new plan MUST address each one — acknowledging is not enough, the plan must call out concrete steps that resolve them:\n")
+		for _, c := range hardConstraints {
+			fmt.Fprintf(&b, "- %s\n", c)
+		}
+	}
 
 	if feedback != "" {
 		b.WriteString("\n## Previous Attempt Feedback\n")

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -508,7 +508,7 @@ func TestPlanPhase_ContextCancellation(t *testing.T) {
 }
 
 func TestBuildPlannerPrompt_NoFeedback(t *testing.T) {
-	prompt := buildPlannerPrompt("build an API", "", nil)
+	prompt := buildPlannerPrompt("build an API", "", nil, nil)
 
 	if !strings.Contains(prompt, "## Task Intent") {
 		t.Error("expected intent header")
@@ -522,10 +522,13 @@ func TestBuildPlannerPrompt_NoFeedback(t *testing.T) {
 	if strings.Contains(prompt, "Assumptions") {
 		t.Error("did not expect assumptions section")
 	}
+	if strings.Contains(prompt, "Hard Constraints") {
+		t.Error("did not expect hard-constraints section")
+	}
 }
 
 func TestBuildPlannerPrompt_WithFeedback(t *testing.T) {
-	prompt := buildPlannerPrompt("build an API", "missing auth", nil)
+	prompt := buildPlannerPrompt("build an API", "missing auth", nil, nil)
 
 	if !strings.Contains(prompt, "Previous Attempt Feedback") {
 		t.Error("expected feedback section")
@@ -539,13 +542,34 @@ func TestBuildPlannerPrompt_WithAssumptions(t *testing.T) {
 	assumptions := []state.Assumption{
 		{Description: "using PostgreSQL", Severity: state.SeverityP2, Phase: state.PhasePlan},
 	}
-	prompt := buildPlannerPrompt("build an API", "some feedback", assumptions)
+	prompt := buildPlannerPrompt("build an API", "some feedback", assumptions, nil)
 
 	if !strings.Contains(prompt, "Assumptions from Previous Loops") {
 		t.Error("expected assumptions section")
 	}
 	if !strings.Contains(prompt, "using PostgreSQL") {
 		t.Error("expected assumption in prompt")
+	}
+}
+
+func TestBuildPlannerPrompt_WithHardConstraints(t *testing.T) {
+	// When rewinding to plan, the quality judge's failing gaps are
+	// forwarded as hard constraints — the planner must address each one
+	// concretely, not just acknowledge it.
+	constraints := []string{
+		"[quality judge, P0] /admin/users is not protected by auth middleware",
+		"[quality judge, P1] /admin/logs bypasses the same middleware",
+	}
+	prompt := buildPlannerPrompt("build an API", "", nil, constraints)
+
+	if !strings.Contains(prompt, "Hard Constraints") {
+		t.Error("expected hard constraints section")
+	}
+	if !strings.Contains(prompt, "non-negotiable") {
+		t.Error("expected 'non-negotiable' framing so the planner doesn't treat constraints as optional")
+	}
+	if !strings.Contains(prompt, "/admin/users") || !strings.Contains(prompt, "/admin/logs") {
+		t.Error("expected every constraint to be rendered as its own bullet")
 	}
 }
 

--- a/internal/phases/quality/phase.go
+++ b/internal/phases/quality/phase.go
@@ -15,17 +15,21 @@ import (
 
 // PhaseResult is the typed output of a quality phase run.
 //
-// Exactly one of Pass, RequeueToCode, or Escalate is true on a successful
-// (non-error) return. RequeueToCode signals the orchestrator to route the
-// task back to the code phase because the failing gaps cannot be resolved
-// by re-judging the same workdir.
+// On a successful (non-error) return exactly one of these is true:
+//   - Pass: verdict met the threshold; advance to PR creation.
+//   - Escalate: local max-loops exhausted and the verdict can't be routed
+//     elsewhere. The orchestrator still consults ReturnTo so an
+//     explicit ReturnToEscalate from the judge is honoured.
+//   - ReturnTo != "": cross-phase rewind. The orchestrator routes the
+//     task back to ReturnToCode or ReturnToPlan (and starts a new outer
+//     cycle) or escalates if ReturnToEscalate.
 type PhaseResult struct {
-	Pass          bool
-	Escalate      bool
-	RequeueToCode bool
-	Loops         int
-	LastScore     float64
-	Feedback      string
+	Pass      bool
+	Escalate  bool
+	ReturnTo  state.ReturnTo
+	Loops     int
+	LastScore float64
+	Feedback  string
 	// Diff is the unified diff the judge evaluated. The orchestrator
 	// threads it through to PostVerdictWithDiff so gaps with file/line
 	// can be rendered as inline PR review comments (#72).
@@ -120,23 +124,29 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 
 		lastFeedback = buildQualityFeedback(verdict)
 
-		// Code-level gaps cannot be resolved by re-judging the same workdir.
-		// Stop looping inside quality and signal cross-phase routing back
-		// to the code phase. The orchestrator (cmd/vairdict/run.go) is
-		// responsible for actually moving the task back.
-		if needsCodeRework(verdict) {
-			slog.Info("quality phase requeue to code",
+		// Cross-phase rewind: the quality judge's ReturnTo diagnoses
+		// whether the failure is a code-, plan-, or intent-level problem.
+		// Re-judging the same workdir can't fix any of those — stop
+		// looping inside quality and let the orchestrator route the task
+		// to the right phase (or escalate on ReturnToEscalate).
+		if verdict.ReturnTo != state.ReturnToNone {
+			slog.Info("quality phase rewind requested",
 				"task_id", task.ID,
 				"loops", loop+1,
 				"last_score", lastScore,
+				"return_to", string(verdict.ReturnTo),
 			)
-			return &PhaseResult{
-				RequeueToCode: true,
-				Loops:         loop + 1,
-				LastScore:     lastScore,
-				Feedback:      lastFeedback,
-				Diff:          p.diff,
-			}, nil
+			res := &PhaseResult{
+				ReturnTo:  verdict.ReturnTo,
+				Loops:     loop + 1,
+				LastScore: lastScore,
+				Feedback:  lastFeedback,
+				Diff:      p.diff,
+			}
+			if verdict.ReturnTo == state.ReturnToEscalate {
+				res.Escalate = true
+			}
+			return res, nil
 		}
 
 		if err := task.Requeue(p.cfg.MaxLoops); err != nil {
@@ -165,21 +175,6 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 		Feedback:  lastFeedback,
 		Diff:      p.diff,
 	}, nil
-}
-
-// needsCodeRework returns true if any blocking gap indicates a code-level
-// problem (intent mismatch or missing/broken feature). These cannot be fixed
-// by re-judging the same workdir — only by re-running the code phase.
-func needsCodeRework(v *state.Verdict) bool {
-	for _, g := range v.Gaps {
-		if !g.Blocking {
-			continue
-		}
-		if g.Severity == state.SeverityP0 || g.Severity == state.SeverityP1 {
-			return true
-		}
-	}
-	return false
 }
 
 func buildQualityFeedback(v *state.Verdict) string {

--- a/internal/phases/quality/phase_test.go
+++ b/internal/phases/quality/phase_test.go
@@ -118,7 +118,10 @@ func TestRun_PassOnRetry_NonBlockingGaps(t *testing.T) {
 	}
 }
 
-func TestRun_RequeueToCode_OnP0Gap(t *testing.T) {
+func TestRun_ReturnToCode_OnP0Gap(t *testing.T) {
+	// The LLM diagnoses a code-level root cause via ReturnTo=code. The
+	// phase forwards it to the orchestrator rather than escalating or
+	// looping within quality.
 	judge := &fakeJudge{verdicts: []*state.Verdict{
 		{
 			Score: 30,
@@ -126,6 +129,7 @@ func TestRun_RequeueToCode_OnP0Gap(t *testing.T) {
 			Gaps: []state.Gap{
 				{Severity: state.SeverityP0, Description: "intent mismatch", Blocking: true},
 			},
+			ReturnTo: state.ReturnToCode,
 		},
 	}}
 
@@ -136,14 +140,14 @@ func TestRun_RequeueToCode_OnP0Gap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !result.RequeueToCode {
-		t.Errorf("expected RequeueToCode, got %+v", result)
+	if result.ReturnTo != state.ReturnToCode {
+		t.Errorf("expected ReturnTo=code, got %+v", result)
 	}
 	if result.Pass {
 		t.Error("should not pass")
 	}
 	if result.Escalate {
-		t.Error("should not escalate yet — orchestrator routes to code")
+		t.Error("should not escalate — orchestrator routes to code")
 	}
 	if result.Loops != 1 {
 		t.Errorf("loops = %d, want 1", result.Loops)
@@ -153,14 +157,17 @@ func TestRun_RequeueToCode_OnP0Gap(t *testing.T) {
 	}
 }
 
-func TestRun_RequeueToCode_OnP1Gap(t *testing.T) {
+func TestRun_ReturnToPlan_ForwardsToOrchestrator(t *testing.T) {
+	// A plan-level diagnosis stops the quality loop the same way a
+	// code-level diagnosis does; the orchestrator handles the rewind.
 	judge := &fakeJudge{verdicts: []*state.Verdict{
 		{
-			Score: 55,
+			Score: 40,
 			Pass:  false,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "e2e tests failed", Blocking: true},
+				{Severity: state.SeverityP0, Description: "plan too narrow", Blocking: true},
 			},
+			ReturnTo: state.ReturnToPlan,
 		},
 	}}
 
@@ -171,13 +178,47 @@ func TestRun_RequeueToCode_OnP1Gap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !result.RequeueToCode {
-		t.Errorf("expected RequeueToCode for P1 blocking, got %+v", result)
+	if result.ReturnTo != state.ReturnToPlan {
+		t.Errorf("expected ReturnTo=plan, got %+v", result)
+	}
+	if result.Escalate {
+		t.Error("should not escalate — orchestrator rewinds to plan")
+	}
+}
+
+func TestRun_ReturnToEscalate_SignalsEscalate(t *testing.T) {
+	// ReturnTo=escalate must both expose the LLM's diagnosis AND set
+	// Escalate=true so orchestrators that only check Escalate still do
+	// the right thing.
+	judge := &fakeJudge{verdicts: []*state.Verdict{
+		{
+			Score: 20,
+			Pass:  false,
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP0, Description: "intent is ambiguous", Blocking: true},
+			},
+			ReturnTo: state.ReturnToEscalate,
+		},
+	}}
+
+	task := qualityTask(t)
+	phase := New(judge, defaultCfg(), "fake-diff")
+
+	result, err := phase.Run(context.Background(), task, "the plan")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ReturnTo != state.ReturnToEscalate {
+		t.Errorf("expected ReturnTo=escalate, got %+v", result)
+	}
+	if !result.Escalate {
+		t.Error("expected Escalate=true when ReturnTo=escalate")
 	}
 }
 
 func TestRun_Escalation_NonBlockingLoopOut(t *testing.T) {
-	// Every loop fails with non-blocking gaps → loops exhausted → escalate.
+	// Every loop fails with non-blocking gaps and no ReturnTo → loops
+	// exhausted → escalate. No cross-phase rewind is requested.
 	failing := &state.Verdict{
 		Score: 60,
 		Pass:  false,
@@ -202,8 +243,8 @@ func TestRun_Escalation_NonBlockingLoopOut(t *testing.T) {
 	if result.Pass {
 		t.Error("should not pass")
 	}
-	if result.RequeueToCode {
-		t.Error("should not requeue to code (no blocking gaps)")
+	if result.ReturnTo != state.ReturnToNone {
+		t.Errorf("should not request cross-phase rewind without a diagnosis, got %+v", result.ReturnTo)
 	}
 }
 
@@ -264,63 +305,6 @@ func TestRun_AttemptsStored(t *testing.T) {
 		if a.Loop != i+1 {
 			t.Errorf("attempt[%d].loop = %d, want %d", i, a.Loop, i+1)
 		}
-	}
-}
-
-func TestNeedsCodeRework(t *testing.T) {
-	tests := []struct {
-		name string
-		v    *state.Verdict
-		want bool
-	}{
-		{
-			name: "no gaps",
-			v:    &state.Verdict{},
-			want: false,
-		},
-		{
-			name: "non-blocking P2",
-			v: &state.Verdict{Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Blocking: false},
-			}},
-			want: false,
-		},
-		{
-			name: "blocking P0",
-			v: &state.Verdict{Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Blocking: true},
-			}},
-			want: true,
-		},
-		{
-			name: "blocking P1",
-			v: &state.Verdict{Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Blocking: true},
-			}},
-			want: true,
-		},
-		{
-			name: "blocking P3 (unusual)",
-			v: &state.Verdict{Gaps: []state.Gap{
-				{Severity: state.SeverityP3, Blocking: true},
-			}},
-			want: false,
-		},
-		{
-			name: "mix: non-blocking P0, blocking P2",
-			v: &state.Verdict{Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Blocking: false},
-				{Severity: state.SeverityP2, Blocking: true},
-			}},
-			want: false,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := needsCodeRework(tc.v); got != tc.want {
-				t.Errorf("needsCodeRework = %v, want %v", got, tc.want)
-			}
-		})
 	}
 }
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -72,6 +72,7 @@ func (s *Store) migrate() error {
 		attempts   TEXT NOT NULL DEFAULT '[]',
 		depends_on TEXT NOT NULL DEFAULT '[]',
 		priority   TEXT NOT NULL DEFAULT 'normal',
+		hard_constraints TEXT NOT NULL DEFAULT '[]',
 		created_at TEXT NOT NULL,
 		updated_at TEXT NOT NULL
 	);
@@ -89,6 +90,7 @@ func (s *Store) migrate() error {
 	}{
 		{"depends_on", `ALTER TABLE tasks ADD COLUMN depends_on TEXT NOT NULL DEFAULT '[]'`},
 		{"priority", `ALTER TABLE tasks ADD COLUMN priority TEXT NOT NULL DEFAULT 'normal'`},
+		{"hard_constraints", `ALTER TABLE tasks ADD COLUMN hard_constraints TEXT NOT NULL DEFAULT '[]'`},
 	} {
 		if _, err := s.db.Exec(alter.stmt); err != nil && !isDuplicateColumnErr(err) {
 			return fmt.Errorf("adding %s column: %w", alter.column, err)
@@ -128,6 +130,10 @@ func (s *Store) CreateTask(t *Task) error {
 	if err != nil {
 		return fmt.Errorf("marshaling depends_on: %w", err)
 	}
+	hardConstraintsJSON, err := json.Marshal(t.HardConstraints)
+	if err != nil {
+		return fmt.Errorf("marshaling hard_constraints: %w", err)
+	}
 
 	priority := t.Priority
 	if priority == "" {
@@ -135,11 +141,11 @@ func (s *Store) CreateTask(t *Task) error {
 	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO tasks (id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO tasks (id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		t.ID, t.Intent, string(t.State), string(t.Phase),
 		string(loopJSON), string(assumptionsJSON), string(attemptsJSON), string(dependsOnJSON),
-		priority,
+		priority, string(hardConstraintsJSON),
 		t.CreatedAt.Format(time.RFC3339Nano), t.UpdatedAt.Format(time.RFC3339Nano),
 	)
 	if err != nil {
@@ -151,7 +157,7 @@ func (s *Store) CreateTask(t *Task) error {
 // GetTask retrieves a task by ID. Returns sql.ErrNoRows if not found.
 func (s *Store) GetTask(id string) (*Task, error) {
 	row := s.db.QueryRow(
-		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, created_at, updated_at
+		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, created_at, updated_at
 		 FROM tasks WHERE id = ?`, id,
 	)
 	return s.scanTask(row)
@@ -175,6 +181,10 @@ func (s *Store) UpdateTask(t *Task) error {
 	if err != nil {
 		return fmt.Errorf("marshaling depends_on: %w", err)
 	}
+	hardConstraintsJSON, err := json.Marshal(t.HardConstraints)
+	if err != nil {
+		return fmt.Errorf("marshaling hard_constraints: %w", err)
+	}
 
 	priority := t.Priority
 	if priority == "" {
@@ -182,11 +192,11 @@ func (s *Store) UpdateTask(t *Task) error {
 	}
 
 	result, err := s.db.Exec(
-		`UPDATE tasks SET intent=?, state=?, phase=?, loop_count=?, assumptions=?, attempts=?, depends_on=?, priority=?, updated_at=?
+		`UPDATE tasks SET intent=?, state=?, phase=?, loop_count=?, assumptions=?, attempts=?, depends_on=?, priority=?, hard_constraints=?, updated_at=?
 		 WHERE id=?`,
 		t.Intent, string(t.State), string(t.Phase),
 		string(loopJSON), string(assumptionsJSON), string(attemptsJSON), string(dependsOnJSON),
-		priority,
+		priority, string(hardConstraintsJSON),
 		t.UpdatedAt.Format(time.RFC3339Nano), t.ID,
 	)
 	if err != nil {
@@ -211,12 +221,12 @@ func (s *Store) ListTasks(filterState TaskState) ([]*Task, error) {
 
 	if filterState == "" {
 		rows, err = s.db.Query(
-			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, created_at, updated_at
+			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, created_at, updated_at
 			 FROM tasks ORDER BY created_at ASC`,
 		)
 	} else {
 		rows, err = s.db.Query(
-			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, created_at, updated_at
+			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, created_at, updated_at
 			 FROM tasks WHERE state = ? ORDER BY created_at ASC`,
 			string(filterState),
 		)
@@ -255,19 +265,21 @@ func (s *Store) scanTaskRow(rows *sql.Rows) (*Task, error) {
 
 func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 	var (
-		t               Task
-		state, phase    string
-		loopJSON        string
-		assumptionsJSON string
-		attemptsJSON    string
-		dependsOnJSON   string
-		priority        string
-		createdAt       string
-		updatedAt       string
+		t                   Task
+		state, phase        string
+		loopJSON            string
+		assumptionsJSON     string
+		attemptsJSON        string
+		dependsOnJSON       string
+		priority            string
+		hardConstraintsJSON string
+		createdAt           string
+		updatedAt           string
 	)
 
 	err := sc.Scan(&t.ID, &t.Intent, &state, &phase,
 		&loopJSON, &assumptionsJSON, &attemptsJSON, &dependsOnJSON, &priority,
+		&hardConstraintsJSON,
 		&createdAt, &updatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("scanning task: %w", err)
@@ -293,6 +305,12 @@ func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 	if dependsOnJSON != "" {
 		if err := json.Unmarshal([]byte(dependsOnJSON), &t.DependsOn); err != nil {
 			return nil, fmt.Errorf("unmarshaling depends_on: %w", err)
+		}
+	}
+
+	if hardConstraintsJSON != "" {
+		if err := json.Unmarshal([]byte(hardConstraintsJSON), &t.HardConstraints); err != nil {
+			return nil, fmt.Errorf("unmarshaling hard_constraints: %w", err)
 		}
 	}
 

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -48,6 +48,48 @@ func TestCreateAndGetTask(t *testing.T) {
 	}
 }
 
+func TestCreateAndGetTask_HardConstraintsRoundTrip(t *testing.T) {
+	// #87: hard_constraints column is persisted and hydrated so quality-
+	// driven plan rewinds survive a process restart.
+	store := newTestStore(t)
+	task := NewTask("task-hc", "build it right this time")
+	task.HardConstraints = []string{
+		"[quality judge, P0] /admin/users is not protected",
+		"[quality judge, P1] rate-limit bypass on /admin/logs",
+	}
+
+	if err := store.CreateTask(task); err != nil {
+		t.Fatalf("creating task: %v", err)
+	}
+
+	got, err := store.GetTask("task-hc")
+	if err != nil {
+		t.Fatalf("getting task: %v", err)
+	}
+	if len(got.HardConstraints) != 2 {
+		t.Fatalf("expected 2 hard constraints, got %d: %v", len(got.HardConstraints), got.HardConstraints)
+	}
+	for i, want := range task.HardConstraints {
+		if got.HardConstraints[i] != want {
+			t.Errorf("hard_constraints[%d] = %q, want %q", i, got.HardConstraints[i], want)
+		}
+	}
+
+	// Mutate and update — confirm the update path also round-trips.
+	got.HardConstraints = append(got.HardConstraints, "[quality judge, P0] third constraint")
+	got.UpdatedAt = time.Now()
+	if err := store.UpdateTask(got); err != nil {
+		t.Fatalf("updating task: %v", err)
+	}
+	refetched, err := store.GetTask("task-hc")
+	if err != nil {
+		t.Fatalf("refetching: %v", err)
+	}
+	if len(refetched.HardConstraints) != 3 {
+		t.Errorf("expected 3 constraints after update, got %d", len(refetched.HardConstraints))
+	}
+}
+
 func TestGetTaskNotFound(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -50,6 +50,12 @@ const (
 )
 
 // validTransitions defines which state transitions are allowed.
+//
+// StateQualityReview can rewind to StateCoding or StatePlanning when the
+// quality judge's verdict says the root cause is a code- or plan-level
+// failure — not something re-judging the same workdir can resolve. See
+// Rewind for the per-cycle budget semantics that accompany those
+// transitions.
 var validTransitions = map[TaskState][]TaskState{
 	// Pending can go into the normal pipeline or straight to blocked if
 	// a dependency already failed at submission time.
@@ -59,7 +65,7 @@ var validTransitions = map[TaskState][]TaskState{
 	StateCoding:        {StateCodeReview},
 	StateCodeReview:    {StateCoding, StateQuality, StateEscalated},
 	StateQuality:       {StateQualityReview},
-	StateQualityReview: {StateQuality, StateDone, StateEscalated},
+	StateQualityReview: {StateQuality, StateCoding, StatePlanning, StateDone, StateEscalated},
 	StateDone:          {},
 	StateEscalated:     {},
 	StateBlocked:       {},
@@ -108,6 +114,29 @@ type Question struct {
 	Priority string `json:"priority"`
 }
 
+// ReturnTo names the phase a failing verdict should rewind to. The quality
+// judge sets it when the root cause of a failure cannot be resolved by
+// re-running the current phase — the orchestrator reads it to route the
+// task back through the outer loop.
+type ReturnTo string
+
+const (
+	// ReturnToNone is the zero value: no rewind requested. Used when the
+	// verdict passes or the judge wants another in-phase retry.
+	ReturnToNone ReturnTo = ""
+	// ReturnToCode rewinds to the code phase (tests failing, acceptance
+	// criteria unmet, etc).
+	ReturnToCode ReturnTo = "code"
+	// ReturnToPlan rewinds to the plan phase (plan was too shallow to
+	// catch this class of problem). The quality failure is injected as
+	// a hard constraint into replanning.
+	ReturnToPlan ReturnTo = "plan"
+	// ReturnToEscalate stops the loop and asks for human input (intent
+	// is fundamentally ambiguous or requires judgement this process
+	// cannot make).
+	ReturnToEscalate ReturnTo = "escalate"
+)
+
 // Verdict is the typed output of a judge evaluation.
 type Verdict struct {
 	Score     float64    `json:"score"`
@@ -118,6 +147,12 @@ type Verdict struct {
 	// alongside the structured verdict (decisions, reviewed items, etc).
 	// It is rendered in cli mode under the phase header. May be empty.
 	Summary string `json:"summary,omitempty"`
+	// ReturnTo is the quality judge's diagnosis of where a failing
+	// verdict should be re-run — code, plan, or escalate. Empty on
+	// passing verdicts and on non-quality judges. The orchestrator uses
+	// it to drive outer-loop rewinds rather than just retrying the same
+	// phase.
+	ReturnTo ReturnTo `json:"return_to,omitempty"`
 }
 
 // Attempt records one execution of a phase.
@@ -131,13 +166,23 @@ type Attempt struct {
 
 // Task is the core entity tracked through the VAIrdict pipeline.
 type Task struct {
-	ID          string        `json:"id"`
-	Intent      string        `json:"intent"`
-	State       TaskState     `json:"state"`
-	Phase       Phase         `json:"phase"`
+	ID     string    `json:"id"`
+	Intent string    `json:"intent"`
+	State  TaskState `json:"state"`
+	Phase  Phase     `json:"phase"`
+	// LoopCount tracks loops completed for each phase within the current
+	// outer cycle. Rewind resets the counter for the target phase (and
+	// every later phase) so a fresh cycle gets its own budget — a code
+	// retry triggered by a plan rewind must not count against the code
+	// phase's original budget.
 	LoopCount   map[Phase]int `json:"loop_count"`
 	Assumptions []Assumption  `json:"assumptions"`
 	Attempts    []Attempt     `json:"attempts"`
+	// HardConstraints are requirements injected into the next plan run
+	// by the outer loop — typically the quality judge's failure finding
+	// when it rewinds to Plan. The planner must satisfy them in the new
+	// plan, not just acknowledge them.
+	HardConstraints []string `json:"hard_constraints,omitempty"`
 	// DependsOn lists task IDs this task waits on. The scheduler in
 	// internal/deps uses it to build the DAG; vairdict status reads it
 	// to render the graph. Empty for tasks without dependencies.
@@ -217,6 +262,51 @@ func (t *Task) Requeue(maxLoops int) error {
 	}
 
 	t.LoopCount[phase]++
+	return nil
+}
+
+// Rewind moves the task from its current review state back to the active
+// state of an earlier phase and resets the per-cycle loop budget for the
+// target phase and every phase after it. Only PhaseCode and PhasePlan are
+// valid rewind targets — escalation is its own terminal state, not a
+// rewind. The caller is responsible for setting any HardConstraints that
+// should flow into replanning before calling Rewind.
+//
+// Budget semantics: LoopCount tracks loops within the current outer cycle.
+// A rewind starts a new cycle for the phases downstream of the target, so
+// their counters are zeroed. The audit trail (task.Attempts) keeps every
+// historical attempt; the counter reset only affects future budget checks.
+func (t *Task) Rewind(to Phase) error {
+	var target TaskState
+	switch to {
+	case PhasePlan:
+		target = StatePlanning
+	case PhaseCode:
+		target = StateCoding
+	default:
+		return fmt.Errorf("rewinding to %s: %w", to, ErrInvalidTransition)
+	}
+	if err := t.Transition(target); err != nil {
+		return fmt.Errorf("rewinding: %w", err)
+	}
+
+	// Reset the per-cycle budget for the target phase and every phase
+	// that follows it. A plan rewind gives the code phase a fresh
+	// budget (and quality, after code); a code rewind only resets code
+	// and quality. Earlier-phase counters stay intact.
+	resetFrom := false
+	if t.LoopCount == nil {
+		t.LoopCount = map[Phase]int{}
+	}
+	for _, p := range AllPhases() {
+		if p == to {
+			resetFrom = true
+		}
+		if resetFrom {
+			delete(t.LoopCount, p)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -275,6 +275,162 @@ func TestEscalationFromAllReviewStates(t *testing.T) {
 	}
 }
 
+func TestRewindToCode_ResetsCodeAndQualityBudget(t *testing.T) {
+	// Issue #87: "a code retry triggered by a plan rewind does not count
+	// against the code phase's original budget". More generally, a rewind
+	// resets the per-cycle counter for the target phase and every phase
+	// downstream. The plan counter stays put — the rewind doesn't
+	// touch the phase we're bypassing.
+	task := NewTask("t-rewind-code", "intent")
+	task.LoopCount = map[Phase]int{
+		PhasePlan:    2,
+		PhaseCode:    3,
+		PhaseQuality: 1,
+	}
+	// Advance through the state machine to QualityReview so the
+	// downstream transition is valid.
+	for _, s := range []TaskState{
+		StatePlanning, StatePlanReview, StateCoding, StateCodeReview,
+		StateQuality, StateQualityReview,
+	} {
+		if err := task.Transition(s); err != nil {
+			t.Fatalf("setup transition to %s: %v", s, err)
+		}
+	}
+
+	if err := task.Rewind(PhaseCode); err != nil {
+		t.Fatalf("rewind to code should succeed from quality_review: %v", err)
+	}
+
+	if task.State != StateCoding {
+		t.Errorf("state = %s, want coding", task.State)
+	}
+	if task.LoopCount[PhasePlan] != 2 {
+		t.Errorf("plan budget should be preserved on code rewind, got %d", task.LoopCount[PhasePlan])
+	}
+	if _, ok := task.LoopCount[PhaseCode]; ok {
+		t.Errorf("code budget should be reset on code rewind, got %d", task.LoopCount[PhaseCode])
+	}
+	if _, ok := task.LoopCount[PhaseQuality]; ok {
+		t.Errorf("quality budget should be reset on code rewind, got %d", task.LoopCount[PhaseQuality])
+	}
+}
+
+func TestRewindToPlan_ResetsAllPhaseBudgets(t *testing.T) {
+	// A plan rewind resets every downstream phase's budget — the code
+	// phase is downstream of plan, so it must not inherit the old
+	// counter from before the rewind.
+	task := NewTask("t-rewind-plan", "intent")
+	task.LoopCount = map[Phase]int{
+		PhasePlan:    1,
+		PhaseCode:    2,
+		PhaseQuality: 3,
+	}
+	for _, s := range []TaskState{
+		StatePlanning, StatePlanReview, StateCoding, StateCodeReview,
+		StateQuality, StateQualityReview,
+	} {
+		if err := task.Transition(s); err != nil {
+			t.Fatalf("setup transition to %s: %v", s, err)
+		}
+	}
+
+	if err := task.Rewind(PhasePlan); err != nil {
+		t.Fatalf("rewind to plan should succeed from quality_review: %v", err)
+	}
+	if task.State != StatePlanning {
+		t.Errorf("state = %s, want planning", task.State)
+	}
+	for _, p := range []Phase{PhasePlan, PhaseCode, PhaseQuality} {
+		if _, ok := task.LoopCount[p]; ok {
+			t.Errorf("%s budget should be reset on plan rewind, got %d", p, task.LoopCount[p])
+		}
+	}
+}
+
+func TestRewind_RejectsInvalidTarget(t *testing.T) {
+	task := NewTask("t", "intent")
+	for _, s := range []TaskState{
+		StatePlanning, StatePlanReview, StateCoding, StateCodeReview,
+		StateQuality, StateQualityReview,
+	} {
+		_ = task.Transition(s)
+	}
+	if err := task.Rewind(PhaseQuality); err == nil {
+		t.Error("rewinding to quality should fail — it is not a valid rewind target")
+	}
+	if err := task.Rewind(Phase("bogus")); err == nil {
+		t.Error("rewinding to an unknown phase should fail")
+	}
+}
+
+func TestRewind_FromNonReviewState(t *testing.T) {
+	// Rewinds are only valid from review states (specifically
+	// quality_review, per validTransitions). Trying to rewind from
+	// active states like StateCoding must error.
+	task := NewTask("t", "intent")
+	_ = task.Transition(StatePlanning)
+	_ = task.Transition(StatePlanReview)
+	_ = task.Transition(StateCoding)
+
+	if err := task.Rewind(PhasePlan); err == nil {
+		t.Error("rewind from coding should fail — no valid transition coding → planning")
+	}
+}
+
+func TestRewindThenRequeue_UsesFreshBudget(t *testing.T) {
+	// End-to-end budget behavior: after rewind, subsequent requeues in
+	// the target phase count from zero — the quality failure that
+	// triggered the rewind does not count against the code phase's
+	// new-cycle budget.
+	task := NewTask("t", "intent")
+	for _, s := range []TaskState{
+		StatePlanning, StatePlanReview, StateCoding, StateCodeReview,
+	} {
+		_ = task.Transition(s)
+	}
+	// Exhaust code's first-cycle budget nearly to the limit.
+	task.LoopCount[PhaseCode] = 2
+	// Advance through quality review.
+	_ = task.Transition(StateQuality)
+	_ = task.Transition(StateQualityReview)
+
+	if err := task.Rewind(PhaseCode); err != nil {
+		t.Fatalf("rewind: %v", err)
+	}
+	// After rewind the code phase should be able to loop the full
+	// budget again without triggering ErrMaxLoopsReached.
+	_ = task.Transition(StateCodeReview)
+	if err := task.Requeue(3); err != nil {
+		t.Fatalf("first requeue in new cycle should not hit max loops (maxLoops=3, fresh budget), got %v", err)
+	}
+	if task.LoopCount[PhaseCode] != 1 {
+		t.Errorf("post-rewind code loop count = %d, want 1", task.LoopCount[PhaseCode])
+	}
+}
+
+func TestQualityReviewTransitions_IncludeRewinds(t *testing.T) {
+	// The state machine must allow cross-phase rewinds from
+	// quality_review. Missing transitions would manifest as
+	// ErrInvalidTransition deep inside the orchestrator.
+	for _, target := range []TaskState{StateCoding, StatePlanning} {
+		t.Run(string(target), func(t *testing.T) {
+			task := NewTask("t-"+string(target), "intent")
+			for _, s := range []TaskState{
+				StatePlanning, StatePlanReview, StateCoding, StateCodeReview,
+				StateQuality, StateQualityReview,
+			} {
+				if err := task.Transition(s); err != nil {
+					t.Fatalf("setup %s: %v", s, err)
+				}
+			}
+			if err := task.Transition(target); err != nil {
+				t.Errorf("quality_review → %s should be allowed: %v", target, err)
+			}
+		})
+	}
+}
+
 func TestAllPhases(t *testing.T) {
 	phases := AllPhases()
 	if len(phases) != 3 {

--- a/internal/ui/ci.go
+++ b/internal/ui/ci.go
@@ -91,6 +91,8 @@ func outcomeName(o PhaseOutcome) string {
 		return "escalate"
 	case OutcomeRequeueToCode:
 		return "requeue_to_code"
+	case OutcomeRequeueToPlan:
+		return "requeue_to_plan"
 	}
 	return "unknown"
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -77,6 +77,7 @@ const (
 	OutcomeFail
 	OutcomeEscalate
 	OutcomeRequeueToCode
+	OutcomeRequeueToPlan
 )
 
 // Options holds the construction parameters for a Renderer.

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -13,12 +13,12 @@ Update this file when opening, completing, or blocking an issue.
 - #90 cmd/resume: resume interrupted run from last checkpoint
 - #91 cmd/interactive: status, notes, pause/continue during execution
 - #82 perf: load test 5 concurrent tasks
-- #87 state/rewind: verdict ReturnTo field + phase rewind in outer loop
+- #86 state/rewind-context: structured failure context propagation (unblocked by #87)
 
 ## In Progress
+- #87 state/rewind: verdict ReturnTo field + phase rewind in outer loop
 
 ## Blocked
-- #86 state/rewind-context: structured failure context propagation (depends on #87)
 
 ## Done
 - #9 chore: repo infrastructure setup


### PR DESCRIPTION
The quality judge now diagnoses the root cause of a failure and the
state machine can rewind to the phase that can actually fix it, instead
of retrying the same phase every time.

* Verdict gains a ReturnTo field (code | plan | escalate) that the
  quality judge emits on every failing verdict. The system prompt
  describes each option with a worked example and a false-positive
  counter-example. The judge normalises the LLM's response — unknown
  values collapse to code, passing verdicts always clear ReturnTo.
* state.Task.Rewind(to Phase) moves the task from quality_review back
  to coding or planning and resets the per-cycle LoopCount for the
  target phase and every phase downstream. A code retry triggered by
  a plan rewind starts with a fresh budget — it does not count against
  the code phase's original budget, per the issue.
* The outer loop in runOrchestration now cycles through plan → code →
  quality up to maxOuterCycles (3) times. On ReturnToPlan the blocking
  gaps are appended to task.HardConstraints and the planner prompt
  surfaces them as non-negotiable requirements the new plan must
  address.
* Replaces the RequeueToCode boolean with the richer ReturnTo on the
  quality phase result and the emitPhaseDone signature. New
  OutcomeRequeueToPlan renders plan-rewinds distinctly in CI output.
* HardConstraints is persisted alongside the task via an additive
  migration, so a replanned cycle survives a process restart.

Tests cover: Rewind budget semantics (code + plan targets, invalid
targets), ReturnTo propagation and normalisation paths, the
orchestrator rewind-to-code and rewind-to-plan happy paths, the
outer-cycle budget exhaustion fallback, and HardConstraints round-trip
through the SQLite store.

Closes #87