### PR TITLE
fix(github): render verdict Summary in PR comment

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -671,6 +671,14 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int) s
 	// Summary line.
 	fmt.Fprintf(&b, "**Score:** %.0f%% | **Phase:** %s | **Loop:** %d\n\n", verdict.Score, phase, loop)
 
+	// Judge narrative (Reviewed / Notes sections). Without this, a passing
+	// verdict with no gaps renders as just the score line, hiding everything
+	// the judge actually checked.
+	if s := strings.TrimSpace(verdict.Summary); s != "" {
+		b.WriteString(s)
+		b.WriteString("\n\n")
+	}
+
 	// Criteria table — build from gaps.
 	if len(verdict.Gaps) > 0 {
 		b.WriteString("### Criteria\n\n")

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -679,7 +679,10 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int) s
 		b.WriteString("\n\n")
 	}
 
-	// Criteria table — build from gaps.
+	// Criteria table — build from gaps. When the verdict passes with zero
+	// gaps we still emit an explicit "no issues found" line so reviewers
+	// can tell the judge ran and had nothing to flag, instead of staring
+	// at an empty comment body and assuming vairdict skipped the review.
 	if len(verdict.Gaps) > 0 {
 		b.WriteString("### Criteria\n\n")
 		b.WriteString("| Severity | Status | Description |\n")
@@ -692,6 +695,8 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int) s
 			fmt.Fprintf(&b, "| %s | %s | %s |\n", g.Severity, status, g.Description)
 		}
 		b.WriteString("\n")
+	} else if verdict.Pass {
+		b.WriteString("✓ No issues found.\n\n")
 	}
 
 	// Gaps section for failures.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -483,6 +483,48 @@ func TestFormatVerdictComment_NoGaps(t *testing.T) {
 	}
 }
 
