### PR TITLE
fix(mentions): remove logo from re-running review comment

### DIFF
--- a/cmd/vairdict/handle_comment.go
+++ b/cmd/vairdict/handle_comment.go
@@ -393,8 +393,8 @@ func handleReviewMention(ctx context.Context, deps handleCommentDeps, prNumber i
 	}
 
 	startBody := fmt.Sprintf(
-		"<img src=\"%s\" alt=\"VAIrdict\" height=\"20\"> Re-running VAIrdict review on @%s's request…\n\n%s\n",
-		github.LogoURL, deps.author, reviewStartMarker)
+		"🔁 Re-running VAIrdict review on @%s's request…\n\n%s\n",
+		deps.author, reviewStartMarker)
 	if err := deps.gh.AddComment(ctx, prNumber, startBody); err != nil {
 		return fmt.Errorf("posting review start comment: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Removes the `<img>` logo tag from the "Re-running VAIrdict review" comment, replacing it with a 🔁 emoji

## Context
The logo in transient status comments is unnecessary visual noise. The verdict comment itself already has the logo branding.

## Test plan
- [x] Existing handle-comment tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)