### PR TITLE
feat(ui): show gaps after failed loops, elapsed time, no-PR message

### DIFF
--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -1009,7 +1009,7 @@ func phaseProgressHandler(spin *ui.Spinner, r ui.Renderer, phase state.Phase) fu
 			r.PhaseLoop(phase, loop, max, score, pass)
 			if !pass && len(gaps) > 0 {
 				// Show blocking gaps inline so the user sees why this loop failed.
-				r.PhaseLoopGaps(gaps)
+				r.PhaseLoopBlockingGaps(gaps)
 			}
 			if !pass {
 				spin.Reset()

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -999,13 +999,18 @@ func emitPhaseAttempts(r ui.Renderer, task *state.Task, phase state.Phase, maxLo
 
 // phaseProgressHandler returns a callback for phase.OnProgress that updates
 // the spinner label on step changes and emits PhaseLoop lines in real time
-// when a loop completes.
-func phaseProgressHandler(spin *ui.Spinner, r ui.Renderer, phase state.Phase) func(loop, max int, step string, score float64, pass bool) {
-	return func(loop, max int, step string, score float64, pass bool) {
+// when a loop completes. On failed loops it also renders blocking gaps so
+// the user can see *why* a loop was rejected without digging into logs.
+func phaseProgressHandler(spin *ui.Spinner, r ui.Renderer, phase state.Phase) func(loop, max int, step string, score float64, pass bool, gaps []state.Gap) {
+	return func(loop, max int, step string, score float64, pass bool, gaps []state.Gap) {
 		if step == "done" {
 			// Loop finished — stop spinner, print result, restart spinner.
 			spin.Stop()
 			r.PhaseLoop(phase, loop, max, score, pass)
+			if !pass && len(gaps) > 0 {
+				// Show blocking gaps inline so the user sees why this loop failed.
+				r.PhaseLoopGaps(gaps)
+			}
 			if !pass {
 				spin.Reset()
 				spin.SetLabel(fmt.Sprintf("loop %d/%d: retrying...", loop+1, max))

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -311,7 +311,7 @@ func (f *fakeRenderer) Close() error                    { return nil }
 func (f *fakeRenderer) Escalation(string, state.Phase, int, float64, []state.Gap) {
 }
 
-func (f *fakeRenderer) PhaseLoopGaps([]state.Gap) {}
+func (f *fakeRenderer) PhaseLoopBlockingGaps([]state.Gap) {}
 
 func (f *fakeRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
 	f.loops = append(f.loops, fakeLoopCall{phase, loop, max, score, pass})

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -311,6 +311,8 @@ func (f *fakeRenderer) Close() error                    { return nil }
 func (f *fakeRenderer) Escalation(string, state.Phase, int, float64, []state.Gap) {
 }
 
+func (f *fakeRenderer) PhaseLoopGaps([]state.Gap) {}
+
 func (f *fakeRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
 	f.loops = append(f.loops, fakeLoopCall{phase, loop, max, score, pass})
 }

--- a/internal/phases/code/phase.go
+++ b/internal/phases/code/phase.go
@@ -36,7 +36,7 @@ type CodePhase struct {
 	judge      Judge
 	cfg        config.CodePhaseConfig
 	workDir    string
-	OnProgress func(loop, max int, step string, score float64, pass bool)
+	OnProgress func(loop, max int, step string, score float64, pass bool, gaps []state.Gap)
 }
 
 // New creates a CodePhase with the given coder, judge, config, and work directory.
@@ -49,9 +49,9 @@ func New(coder Coder, judge Judge, cfg config.CodePhaseConfig, workDir string) *
 	}
 }
 
-func (p *CodePhase) notify(loop, max int, step string, score float64, pass bool) {
+func (p *CodePhase) notify(loop, max int, step string, score float64, pass bool, gaps []state.Gap) {
 	if p.OnProgress != nil {
-		p.OnProgress(loop, max, step, score, pass)
+		p.OnProgress(loop, max, step, score, pass, gaps)
 	}
 }
 
@@ -77,7 +77,7 @@ func (p *CodePhase) Run(ctx context.Context, task *state.Task, plan string) (*Ph
 		prompt := buildCoderPrompt(task.Intent, plan, lastFeedback, task.Assumptions)
 
 		// Run the coder agent.
-		p.notify(loop+1, p.cfg.MaxLoops, "coding", 0, false)
+		p.notify(loop+1, p.cfg.MaxLoops, "coding", 0, false, nil)
 		_, err := p.coder.Run(ctx, prompt, p.workDir)
 		if err != nil {
 			return nil, fmt.Errorf("running coder agent: %w", err)
@@ -89,13 +89,13 @@ func (p *CodePhase) Run(ctx context.Context, task *state.Task, plan string) (*Ph
 		}
 
 		// Run the judge.
-		p.notify(loop+1, p.cfg.MaxLoops, "judging code", 0, false)
+		p.notify(loop+1, p.cfg.MaxLoops, "judging code", 0, false, nil)
 		verdict, err := p.judge.Judge(ctx, p.workDir)
 		if err != nil {
 			return nil, fmt.Errorf("running code judge: %w", err)
 		}
 
-		p.notify(loop+1, p.cfg.MaxLoops, "done", verdict.Score, verdict.Pass)
+		p.notify(loop+1, p.cfg.MaxLoops, "done", verdict.Score, verdict.Pass, verdict.Gaps)
 
 		lastScore = verdict.Score
 

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -46,7 +46,7 @@ type PlanPhase struct {
 	planner    Planner
 	judge      Judge
 	cfg        config.PlanPhaseConfig
-	OnProgress func(loop, max int, step string, score float64, pass bool)
+	OnProgress func(loop, max int, step string, score float64, pass bool, gaps []state.Gap)
 }
 
 // New creates a PlanPhase with the given planner client, judge, and config.
@@ -58,9 +58,9 @@ func New(planner Planner, judge Judge, cfg config.PlanPhaseConfig) *PlanPhase {
 	}
 }
 
-func (p *PlanPhase) notify(loop, max int, step string, score float64, pass bool) {
+func (p *PlanPhase) notify(loop, max int, step string, score float64, pass bool, gaps []state.Gap) {
 	if p.OnProgress != nil {
-		p.OnProgress(loop, max, step, score, pass)
+		p.OnProgress(loop, max, step, score, pass, gaps)
 	}
 }
 
@@ -112,7 +112,7 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 		prompt := buildPlannerPrompt(task.Intent, lastFeedback, task.Assumptions, task.HardConstraints)
 
 		// Call the planner agent.
-		p.notify(loop+1, p.cfg.MaxLoops, "generating plan", 0, false)
+		p.notify(loop+1, p.cfg.MaxLoops, "generating plan", 0, false, nil)
 		var resp plannerResponse
 		if err := p.planner.CompleteWithSystem(ctx, plannerSystemPrompt, prompt, &resp); err != nil {
 			return nil, fmt.Errorf("calling planner agent: %w", err)
@@ -127,13 +127,13 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 		}
 
 		// Run the judge.
-		p.notify(loop+1, p.cfg.MaxLoops, "judging plan", 0, false)
+		p.notify(loop+1, p.cfg.MaxLoops, "judging plan", 0, false, nil)
 		verdict, err := p.judge.Judge(ctx, task.Intent, fullPlan)
 		if err != nil {
 			return nil, fmt.Errorf("running plan judge: %w", err)
 		}
 
-		p.notify(loop+1, p.cfg.MaxLoops, "done", verdict.Score, verdict.Pass)
+		p.notify(loop+1, p.cfg.MaxLoops, "done", verdict.Score, verdict.Pass, verdict.Gaps)
 
 		lastScore = verdict.Score
 

--- a/internal/phases/quality/phase.go
+++ b/internal/phases/quality/phase.go
@@ -52,7 +52,7 @@ type QualityPhase struct {
 	judge      Judge
 	cfg        config.QualityPhaseConfig
 	diff       string
-	OnProgress func(loop, max int, step string, score float64, pass bool)
+	OnProgress func(loop, max int, step string, score float64, pass bool, gaps []state.Gap)
 }
 
 // New creates a QualityPhase with the given judge, config, and diff. The
@@ -67,9 +67,9 @@ func New(judge Judge, cfg config.QualityPhaseConfig, diff string) *QualityPhase 
 	}
 }
 
-func (p *QualityPhase) notify(loop, max int, step string, score float64, pass bool) {
+func (p *QualityPhase) notify(loop, max int, step string, score float64, pass bool, gaps []state.Gap) {
 	if p.OnProgress != nil {
-		p.OnProgress(loop, max, step, score, pass)
+		p.OnProgress(loop, max, step, score, pass, gaps)
 	}
 }
 
@@ -95,13 +95,13 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 			return nil, fmt.Errorf("transitioning to quality review: %w", err)
 		}
 
-		p.notify(loop+1, p.cfg.MaxLoops, "reviewing", 0, false)
+		p.notify(loop+1, p.cfg.MaxLoops, "reviewing", 0, false, nil)
 		verdict, err := p.judge.Judge(ctx, task.Intent, plan, p.diff)
 		if err != nil {
 			return nil, fmt.Errorf("running quality judge: %w", err)
 		}
 
-		p.notify(loop+1, p.cfg.MaxLoops, "done", verdict.Score, verdict.Pass)
+		p.notify(loop+1, p.cfg.MaxLoops, "done", verdict.Score, verdict.Pass, verdict.Gaps)
 
 		lastScore = verdict.Score
 

--- a/internal/ui/ci.go
+++ b/internal/ui/ci.go
@@ -44,7 +44,7 @@ func (r *ciRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, 
 	r.printf("vairdict: phase loop phase=%s loop=%d/%d score=%.0f pass=%v\n", phase, loop, max, score, pass)
 }
 
-func (r *ciRenderer) PhaseLoopGaps(gaps []state.Gap) {
+func (r *ciRenderer) PhaseLoopBlockingGaps(gaps []state.Gap) {
 	for _, g := range gaps {
 		if g.Blocking {
 			r.printf("vairdict: gap [%s] %s\n", g.Severity, g.Description)

--- a/internal/ui/ci.go
+++ b/internal/ui/ci.go
@@ -44,6 +44,14 @@ func (r *ciRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, 
 	r.printf("vairdict: phase loop phase=%s loop=%d/%d score=%.0f pass=%v\n", phase, loop, max, score, pass)
 }
 
+func (r *ciRenderer) PhaseLoopGaps(gaps []state.Gap) {
+	for _, g := range gaps {
+		if g.Blocking {
+			r.printf("vairdict: gap [%s] %s\n", g.Severity, g.Description)
+		}
+	}
+}
+
 func (r *ciRenderer) PhaseDone(
 	phase state.Phase,
 	outcome PhaseOutcome,

--- a/internal/ui/cli.go
+++ b/internal/ui/cli.go
@@ -108,7 +108,7 @@ func (r *cliRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64,
 		loop, max, rule, scoreColor, score, r.pal.reset, mark)
 }
 
-func (r *cliRenderer) PhaseLoopGaps(gaps []state.Gap) {
+func (r *cliRenderer) PhaseLoopBlockingGaps(gaps []state.Gap) {
 	defer r.flush()
 	// Only show blocking gaps inline to keep output concise.
 	var blocking []state.Gap

--- a/internal/ui/cli.go
+++ b/internal/ui/cli.go
@@ -108,6 +108,23 @@ func (r *cliRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64,
 		loop, max, rule, scoreColor, score, r.pal.reset, mark)
 }
 
+func (r *cliRenderer) PhaseLoopGaps(gaps []state.Gap) {
+	defer r.flush()
+	// Only show blocking gaps inline to keep output concise.
+	var blocking []state.Gap
+	for _, g := range gaps {
+		if g.Blocking {
+			blocking = append(blocking, g)
+		}
+	}
+	if len(blocking) == 0 {
+		return
+	}
+	for _, g := range blocking {
+		r.printf("     %s%s%s [%s] %s\n", r.pal.dim, r.glyphs.blocking, r.pal.reset, g.Severity, g.Description)
+	}
+}
+
 func (r *cliRenderer) PhaseDone(
 	phase state.Phase,
 	outcome PhaseOutcome,
@@ -162,7 +179,7 @@ func (r *cliRenderer) Escalation(taskID string, phase state.Phase, loops int, sc
 		r.renderGaps(gaps)
 	}
 	r.println("")
-	r.printf("   %sHuman intervention required.%s\n", r.pal.dim, r.pal.reset)
+	r.printf("   %sNo PR was created. Human intervention required.%s\n", r.pal.dim, r.pal.reset)
 }
 
 func (r *cliRenderer) RunComplete(taskID string) {

--- a/internal/ui/json.go
+++ b/internal/ui/json.go
@@ -64,6 +64,24 @@ func (r *jsonRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64
 	})
 }
 
+func (r *jsonRenderer) PhaseLoopGaps(gaps []state.Gap) {
+	if len(gaps) == 0 {
+		return
+	}
+	var blocking []any
+	for _, g := range gaps {
+		if g.Blocking {
+			blocking = append(blocking, map[string]any{
+				"severity":    string(g.Severity),
+				"description": g.Description,
+			})
+		}
+	}
+	if len(blocking) > 0 {
+		r.emit("phase_loop_gaps", map[string]any{"gaps": blocking})
+	}
+}
+
 func (r *jsonRenderer) PhaseDone(
 	phase state.Phase,
 	outcome PhaseOutcome,

--- a/internal/ui/json.go
+++ b/internal/ui/json.go
@@ -64,7 +64,7 @@ func (r *jsonRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64
 	})
 }
 
-func (r *jsonRenderer) PhaseLoopGaps(gaps []state.Gap) {
+func (r *jsonRenderer) PhaseLoopBlockingGaps(gaps []state.Gap) {
 	if len(gaps) == 0 {
 		return
 	}

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -22,9 +22,10 @@ type Spinner struct {
 	pal    palette
 	frames []string
 
-	mu      sync.Mutex
-	running bool
-	done    chan struct{}
+	mu        sync.Mutex
+	running   bool
+	done      chan struct{}
+	startedAt time.Time
 }
 
 // NewSpinner creates a spinner that writes to w. Call Start() to begin
@@ -58,6 +59,7 @@ func (s *Spinner) Start() {
 		return
 	}
 	s.running = true
+	s.startedAt = time.Now()
 	s.mu.Unlock()
 
 	go s.loop()
@@ -75,10 +77,16 @@ func (s *Spinner) loop() {
 		case <-tick.C:
 			s.mu.Lock()
 			label := s.label
+			elapsed := time.Since(s.startedAt).Truncate(time.Second)
 			s.mu.Unlock()
 			frame := s.frames[i%len(s.frames)]
+			// Show elapsed time after the label (only once >=1s has passed).
+			elapsedStr := ""
+			if elapsed >= time.Second {
+				elapsedStr = fmt.Sprintf(" %s(%s)%s", s.pal.dim, formatDuration(elapsed), s.pal.reset)
+			}
 			// \r returns to start of line, print spinner + label, clear rest of line with \033[K
-			_, _ = fmt.Fprintf(s.w, "\r   %s%s %s%s\033[K", s.pal.dim, frame, label, s.pal.reset)
+			_, _ = fmt.Fprintf(s.w, "\r   %s%s %s%s%s\033[K", s.pal.dim, frame, label, s.pal.reset, elapsedStr)
 			i++
 		}
 	}
@@ -110,4 +118,19 @@ func (s *Spinner) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.done = make(chan struct{})
+}
+
+// formatDuration renders a duration as a compact human-readable string:
+// "5s", "1m30s", "2m".
+func formatDuration(d time.Duration) string {
+	d = d.Truncate(time.Second)
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	if m == 0 {
+		return fmt.Sprintf("%ds", s)
+	}
+	if s == 0 {
+		return fmt.Sprintf("%dm", m)
+	}
+	return fmt.Sprintf("%dm%ds", m, s)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -107,6 +107,10 @@ type Renderer interface {
 	// PhaseLoop prints one loop's progress line within a phase.
 	PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool)
 
+	// PhaseLoopGaps prints blocking gaps inline after a failed loop so the
+	// user can see why a loop was rejected without digging into logs.
+	PhaseLoopGaps(gaps []state.Gap)
+
 	// PhaseDone prints the closing summary block for a phase: outcome,
 	// score, loops, narrative summary (if any), and gaps (if any).
 	PhaseDone(

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -107,9 +107,11 @@ type Renderer interface {
 	// PhaseLoop prints one loop's progress line within a phase.
 	PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool)
 
-	// PhaseLoopGaps prints blocking gaps inline after a failed loop so the
-	// user can see why a loop was rejected without digging into logs.
-	PhaseLoopGaps(gaps []state.Gap)
+	// PhaseLoopBlockingGaps prints blocking gaps inline after a failed loop
+	// so the user can see why a loop was rejected without digging into logs.
+	// Only gaps with Blocking == true are rendered; non-blocking gaps are
+	// omitted to keep the output concise.
+	PhaseLoopBlockingGaps(gaps []state.Gap)
 
 	// PhaseDone prints the closing summary block for a phase: outcome,
 	// score, loops, narrative summary (if any), and gaps (if any).


### PR DESCRIPTION
## Summary
- **Inline blocking gaps after failed loops**: Each failed loop now shows the blocking gaps that caused the rejection, so users don't need to dig into log files to understand why a loop failed
- **Elapsed time on spinner**: The spinner now displays elapsed time (e.g. `loop 1/3: judging plan (45s)`) giving visibility into how long each agent call is taking
- **Explicit "No PR created" on escalation**: The escalation block now says "No PR was created. Human intervention required." instead of just "Human intervention required."

### Before
```
📋 Plan phase
   Loop 1/3 ──────────── 75% ❌
   Loop 2/3 ──────────── 75% ❌
   ⠙ loop 3/3: judging plan
```

### After
```
📋 Plan phase
   Loop 1/3 ──────────── 75% ❌
     ⛔ [P1] plan does not address error handling requirements
     ⛔ [P0] missing database migration strategy
   Loop 2/3 ──────────── 75% ❌
     ⛔ [P1] plan does not address error handling requirements
   ⠙ loop 3/3: judging plan (1m30s)

   No PR was created. Human intervention required.
```

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/ui/... ./internal/phases/... ./cmd/vairdict/...` all pass
- [ ] Manual test: run `vairdict run --issue <N>` on a task that fails a phase and verify gaps appear inline
- [ ] Manual test: verify elapsed time appears on spinner after ~1s
- [ ] Manual test: verify escalation shows "No PR was created" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)