+func TestFormatVerdictComment_RendersSummary(t *testing.T) {
+	// A passing verdict with no gaps previously rendered only the score
+	// line, dropping the judge's Reviewed/Notes narrative — see PR #107
+	// where a 1200-line diff got an empty comment. The summary must
+	// survive into the posted PR comment.
+	summary := "## Reviewed\n- diff against plan\n\n## Notes\n- watch for follow-up"
+	verdict := &state.Verdict{
+		Score:   95,
+		Pass:    true,
+		Summary: summary,
+	}
+
+	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1)
+
+	if !contains(comment, "## Reviewed") {
+		t.Error("comment missing Reviewed section from Summary")
+	}
+	if !contains(comment, "diff against plan") {
+		t.Error("comment missing Reviewed bullet from Summary")
+	}
+	if !contains(comment, "## Notes") {
+		t.Error("comment missing Notes section from Summary")
+	}
+	if !contains(comment, "watch for follow-up") {
+		t.Error("comment missing Notes bullet from Summary")
+	}
+}
+
+func TestFormatVerdictComment_EmptySummaryNotRendered(t *testing.T) {
+	verdict := &state.Verdict{
+		Score:   100,
+		Pass:    true,
+		Summary: "   \n\t  ",
+	}
+
+	comment := FormatVerdictComment(verdict, state.PhasePlan, 1)
+
+	if contains(comment, "## Reviewed") || contains(comment, "## Notes") {
+		t.Error("whitespace-only summary should not emit any section")
+	}
+}
+
 func TestParsePRNumber(t *testing.T) {
 	tests := []struct {
 		url  string

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -481,6 +481,27 @@ func TestFormatVerdictComment_NoGaps(t *testing.T) {
 	if !contains(comment, "PASS") {
 		t.Error("should contain PASS")
 	}
+	// A passing verdict with no gaps must still say something concrete
+	// about the review outcome — otherwise reviewers of a large diff see
+	// nothing and assume the judge was a no-op.
+	if !contains(comment, "No issues found") {
+		t.Error("pass with no gaps should explicitly say no issues found")
+	}
+}
+
+func TestFormatVerdictComment_FailWithNoGaps_NoSuchMessage(t *testing.T) {
+	// "No issues found" is a PASS-only affirmation. A failing verdict
+	// (even one without structured gaps) must never render it.
+	verdict := &state.Verdict{
+		Score: 0,
+		Pass:  false,
+	}
+
+	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1)
+
+	if contains(comment, "No issues found") {
+		t.Error("fail verdict must not render the no-issues affirmation")
+	}
 }
 
 func TestFormatVerdictComment_RendersSummary(t *testing.T) {

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -131,13 +131,39 @@ const systemPromptCore = `You are an experienced senior code reviewer acting as 
 for a software development process engine. Your job is to evaluate
 whether the implemented code fulfills the original task intent.
 
+## Reviewer mindset — no prior context
+
+Treat this as a fresh review. You are NOT the author of this change and
+you do NOT carry any prior reasoning about why specific choices were
+made. The implementation was produced by a different agent; do not
+defer to its implicit justifications. Only the intent, plan, facts,
+and diff below exist — everything else is something you must infer
+from the diff itself or flag as a question.
+
 You care about correctness, clarity, and future maintenance pain. You are
 considered and deliberate — every observation earns its place. A thoughtful
 review surfaces design decisions, risks, and follow-ups — not just bugs.
-On any diff that substantively changes behaviour (≳200 lines or ≳3 files),
-2–3 P3/P2 observations are normal; silence on such a diff almost certainly
-means you missed something worth saying. Only leave gaps empty when the
-change is small AND genuinely has no design question worth surfacing.
+
+## Substantive-diff rule (HARD)
+
+A diff is "substantive" when it changes >200 lines OR touches >3 files.
+On a substantive diff you MUST produce at least one entry in "gaps" —
+typically 2–3 P3/P2 design observations, occasionally a P1 correctness
+concern. Returning an empty gaps array on a substantive diff is a
+failure mode, not a clean bill of health: an experienced reviewer
+always surfaces something — a naming question, a missing test case,
+an invariant worth documenting, a follow-up worth filing, a non-obvious
+trade-off worth naming.
+
+If you find yourself about to submit zero gaps on a substantive diff,
+stop and re-read the diff asking:
+- What would I want the author to clarify before I approved this?
+- Which decision here will cost us in six months if we don't revisit it?
+- Which new function/name/structure would I rename if I owned this?
+
+Exactly one of those will yield a real observation; emit it. This rule
+is not a licence to pad with nits — every entry must be a concern a
+senior reviewer would actually raise, not filler.
 
 Flag things that would cause a bug, a regression, or real maintenance
 pain — and additionally surface the design-level concerns a senior
@@ -297,10 +323,12 @@ submit_verdict input:
   "questions": []
 }
 
-Note: on a substantive diff, 2–3 design observations (P3/P2) is normal —
-what a senior reviewer would write in a real PR. Only leave gaps empty
-when the diff is small AND genuinely has no design question worth
-surfacing; never pad with nits to hit a target.
+Note: on a substantive diff, 2–3 design observations (P3/P2) is the
+expected floor, not a ceiling — what a senior reviewer would write in
+a real PR. An empty gaps array is ONLY valid when the diff is small
+AND genuinely has no design question worth surfacing; never pad with
+nits to hit a target, and never go silent on a substantive change to
+avoid the work of finding something real.
 
 ### Example 2 — clear fail (intent mismatch + security)
 

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -536,6 +536,38 @@ func TestJudge_SecurityChecksAreBlocking(t *testing.T) {
 	}
 }
 
+func TestJudge_SystemPromptForbidsSilenceOnSubstantiveDiff(t *testing.T) {
+	// PR #107 was a 1200-line / 16-file diff that the judge passed with
+	// zero gaps. The prompt must keep an explicit hard rule against that
+	// failure mode so a future prompt edit cannot silently soften it.
+	for _, keyword := range []string{
+		"Substantive-diff rule",
+		"MUST produce at least one entry",
+		">200 lines",
+		">3 files",
+	} {
+		if !strings.Contains(systemPrompt, keyword) {
+			t.Errorf("system prompt missing substantive-diff rule marker %q", keyword)
+		}
+	}
+}
+
+func TestJudge_SystemPromptEstablishesFreshReviewerMindset(t *testing.T) {
+	// When judge and coder are backed by the same model family, the judge
+	// can carry an implicit self-defense bias. The prompt must instruct
+	// it to review as a fresh reviewer with no prior reasoning about the
+	// change.
+	for _, keyword := range []string{
+		"Reviewer mindset",
+		"no prior",
+		"NOT the author",
+	} {
+		if !strings.Contains(systemPrompt, keyword) {
+			t.Errorf("system prompt missing fresh-reviewer marker %q", keyword)
+		}
+	}
+}
+
 func TestJudge_CodeReuseAndStyleAreNonBlocking(t *testing.T) {
 	if !strings.Contains(systemPrompt, "P2 non-blocking") {
 		t.Error("system prompt should mark code-reuse checks as P2 non-blocking")


### PR DESCRIPTION
## Summary

The quality judge produces a `Reviewed` / `Notes` narrative in `verdict.Summary` (see `internal/judges/quality/judge.go:243`), and the CLI renderer surfaces it (`cmd/vairdict/run.go:900`) — but `FormatVerdictComment` in `internal/github/client.go` never read the field.

On a passing verdict with no gaps, the PR comment therefore collapsed to just the header + score line, which is what happened on #107 (1200+ line diff, comment said only `Score: 95% | Phase: quality | Loop: 1`).

## Changes

- `internal/github/client.go`: render trimmed `verdict.Summary` between the score line and the criteria table.
- `internal/github/client_test.go`: added `TestFormatVerdictComment_RendersSummary` (happy path) and `TestFormatVerdictComment_EmptySummaryNotRendered` (whitespace-only guard).

## Test plan

- [x] `go test ./internal/github/...` passes
- [x] New tests fail without the client.go change and pass with it
- [ ] On next quality-judge run against a real PR, confirm the posted comment includes the Reviewed/Notes sections


---
_Generated by [Claude Code](https://claude.ai/code/session_01A2T1xQgEdGojCGbd5GzicV)_