### PR TITLE
feat(mentions): add :eyes: reaction on @vairdict comment acknowledgment

### DIFF
--- a/.github/workflows/vairdict-mentions.yml
+++ b/.github/workflows/vairdict-mentions.yml
@@ -49,5 +49,6 @@ jobs:
           VAIRDICT_COMMENT_BODY: ${{ github.event.comment.body }}
           VAIRDICT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           VAIRDICT_COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+          VAIRDICT_COMMENT_ID: ${{ github.event.comment.id }}
         run: |
           "${{ runner.temp }}/vairdict" handle-comment "${{ github.event.issue.number }}"

--- a/cmd/vairdict/handle_comment.go
+++ b/cmd/vairdict/handle_comment.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+
 	"strconv"
 	"strings"
 	"time"
@@ -208,6 +209,7 @@ func authorized(association string) bool {
 // does too, which keeps the orchestration core free of exec/network.
 type handleCommentGH interface {
 	AddComment(ctx context.Context, prNumber int, body string) error
+	AddReaction(ctx context.Context, commentID int64, content string) error
 	FetchPR(ctx context.Context, number int) (*github.PRDetails, error)
 	SetCommitStatus(ctx context.Context, sha, state, statusContext, description string) error
 	RecentCommentExists(ctx context.Context, prNumber int, marker string, within time.Duration) (bool, error)
@@ -222,6 +224,7 @@ type handleCommentDeps struct {
 	body       string
 	author     string
 	assoc      string
+	commentID  int64
 	runReview  func(prNumber int) error
 	rateWindow time.Duration
 }
@@ -269,12 +272,15 @@ func runHandleComment(prNumber int) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
+	commentID, _ := strconv.ParseInt(os.Getenv("VAIRDICT_COMMENT_ID"), 10, 64)
+
 	return runHandleCommentWith(ctx, prNumber, handleCommentDeps{
 		gh:         ghClient,
 		stdout:     os.Stdout,
 		body:       os.Getenv("VAIRDICT_COMMENT_BODY"),
 		author:     os.Getenv("VAIRDICT_COMMENT_AUTHOR"),
 		assoc:      os.Getenv("VAIRDICT_COMMENT_ASSOCIATION"),
+		commentID:  commentID,
 		runReview:  runReview,
 		rateWindow: reviewRateLimitWindow,
 	})
@@ -294,6 +300,14 @@ func runHandleCommentWith(ctx context.Context, prNumber int, deps handleCommentD
 	if !res.Mentioned {
 		slog.Debug("no @vairdict mention, nothing to do", "pr", prNumber)
 		return nil
+	}
+
+	// Acknowledge the mention immediately with an :eyes: reaction so the
+	// commenter sees visual feedback before any processing starts.
+	if deps.commentID != 0 {
+		if err := deps.gh.AddReaction(ctx, deps.commentID, "eyes"); err != nil {
+			slog.Warn("failed to add eyes reaction", "pr", prNumber, "error", err)
+		}
 	}
 
 	if res.Command == cmdNone {

--- a/cmd/vairdict/handle_comment.go
+++ b/cmd/vairdict/handle_comment.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
-
 	"strconv"
 	"strings"
 	"time"

--- a/cmd/vairdict/handle_comment_test.go
+++ b/cmd/vairdict/handle_comment_test.go
@@ -96,11 +96,18 @@ type fakeHandleGH struct {
 	recent            bool
 	recentErr         error
 	recentCalls       int
+	reactions         []string
+	reactionErr       error
 }
 
 func (f *fakeHandleGH) AddComment(_ context.Context, _ int, body string) error {
 	f.comments = append(f.comments, body)
 	return f.commentErr
+}
+
+func (f *fakeHandleGH) AddReaction(_ context.Context, _ int64, content string) error {
+	f.reactions = append(f.reactions, content)
+	return f.reactionErr
 }
 
 func (f *fakeHandleGH) FetchPR(_ context.Context, _ int) (*github.PRDetails, error) {
@@ -422,6 +429,38 @@ func TestRunHandleComment_Ignore_FetchPRError(t *testing.T) {
 	err := runHandleCommentWith(context.Background(), 99, deps)
 	if err == nil {
 		t.Fatal("expected error when fetching PR fails")
+	}
+}
+
+func TestRunHandleComment_EyesReaction_OnMention(t *testing.T) {
+	t.Parallel()
+	gh := &fakeHandleGH{}
+	deps := baseHandleDeps(gh)
+	deps.body = "@vairdict review"
+	deps.author = "alice"
+	deps.assoc = "MEMBER"
+	deps.commentID = 12345
+	if err := runHandleCommentWith(context.Background(), 1, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gh.reactions) != 1 || gh.reactions[0] != "eyes" {
+		t.Errorf("expected [eyes] reaction, got %v", gh.reactions)
+	}
+}
+
+func TestRunHandleComment_NoReaction_WithoutCommentID(t *testing.T) {
+	t.Parallel()
+	gh := &fakeHandleGH{}
+	deps := baseHandleDeps(gh)
+	deps.body = "@vairdict review"
+	deps.author = "alice"
+	deps.assoc = "MEMBER"
+	// commentID is 0 (not set)
+	if err := runHandleCommentWith(context.Background(), 1, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gh.reactions) != 0 {
+		t.Errorf("expected no reactions without comment ID, got %v", gh.reactions)
 	}
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -308,6 +308,20 @@ func ParseLinkedIssue(body string) int {
 	return n
 }
 
+// AddReaction adds a reaction to an issue comment via the GitHub API.
+// content must be one of: +1, -1, laugh, confused, heart, hooray, rocket, eyes.
+func (c *Client) AddReaction(ctx context.Context, commentID int64, content string) error {
+	_, err := c.runner.Run(ctx, "gh", "api",
+		fmt.Sprintf("repos/{owner}/{repo}/issues/comments/%d/reactions", commentID),
+		"-X", "POST",
+		"-f", "content="+content,
+	)
+	if err != nil {
+		return fmt.Errorf("adding %s reaction to comment %d: %w", content, commentID, err)
+	}
+	return nil
+}
+
 // AddComment adds a comment to a PR.
 func (c *Client) AddComment(ctx context.Context, prNumber int, body string) error {
 	_, err := c.runner.Run(ctx, "gh", "pr", "comment", fmt.Sprintf("%d", prNumber), "--body", body)


### PR DESCRIPTION
## Summary
- Adds immediate 👀 reaction to `@vairdict` mention comments so the commenter gets visual feedback before processing starts
- Adds `AddReaction` method to the GitHub client (`POST /issues/comments/{id}/reactions`)
- Passes `VAIRDICT_COMMENT_ID` from the webhook payload through the workflow env vars

## Context
When commenting `@vairdict review` on PR #107, the workflow ran but failed because the installed binary (v0.0.3) predates the `handle-comment` command. Even once that's fixed with a new release, there was no immediate visual acknowledgment — this PR adds the :eyes: reaction so users know vairdict saw their comment.

## Test plan
- [x] Unit tests for :eyes: reaction when comment ID is present
- [x] Unit tests for no reaction when comment ID is missing (graceful degradation)
- [x] Existing handle-comment tests still pass
- [ ] After release cut: verify reaction appears on real `@vairdict review` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)