### PR TITLE
feat(review): unified review with inline comments

### DIFF
--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -162,7 +162,7 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 	}
 
 	if deps.noComment {
-		_, _ = fmt.Fprintln(deps.stdout, github.FormatVerdictComment(verdict, state.PhaseQuality, 1))
+		_, _ = fmt.Fprintln(deps.stdout, github.FormatVerdictComment(verdict, state.PhaseQuality, 1, nil))
 	} else {
 		if err := deps.gh.PostVerdictWithDiff(ctx, prNumber, verdict, state.PhaseQuality, 1, diff); err != nil {
 			return fmt.Errorf("posting verdict: %w", err)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -448,6 +448,8 @@ func (c *Client) PostVerdictWithDiff(ctx context.Context, prNumber int, verdict 
 		if !cannotApprovePRRe.MatchString(err.Error()) {
 			return fmt.Errorf("posting verdict approval: %w", err)
 		}
+		// Approval denied (self-authored PR or Actions token restriction).
+		// Fall through to a plain comment so the verdict still gets posted.
 		slog.Info("approval rejected, falling back to comment", "pr", prNumber, "reason", err)
 	}
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -390,17 +390,55 @@ func (c *Client) PostVerdict(ctx context.Context, prNumber int, verdict *state.V
 
 // PostVerdictWithDiff is like PostVerdict but accepts a diff string for
 // resolving inline comment positions. When diff is non-empty, gaps that
-// have File and Line set are posted as inline review comments.
+// have File and Line set are posted as inline review comments attached to
+// the same review as the verdict summary — a single cohesive review.
 func (c *Client) PostVerdictWithDiff(ctx context.Context, prNumber int, verdict *state.Verdict, phase state.Phase, loop int, diff string) error {
 	c.deletePreviousVerdicts(ctx, prNumber)
 
-	// Post inline review comments for gaps with file:line info.
+	// Build inline comments from gaps with file:line info.
+	var inlineResult *InlineReviewResult
 	if diff != "" {
-		c.postInlineReview(ctx, prNumber, verdict, diff)
+		inlineResult = BuildInlineReview(verdict, diff)
 	}
 
-	comment := FormatVerdictComment(verdict, phase, loop)
+	var inlineIndices map[int]bool
+	var inlineComments []InlineComment
+	if inlineResult != nil {
+		inlineIndices = inlineResult.InlineGapIndices
+		if inlineResult.Payload != nil {
+			inlineComments = inlineResult.Payload.Comments
+		}
+	}
 
+	comment := FormatVerdictComment(verdict, phase, loop, inlineIndices)
+
+	// When we have inline comments, post everything as a single review
+	// so inline comments appear as children of the verdict summary.
+	if len(inlineComments) > 0 {
+		event := "COMMENT"
+		if verdict.Pass {
+			event = "APPROVE"
+		}
+		review := &InlineReviewPayload{
+			Event:    event,
+			Body:     comment,
+			Comments: inlineComments,
+		}
+		err := c.postReviewPayload(ctx, prNumber, review)
+		if err != nil && verdict.Pass && cannotApprovePRRe.MatchString(err.Error()) {
+			// Approval denied — retry as COMMENT.
+			slog.Info("approval rejected, falling back to comment review", "pr", prNumber, "reason", err)
+			review.Event = "COMMENT"
+			err = c.postReviewPayload(ctx, prNumber, review)
+		}
+		if err != nil {
+			return fmt.Errorf("posting verdict review: %w", err)
+		}
+		slog.Info("verdict posted", "pr", prNumber, "pass", verdict.Pass, "score", verdict.Score, "mode", "review", "inline_comments", len(inlineComments))
+		return nil
+	}
+
+	// No inline comments — use the simpler approval/comment path.
 	if verdict.Pass {
 		err := c.ApprovePR(ctx, prNumber, comment)
 		if err == nil {
@@ -410,8 +448,6 @@ func (c *Client) PostVerdictWithDiff(ctx context.Context, prNumber int, verdict 
 		if !cannotApprovePRRe.MatchString(err.Error()) {
 			return fmt.Errorf("posting verdict approval: %w", err)
 		}
-		// Approval denied (self-authored PR or Actions token restriction).
-		// Fall through to a plain comment so the verdict still gets posted.
 		slog.Info("approval rejected, falling back to comment", "pr", prNumber, "reason", err)
 	}
 
@@ -433,18 +469,28 @@ type InlineReviewPayload struct {
 	Comments []InlineComment `json:"comments"`
 }
 
+// InlineReviewResult holds the review payload and the indices of gaps that
+// were successfully anchored as inline comments. The indices let callers
+// (e.g. FormatVerdictComment) omit those gaps from the summary comment
+// since they are already visible as inline review comments on the PR.
+type InlineReviewResult struct {
+	Payload          *InlineReviewPayload
+	InlineGapIndices map[int]bool
+}
+
 // BuildInlineReview turns a verdict + diff into a review payload whose
 // comments point only at lines present in the diff. Gaps without File/Line
 // or whose line does not appear in the diff are collected into the review
 // body so reviewers still see every concern — previously they were dropped
 // silently and only surfaced in the verdict table.
-// Returns nil only when the verdict has no gaps at all.
-func BuildInlineReview(verdict *state.Verdict, diff string) *InlineReviewPayload {
+// Returns a result with a nil Payload only when the verdict has no gaps at all.
+func BuildInlineReview(verdict *state.Verdict, diff string) *InlineReviewResult {
 	positions := ParseDiffPositions(diff)
 
 	var comments []InlineComment
 	var unanchored []state.Gap
-	for _, g := range verdict.Gaps {
+	inlineIndices := make(map[int]bool)
+	for i, g := range verdict.Gaps {
 		if g.File == "" || g.Line == 0 {
 			unanchored = append(unanchored, g)
 			continue
@@ -461,16 +507,20 @@ func BuildInlineReview(verdict *state.Verdict, diff string) *InlineReviewPayload
 			Position: pos,
 			Body:     formatInlineComment(g),
 		})
+		inlineIndices[i] = true
 	}
 
 	if len(comments) == 0 && len(unanchored) == 0 {
-		return nil
+		return &InlineReviewResult{}
 	}
 
-	return &InlineReviewPayload{
-		Event:    "COMMENT",
-		Body:     formatReviewBody(len(comments), unanchored),
-		Comments: comments,
+	return &InlineReviewResult{
+		Payload: &InlineReviewPayload{
+			Event:    "COMMENT",
+			Body:     formatReviewBody(len(comments), unanchored),
+			Comments: comments,
+		},
+		InlineGapIndices: inlineIndices,
 	}
 }
 
@@ -491,35 +541,25 @@ func formatReviewBody(inlineCount int, unanchored []state.Gap) string {
 	return b.String()
 }
 
-// postInlineReview creates a single GitHub review with inline comments
-// for gaps that have resolvable file:line positions. Best-effort — errors
-// are logged but do not block the summary verdict from being posted.
-func (c *Client) postInlineReview(ctx context.Context, prNumber int, verdict *state.Verdict, diff string) {
-	review := BuildInlineReview(verdict, diff)
-	if review == nil {
-		return
-	}
-
+// postReviewPayload posts a review payload to the GitHub API.
+func (c *Client) postReviewPayload(ctx context.Context, prNumber int, review *InlineReviewPayload) error {
 	payload, err := json.Marshal(review)
 	if err != nil {
-		slog.Debug("failed to marshal review payload", "error", err)
-		return
+		return fmt.Errorf("marshalling review payload: %w", err)
 	}
 
 	// Write payload to a temp file for gh api --input since our
 	// CommandRunner doesn't support stdin.
 	f, err := os.CreateTemp("", "vairdict-review-*.json")
 	if err != nil {
-		slog.Debug("failed to create temp file for review", "error", err)
-		return
+		return fmt.Errorf("creating temp file for review: %w", err)
 	}
 	tmpPath := f.Name()
 	defer func() { _ = os.Remove(tmpPath) }()
 
 	if _, err := f.Write(payload); err != nil {
 		_ = f.Close()
-		slog.Debug("failed to write review payload", "error", err)
-		return
+		return fmt.Errorf("writing review payload: %w", err)
 	}
 	_ = f.Close()
 
@@ -529,10 +569,9 @@ func (c *Client) postInlineReview(ctx context.Context, prNumber int, verdict *st
 		"--input", tmpPath,
 	)
 	if err != nil {
-		slog.Debug("failed to post inline review", "pr", prNumber, "error", err)
-		return
+		return fmt.Errorf("posting review to PR #%d: %w", prNumber, err)
 	}
-	slog.Info("inline review posted", "pr", prNumber, "comments", len(review.Comments))
+	return nil
 }
 
 // formatInlineComment builds the markdown body for a single inline comment.
@@ -658,7 +697,11 @@ func FormatPRBody(task *state.Task, issueNumber int, summary string) string {
 const logoURL = "https://raw.githubusercontent.com/vairdict/vairdict/main/assets/logo.png"
 
 // FormatVerdictComment builds a structured markdown comment from a Verdict.
-func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int) string {
+// inlineGapIndices contains the indices of gaps that were already posted as
+// inline review comments on the PR. Those gaps are excluded from the criteria
+// table to avoid duplication — the summary focuses on high-level narrative
+// and non-inline concerns.
+func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int, inlineGapIndices map[int]bool) string {
 	var b strings.Builder
 
 	// Header with logo and pass/fail status.
@@ -679,15 +722,26 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int) s
 		b.WriteString("\n\n")
 	}
 
-	// Criteria table — build from gaps. When the verdict passes with zero
-	// gaps we still emit an explicit "no issues found" line so reviewers
-	// can tell the judge ran and had nothing to flag, instead of staring
-	// at an empty comment body and assuming vairdict skipped the review.
-	if len(verdict.Gaps) > 0 {
+	// Separate gaps into inline (already visible on specific lines) and
+	// summary-only (belong in this comment).
+	var summaryGaps []state.Gap
+	inlineCount := 0
+	for i, g := range verdict.Gaps {
+		if inlineGapIndices[i] {
+			inlineCount++
+		} else {
+			summaryGaps = append(summaryGaps, g)
+		}
+	}
+
+	// Criteria table — only non-inline gaps. When the verdict passes with
+	// zero gaps we still emit an explicit "no issues found" line so
+	// reviewers can tell the judge ran and had nothing to flag.
+	if len(summaryGaps) > 0 {
 		b.WriteString("### Criteria\n\n")
 		b.WriteString("| Severity | Status | Description |\n")
 		b.WriteString("|----------|--------|-------------|\n")
-		for _, g := range verdict.Gaps {
+		for _, g := range summaryGaps {
 			status := "pass"
 			if g.Blocking {
 				status = "BLOCKING"
@@ -699,9 +753,14 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int) s
 		b.WriteString("✓ No issues found.\n\n")
 	}
 
-	// Gaps section for failures.
+	if inlineCount > 0 {
+		fmt.Fprintf(&b, "> %d additional comment(s) posted inline on the diff.\n\n", inlineCount)
+	}
+
+	// Blocking gaps section for failures — include ALL blocking gaps
+	// (even inline ones) so the summary is a complete failure report.
 	if !verdict.Pass {
-		blocking := make([]state.Gap, 0)
+		var blocking []state.Gap
 		for _, g := range verdict.Gaps {
 			if g.Blocking {
 				blocking = append(blocking, g)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -397,7 +397,7 @@ func TestFormatVerdictComment_Pass(t *testing.T) {
 		},
 	}
 
-	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1)
+	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1, nil)
 
 	checks := []struct {
 		name string
@@ -441,7 +441,7 @@ func TestFormatVerdictComment_Fail(t *testing.T) {
 		},
 	}
 
-	comment := FormatVerdictComment(verdict, state.PhaseCode, 2)
+	comment := FormatVerdictComment(verdict, state.PhaseCode, 2, nil)
 
 	checks := []struct {
 		name string
@@ -473,7 +473,7 @@ func TestFormatVerdictComment_NoGaps(t *testing.T) {
 		Pass:  true,
 	}
 
-	comment := FormatVerdictComment(verdict, state.PhasePlan, 1)
+	comment := FormatVerdictComment(verdict, state.PhasePlan, 1, nil)
 
 	if contains(comment, "### Criteria") {
 		t.Error("should not have criteria table when no gaps")
@@ -497,7 +497,7 @@ func TestFormatVerdictComment_FailWithNoGaps_NoSuchMessage(t *testing.T) {
 		Pass:  false,
 	}
 
-	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1)
+	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1, nil)
 
 	if contains(comment, "No issues found") {
 		t.Error("fail verdict must not render the no-issues affirmation")
@@ -516,7 +516,7 @@ func TestFormatVerdictComment_RendersSummary(t *testing.T) {
 		Summary: summary,
 	}
 
-	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1)
+	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1, nil)
 
 	if !contains(comment, "## Reviewed") {
 		t.Error("comment missing Reviewed section from Summary")
@@ -539,7 +539,7 @@ func TestFormatVerdictComment_EmptySummaryNotRendered(t *testing.T) {
 		Summary: "   \n\t  ",
 	}
 
-	comment := FormatVerdictComment(verdict, state.PhasePlan, 1)
+	comment := FormatVerdictComment(verdict, state.PhasePlan, 1, nil)
 
 	if contains(comment, "## Reviewed") || contains(comment, "## Notes") {
 		t.Error("whitespace-only summary should not emit any section")
@@ -771,10 +771,11 @@ func TestPostVerdictWithDiff_InlineComments(t *testing.T) {
 	}
 }
 
-func TestPostVerdictWithDiff_ReviewStillPostedForUnanchoredGaps(t *testing.T) {
-	// #100 follow-up: gaps without file/line used to be dropped
-	// silently from the inline review. Now they surface in the review
-	// body so reviewers still see them in the PR's review tab.
+func TestPostVerdictWithDiff_UnanchoredGapsSurfaceInComment(t *testing.T) {
+	// Gaps without file/line don't produce inline comments, so when
+	// there are no inline comments the verdict is posted as a plain
+	// comment. The unanchored gaps must still appear in the criteria
+	// table of that comment.
 	diff := `diff --git a/x.go b/x.go
 --- a/x.go
 +++ b/x.go
@@ -798,15 +799,19 @@ func TestPostVerdictWithDiff_ReviewStillPostedForUnanchoredGaps(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var sawReview bool
+	// No inline comments → should fall back to gh pr comment, not review API.
+	var sawComment bool
 	for _, call := range runner.Calls {
-		if call.Name == "gh" && len(call.Args) >= 2 &&
-			call.Args[0] == "api" && strings.Contains(strings.Join(call.Args, " "), "reviews") {
-			sawReview = true
+		if call.Name == "gh" && len(call.Args) >= 2 && call.Args[1] == "comment" {
+			sawComment = true
+			body := strings.Join(call.Args, " ")
+			if !strings.Contains(body, "missing docs") {
+				t.Error("verdict comment should contain the unanchored gap")
+			}
 		}
 	}
-	if !sawReview {
-		t.Error("expected review API call so unanchored gap surfaces, saw none")
+	if !sawComment {
+		t.Error("expected gh pr comment call for verdict with no inline comments")
 	}
 }
 
@@ -853,17 +858,17 @@ func TestBuildInlineReview_FiltersByResolvability(t *testing.T) {
 		},
 	}
 
-	review := BuildInlineReview(verdict, diff)
-	if review == nil {
+	result := BuildInlineReview(verdict, diff)
+	if result.Payload == nil {
 		t.Fatal("expected review payload, got nil")
 	}
-	if review.Event != "COMMENT" {
-		t.Errorf("expected event=COMMENT (batched, no notification spam), got %q", review.Event)
+	if result.Payload.Event != "COMMENT" {
+		t.Errorf("expected event=COMMENT (batched, no notification spam), got %q", result.Payload.Event)
 	}
-	if len(review.Comments) != 1 {
-		t.Fatalf("expected 1 inline comment, got %d", len(review.Comments))
+	if len(result.Payload.Comments) != 1 {
+		t.Fatalf("expected 1 inline comment, got %d", len(result.Payload.Comments))
 	}
-	only := review.Comments[0]
+	only := result.Payload.Comments[0]
 	if only.Path != "foo.go" {
 		t.Errorf("expected path foo.go, got %q", only.Path)
 	}
@@ -876,9 +881,16 @@ func TestBuildInlineReview_FiltersByResolvability(t *testing.T) {
 	// The three non-resolvable gaps must now appear in the review body so
 	// reviewers see every concern, not just the subset with anchors.
 	for _, want := range []string{"no file info", "line outside diff", "wrong file"} {
-		if !contains(review.Body, want) {
-			t.Errorf("expected unanchored gap %q in review body, got %q", want, review.Body)
+		if !contains(result.Payload.Body, want) {
+			t.Errorf("expected unanchored gap %q in review body, got %q", want, result.Payload.Body)
 		}
+	}
+	// Verify inline gap index tracking.
+	if !result.InlineGapIndices[0] {
+		t.Error("expected gap index 0 to be marked as inline")
+	}
+	if result.InlineGapIndices[1] || result.InlineGapIndices[2] || result.InlineGapIndices[3] {
+		t.Error("non-inline gap indices should not be in InlineGapIndices")
 	}
 }
 
@@ -902,16 +914,16 @@ func TestBuildInlineReview_UnanchoredGapsStillSurface(t *testing.T) {
 		},
 	}
 
-	review := BuildInlineReview(verdict, diff)
-	if review == nil {
+	result := BuildInlineReview(verdict, diff)
+	if result.Payload == nil {
 		t.Fatal("expected review payload so unanchored gaps surface, got nil")
 	}
-	if len(review.Comments) != 0 {
-		t.Errorf("expected 0 inline comments, got %d", len(review.Comments))
+	if len(result.Payload.Comments) != 0 {
+		t.Errorf("expected 0 inline comments, got %d", len(result.Payload.Comments))
 	}
 	for _, want := range []string{"no location", "out of diff"} {
-		if !contains(review.Body, want) {
-			t.Errorf("expected unanchored gap %q in review body, got %q", want, review.Body)
+		if !contains(result.Payload.Body, want) {
+			t.Errorf("expected unanchored gap %q in review body, got %q", want, result.Payload.Body)
 		}
 	}
 }
@@ -928,8 +940,9 @@ func TestBuildInlineReview_NilWhenNoGapsAtAll(t *testing.T) {
  c
 `
 	verdict := &state.Verdict{}
-	if review := BuildInlineReview(verdict, diff); review != nil {
-		t.Errorf("expected nil review when verdict has no gaps, got %+v", review)
+	result := BuildInlineReview(verdict, diff)
+	if result.Payload != nil {
+		t.Errorf("expected nil payload when verdict has no gaps, got %+v", result.Payload)
 	}
 }
 
@@ -956,17 +969,22 @@ func TestBuildInlineReview_MixedInlineAndSummary(t *testing.T) {
 		},
 	}
 
-	review := BuildInlineReview(verdict, diff)
-	if review == nil || len(review.Comments) != 1 {
-		t.Fatalf("expected exactly 1 inline comment, got %+v", review)
+	result := BuildInlineReview(verdict, diff)
+	if result.Payload == nil || len(result.Payload.Comments) != 1 {
+		t.Fatalf("expected exactly 1 inline comment, got %+v", result)
 	}
 
-	summary := FormatVerdictComment(verdict, state.PhaseQuality, 1)
-	if !contains(summary, "bad on added line") {
-		t.Error("summary must still list the inline-eligible gap")
+	// When inlineGapIndices is passed, the inline gap should be excluded
+	// from the criteria table but the non-inline gap should remain.
+	summary := FormatVerdictComment(verdict, state.PhaseQuality, 1, result.InlineGapIndices)
+	if contains(summary, "| P1 |") {
+		t.Error("inline gap should NOT appear in criteria table when inlineGapIndices is set")
 	}
 	if !contains(summary, "architectural concern") {
 		t.Error("summary must list the location-less gap that has no inline counterpart")
+	}
+	if !contains(summary, "1 additional comment(s) posted inline") {
+		t.Error("summary should note inline comments were posted")
 	}
 }
 
@@ -1048,18 +1066,18 @@ func TestBuildInlineReview_SuggestionPreserved(t *testing.T) {
 		},
 	}
 
-	review := BuildInlineReview(verdict, diff)
-	if review == nil {
+	result := BuildInlineReview(verdict, diff)
+	if result.Payload == nil {
 		t.Fatal("expected review payload")
 	}
-	if len(review.Comments) != 1 {
-		t.Fatalf("expected 1 inline comment, got %d", len(review.Comments))
+	if len(result.Payload.Comments) != 1 {
+		t.Fatalf("expected 1 inline comment, got %d", len(result.Payload.Comments))
 	}
-	if !contains(review.Comments[0].Body, "```suggestion") {
-		t.Errorf("inline comment should contain suggestion block, got %q", review.Comments[0].Body)
+	if !contains(result.Payload.Comments[0].Body, "```suggestion") {
+		t.Errorf("inline comment should contain suggestion block, got %q", result.Payload.Comments[0].Body)
 	}
-	if !contains(review.Comments[0].Body, "os.Getenv") {
-		t.Errorf("suggestion should contain replacement code, got %q", review.Comments[0].Body)
+	if !contains(result.Payload.Comments[0].Body, "os.Getenv") {
+		t.Errorf("suggestion should contain replacement code, got %q", result.Payload.Comments[0].Body)
 	}
 }
 
@@ -1074,7 +1092,7 @@ func TestFormatVerdictComment_GapWithFileLocation(t *testing.T) {
 		},
 	}
 
-	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1)
+	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1, nil)
 
 	// Both gaps should appear in the table regardless of file/line.
 	if !contains(comment, "magic number") {


### PR DESCRIPTION
## Summary
- Posts inline comments and verdict summary as a **single GitHub review** instead of two separate posts (a review + a comment)
- Inline comments now appear as sub-comments of the verdict summary, not under a disconnected "VAIrdict inline review: N comment(s)" header
- Summary criteria table excludes gaps already posted inline, with a note like "> 2 additional comment(s) posted inline on the diff."

## Test plan
- [x] All existing tests updated and passing
- [x] `TestBuildInlineReview_MixedInlineAndSummary` verifies inline gaps excluded from summary criteria table
- [x] `TestPostVerdictWithDiff_InlineComments` verifies single review API call
- [x] `TestPostVerdictWithDiff_UnanchoredGapsSurfaceInComment` verifies fallback to plain comment when no inline comments
- [ ] Manual: trigger `@vairdict review` on a PR and verify inline comments appear under the verdict summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)