### PR TITLE
feat(state/rewind-context): structured failure context propagation on rewind (#86)

### DIFF
--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -822,18 +822,11 @@ func buildRewindContext(cycle int, target state.Phase, v *state.Verdict, priorAp
 	}
 	if strings.TrimSpace(v.Summary) != "" {
 		rc.RootCause = v.Summary
-	} else if len(v.Gaps) > 0 {
-		// Fall back to the first blocking gap, then any gap, as the
-		// one-line diagnosis when the judge didn't write a summary.
-		for _, g := range v.Gaps {
-			if g.Blocking {
-				rc.RootCause = g.Description
-				break
-			}
-		}
-		if rc.RootCause == "" {
-			rc.RootCause = v.Gaps[0].Description
-		}
+	} else if g := pickDiagnosisGap(v.Gaps); g != nil {
+		// Fall back to a gap description when the judge didn't write a
+		// summary. Prefix with severity so a P3 gap can't masquerade as
+		// the blocking diagnosis when it ends up being the only one.
+		rc.RootCause = fmt.Sprintf("[%s] %s", g.Severity, g.Description)
 	}
 	for _, g := range v.Gaps {
 		line := fmt.Sprintf("[%s] %s", g.Severity, g.Description)
@@ -850,6 +843,21 @@ func buildRewindContext(cycle int, target state.Phase, v *state.Verdict, priorAp
 		}
 	}
 	return rc
+}
+
+// pickDiagnosisGap picks the most representative gap to use as a root-
+// cause fallback: the first blocking gap if any exists, else the first
+// gap. Returns nil when the slice is empty.
+func pickDiagnosisGap(gaps []state.Gap) *state.Gap {
+	for i := range gaps {
+		if gaps[i].Blocking {
+			return &gaps[i]
+		}
+	}
+	if len(gaps) > 0 {
+		return &gaps[0]
+	}
+	return nil
 }
 
 // buildQualityHardConstraints extracts the blocking gaps from the last

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -665,19 +666,30 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 			})
 		}
 
+		qualityVerdict := lastVerdictForPhase(task, state.PhaseQuality)
 		switch qualityResult.ReturnTo {
 		case state.ReturnToCode:
+			// The coder's "approach" is the diff it produced, not the
+			// plan it worked from — the plan survives into the next
+			// code run untouched, so telling the coder not to reproduce
+			// the plan would be wrong. The diff captures what actually
+			// failed and must change.
+			task.RewindContexts = append(task.RewindContexts,
+				buildRewindContext(cycle+1, state.PhaseCode, qualityVerdict, qualityResult.Diff))
 			if err := task.Rewind(state.PhaseCode); err != nil {
 				r.Error(err)
 				return fmt.Errorf("rewinding to code: %w", err)
 			}
 			slog.Info("outer loop rewinding to code",
 				"task_id", task.ID, "cycle", cycle+1,
+				"rewind_contexts", len(task.RewindContexts),
 			)
 			continue
 		case state.ReturnToPlan:
 			task.HardConstraints = append(task.HardConstraints,
-				buildQualityHardConstraints(lastVerdictForPhase(task, state.PhaseQuality))...)
+				buildQualityHardConstraints(qualityVerdict)...)
+			task.RewindContexts = append(task.RewindContexts,
+				buildRewindContext(cycle+1, state.PhasePlan, qualityVerdict, planResult.Plan))
 			if err := task.Rewind(state.PhasePlan); err != nil {
 				r.Error(err)
 				return fmt.Errorf("rewinding to plan: %w", err)
@@ -686,6 +698,7 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 			slog.Info("outer loop rewinding to plan",
 				"task_id", task.ID, "cycle", cycle+1,
 				"hard_constraints", len(task.HardConstraints),
+				"rewind_contexts", len(task.RewindContexts),
 			)
 			continue
 		}
@@ -788,6 +801,55 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 
 	r.RunComplete(task.ID)
 	return nil
+}
+
+// buildRewindContext packages the quality judge's verdict into a
+// structured RewindContext for the planner or coder. priorApproach is
+// whatever the next attempt must not reproduce: the prior plan for a
+// ReturnToPlan rewind, the prior code diff for a ReturnToCode rewind.
+// Every blocking gap becomes a MustAddress entry; every gap (blocking
+// or not) becomes a Failure entry so the next attempt sees the
+// symptoms, not just the diagnosis.
+func buildRewindContext(cycle int, target state.Phase, v *state.Verdict, priorApproach string) state.RewindContext {
+	rc := state.RewindContext{
+		Cycle:         cycle,
+		Target:        target,
+		TriedApproach: priorApproach,
+		CreatedAt:     time.Now(),
+	}
+	if v == nil {
+		return rc
+	}
+	if strings.TrimSpace(v.Summary) != "" {
+		rc.RootCause = v.Summary
+	} else if len(v.Gaps) > 0 {
+		// Fall back to the first blocking gap, then any gap, as the
+		// one-line diagnosis when the judge didn't write a summary.
+		for _, g := range v.Gaps {
+			if g.Blocking {
+				rc.RootCause = g.Description
+				break
+			}
+		}
+		if rc.RootCause == "" {
+			rc.RootCause = v.Gaps[0].Description
+		}
+	}
+	for _, g := range v.Gaps {
+		line := fmt.Sprintf("[%s] %s", g.Severity, g.Description)
+		if g.File != "" {
+			if g.Line > 0 {
+				line = fmt.Sprintf("%s (%s:%d)", line, g.File, g.Line)
+			} else {
+				line = fmt.Sprintf("%s (%s)", line, g.File)
+			}
+		}
+		rc.Failure = append(rc.Failure, line)
+		if g.Blocking {
+			rc.MustAddress = append(rc.MustAddress, g.Description)
+		}
+	}
+	return rc
 }
 
 // buildQualityHardConstraints extracts the blocking gaps from the last

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -1047,6 +1047,139 @@ func TestRunOrchestration_CycleBudgetExhausted(t *testing.T) {
 	}
 }
 
+func TestRunOrchestration_QualityReturnToCode_AppendsRewindContext(t *testing.T) {
+	t.Parallel()
+	// #86: on every rewind the orchestrator must build a structured
+	// RewindContext from the quality verdict and append it to the task
+	// so the next attempt doesn't reproduce the failed approach.
+	b := newOrchBundle()
+	b.plan.result = &planphase.PhaseResult{
+		Pass: true, Loops: 1, LastScore: 90, Plan: "approved plan v1",
+	}
+	b.quality.results = []*qualityphase.PhaseResult{
+		{ReturnTo: state.ReturnToCode, Loops: 1, LastScore: 50, Diff: "--- a/main.go\n+++ b/main.go\n@@ retry loop @@"},
+		{Pass: true, Loops: 1, LastScore: 95, Diff: "diff-2"},
+	}
+	b.quality.gapsByCall = [][]state.Gap{
+		{{Severity: state.SeverityP0, Description: "race in retry loop", Blocking: true}},
+		nil,
+	}
+	task := state.NewTask("t-rc", "intent")
+	r := &fakeRenderer{}
+
+	if err := runOrchestration(context.Background(), b.deps(), task, r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(task.RewindContexts) != 1 {
+		t.Fatalf("expected 1 rewind context after a single rewind to code, got %d", len(task.RewindContexts))
+	}
+	rc := task.RewindContexts[0]
+	if rc.Target != state.PhaseCode {
+		t.Errorf("expected Target=code, got %s", rc.Target)
+	}
+	if rc.Cycle != 1 {
+		t.Errorf("expected Cycle=1, got %d", rc.Cycle)
+	}
+	if rc.RootCause == "" {
+		t.Error("expected RootCause populated from quality verdict")
+	}
+	// On ReturnToCode, TriedApproach must be the code diff — what the
+	// coder produced — not the plan it worked against. Without that,
+	// the next code run can regenerate the same broken implementation.
+	if !strings.Contains(rc.TriedApproach, "retry loop") {
+		t.Errorf("expected prior code diff recorded as TriedApproach, got %q", rc.TriedApproach)
+	}
+	if strings.Contains(rc.TriedApproach, "approved plan v1") {
+		t.Error("TriedApproach on a ReturnToCode rewind must be the diff, not the plan")
+	}
+	if len(rc.MustAddress) == 0 {
+		t.Error("expected blocking gap recorded in MustAddress")
+	}
+}
+
+func TestRunOrchestration_MultipleRewindsAccumulateContext(t *testing.T) {
+	t.Parallel()
+	// #86 acceptance: multiple rewinds must accumulate context (no
+	// amnesia). Two successive code rewinds followed by a pass → the
+	// task ends with two distinct rewind contexts and the coder sees
+	// the latest two on its final call.
+	b := newOrchBundle()
+	b.plan.result = &planphase.PhaseResult{
+		Pass: true, Loops: 1, LastScore: 90, Plan: "plan v1",
+	}
+	b.quality.results = []*qualityphase.PhaseResult{
+		{ReturnTo: state.ReturnToCode, Loops: 1, LastScore: 40, Diff: "d1"},
+		{ReturnTo: state.ReturnToCode, Loops: 1, LastScore: 55, Diff: "d2"},
+		{Pass: true, Loops: 1, LastScore: 95, Diff: "d3"},
+	}
+	b.quality.gapsByCall = [][]state.Gap{
+		{{Severity: state.SeverityP0, Description: "first failure", Blocking: true}},
+		{{Severity: state.SeverityP0, Description: "second failure", Blocking: true}},
+		nil,
+	}
+	task := state.NewTask("t-acc", "intent")
+	r := &fakeRenderer{}
+
+	if err := runOrchestration(context.Background(), b.deps(), task, r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(task.RewindContexts) != 2 {
+		t.Fatalf("expected 2 rewind contexts accumulated, got %d", len(task.RewindContexts))
+	}
+	if task.RewindContexts[0].Cycle != 1 || task.RewindContexts[1].Cycle != 2 {
+		t.Errorf("expected cycles [1,2], got [%d,%d]", task.RewindContexts[0].Cycle, task.RewindContexts[1].Cycle)
+	}
+	if task.RewindContexts[0].RootCause == task.RewindContexts[1].RootCause {
+		t.Error("each rewind must record its own distinct root cause — no amnesia")
+	}
+	for _, rc := range task.RewindContexts {
+		if rc.Target != state.PhaseCode {
+			t.Errorf("expected Target=code for every rewind, got %s", rc.Target)
+		}
+	}
+}
+
+func TestRunOrchestration_QualityReturnToPlan_AppendsRewindContext(t *testing.T) {
+	t.Parallel()
+	// On a ReturnToPlan rewind the orchestrator must build a
+	// plan-targeted RewindContext AND keep the HardConstraints behavior
+	// intact — the two mechanisms coexist: HardConstraints are the
+	// non-negotiable list, RewindContext is the rich "why + what not
+	// to reproduce" block.
+	b := newOrchBundle()
+	b.plan.results = []*planphase.PhaseResult{
+		{Pass: true, Loops: 1, LastScore: 90, Plan: "plan v1"},
+		{Pass: true, Loops: 1, LastScore: 92, Plan: "plan v2"},
+	}
+	b.quality.results = []*qualityphase.PhaseResult{
+		{ReturnTo: state.ReturnToPlan, Loops: 1, LastScore: 30, Diff: "d1"},
+		{Pass: true, Loops: 1, LastScore: 95, Diff: "d2"},
+	}
+	b.quality.gapsByCall = [][]state.Gap{
+		{{Severity: state.SeverityP0, Description: "plan too narrow", Blocking: true}},
+		nil,
+	}
+	task := state.NewTask("t-rp", "intent")
+	r := &fakeRenderer{}
+
+	if err := runOrchestration(context.Background(), b.deps(), task, r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(task.RewindContexts) != 1 {
+		t.Fatalf("expected 1 rewind context, got %d", len(task.RewindContexts))
+	}
+	rc := task.RewindContexts[0]
+	if rc.Target != state.PhasePlan {
+		t.Errorf("expected Target=plan, got %s", rc.Target)
+	}
+	if !strings.Contains(rc.TriedApproach, "plan v1") {
+		t.Errorf("expected prior plan in TriedApproach, got %q", rc.TriedApproach)
+	}
+	if len(task.HardConstraints) == 0 {
+		t.Error("HardConstraints should still be populated alongside RewindContext")
+	}
+}
+
 func TestRunOrchestration_PostVerdictFailure_DoesNotFailRun(t *testing.T) {
 	t.Parallel()
 	b := newOrchBundle()

--- a/internal/judges/quality/diffannot.go
+++ b/internal/judges/quality/diffannot.go
@@ -1,0 +1,75 @@
+package quality
+
+import (
+	"strconv"
+	"strings"
+)
+
+// annotateDiff walks a unified diff and prefixes every added ('+') line
+// with its absolute new-file line number in the form "+L<n>: ". The goal
+// is to let the judging model cite file:line anchors by copying the
+// number it sees rather than counting lines within a hunk — LLMs
+// routinely get that arithmetic wrong, which produces mis-anchored
+// inline PR comments.
+//
+// Context and removed lines are left untouched: the judge anchors gaps
+// to new-file lines (the "+ side"), so only added lines need the label.
+// The hunk header still provides the starting line number for any edge
+// cases the prompt wants to reason about.
+//
+// The input is expected to be a standard `git diff` unified output; any
+// line the parser can't classify is passed through verbatim so a
+// malformed diff never prevents the judge from running.
+func annotateDiff(diff string) string {
+	if diff == "" {
+		return diff
+	}
+	lines := strings.Split(diff, "\n")
+	var newLine int
+	inHunk := false
+
+	for i, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "@@"):
+			newLine = parseHunkNewStart(line)
+			inHunk = newLine > 0
+		case !inHunk:
+			// File headers ("diff --git", "---", "+++", "index ...") and
+			// any pre-hunk content pass through unchanged.
+		case strings.HasPrefix(line, "+++"), strings.HasPrefix(line, "---"):
+			// File headers can appear between hunks in multi-file diffs;
+			// they don't advance the line counter.
+		case strings.HasPrefix(line, "+"):
+			lines[i] = "+L" + strconv.Itoa(newLine) + ": " + line[1:]
+			newLine++
+		case strings.HasPrefix(line, "-"):
+			// Removed line — no new-file number to attach.
+		case strings.HasPrefix(line, " "), line == "":
+			// Context line — advances the new-file counter without
+			// receiving a label (gaps anchor to added lines).
+			newLine++
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// parseHunkNewStart extracts the starting new-file line number from a
+// unified-diff hunk header: "@@ -<old>,<len> +<new>,<len> @@ ...".
+// Returns 0 when the header is malformed so the caller can skip
+// annotation for that hunk rather than fabricate line numbers.
+func parseHunkNewStart(header string) int {
+	plus := strings.Index(header, "+")
+	if plus < 0 {
+		return 0
+	}
+	rest := header[plus+1:]
+	end := strings.IndexAny(rest, ", @")
+	if end < 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/judges/quality/diffannot_test.go
+++ b/internal/judges/quality/diffannot_test.go
@@ -1,0 +1,143 @@
+package quality
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnnotateDiff_AddsNewFileLineNumberToAddedLines(t *testing.T) {
+	in := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -10,3 +10,4 @@ func Foo() {
+ 	a := 1
++	b := 2
+ 	return a + b
++	// trailing comment
+`
+	out := annotateDiff(in)
+
+	// First '+' line is line 11 (hunk starts at 10, one preceding context line).
+	if !strings.Contains(out, "+L11: \tb := 2") {
+		t.Errorf("expected '+L11: \\tb := 2' in annotated diff, got:\n%s", out)
+	}
+	// Second '+' line: after line 11 and context line 12, trailing '+' is 13.
+	if !strings.Contains(out, "+L13: \t// trailing comment") {
+		t.Errorf("expected '+L13: \\t// trailing comment' in annotated diff, got:\n%s", out)
+	}
+}
+
+func TestAnnotateDiff_LeavesRemovedAndContextLinesAlone(t *testing.T) {
+	in := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -5,3 +5,3 @@
+ 	context line
+-	removed line
++	added line
+`
+	out := annotateDiff(in)
+
+	// Context line must not be modified at all.
+	if !strings.Contains(out, "\n \tcontext line\n") {
+		t.Errorf("context line should pass through unchanged, got:\n%s", out)
+	}
+	// Removed line must keep its '-' prefix and content intact.
+	if !strings.Contains(out, "\n-\tremoved line\n") {
+		t.Errorf("removed line should pass through unchanged, got:\n%s", out)
+	}
+	// Added line gets the label.
+	if !strings.Contains(out, "+L6: \tadded line") {
+		t.Errorf("added line should be labelled +L6, got:\n%s", out)
+	}
+}
+
+func TestAnnotateDiff_HandlesMultipleHunksPerFile(t *testing.T) {
+	// Two hunks in one file; each restarts from its own @@ header.
+	in := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1,2 +1,3 @@
+ 	a
++	b
+@@ -10,2 +11,3 @@
+ 	x
++	y
+`
+	out := annotateDiff(in)
+
+	if !strings.Contains(out, "+L2: \tb") {
+		t.Errorf("first hunk's added line should be L2, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+L12: \ty") {
+		t.Errorf("second hunk's added line should be L12 (11 + 1 context), got:\n%s", out)
+	}
+}
+
+func TestAnnotateDiff_HandlesMultipleFiles(t *testing.T) {
+	// Annotator should restart counting at every file's first hunk.
+	in := `diff --git a/a.go b/a.go
+--- a/a.go
++++ b/a.go
+@@ -1,1 +1,2 @@
+ 	x
++	y
+diff --git a/b.go b/b.go
+--- a/b.go
++++ b/b.go
+@@ -100,1 +100,2 @@
+ 	p
++	q
+`
+	out := annotateDiff(in)
+
+	if !strings.Contains(out, "+L2: \ty") {
+		t.Errorf("a.go added line should be L2, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+L101: \tq") {
+		t.Errorf("b.go added line should be L101, got:\n%s", out)
+	}
+}
+
+func TestAnnotateDiff_EmptyAndNonDiffInputsPassThrough(t *testing.T) {
+	if got := annotateDiff(""); got != "" {
+		t.Errorf("empty input should return empty, got %q", got)
+	}
+	// Input with no @@ header at all: nothing to annotate, pass through.
+	nonDiff := "just some text\nwith a + leading char\nbut no hunks"
+	if got := annotateDiff(nonDiff); got != nonDiff {
+		t.Errorf("non-diff input should pass through verbatim, got:\n%s", got)
+	}
+}
+
+func TestAnnotateDiff_MalformedHunkHeaderSkipsAnnotation(t *testing.T) {
+	// When parseHunkNewStart returns 0, we must NOT fabricate a label.
+	// "@@ no plus side @@" is malformed; the following '+' line stays raw.
+	in := "@@ malformed @@\n+content\n"
+	out := annotateDiff(in)
+	if strings.Contains(out, "+L0:") {
+		t.Errorf("malformed hunk must not produce L0 labels, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+content") {
+		t.Errorf("malformed hunk should leave added line untouched, got:\n%s", out)
+	}
+}
+
+func TestParseHunkNewStart(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"@@ -1,3 +4,5 @@", 4},
+		{"@@ -10,0 +11 @@ func Foo()", 11},
+		{"@@ -5 +5 @@", 5},
+		{"@@ no plus side @@", 0},
+		{"", 0},
+		{"@@ -1,3 +notanumber @@", 0},
+	}
+	for _, c := range cases {
+		if got := parseHunkNewStart(c.in); got != c.want {
+			t.Errorf("parseHunkNewStart(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -318,6 +318,12 @@ escalate.
    repo-wide gaps (e.g. "missing CI workflow", "no README section"). Gaps
    without an anchor cannot be posted as inline PR comments, so defaulting
    to file/line keeps reviewers' feedback visible where it belongs.
+   Every added ('+') line in the diff is pre-labelled "+L<n>: ..." where
+   <n> is its absolute new-file line number — copy that number verbatim
+   into "line". Do NOT count lines yourself from the @@ hunk header; use
+   the label. If the line you want to reference is unchanged context
+   (not a '+' line), pick the nearest adjacent '+' line and anchor
+   there — GitHub review comments can only attach to changed lines.
 5. For gaps with file/line, you may also set "suggestion" — the exact replacement
    code for the line(s) at that location. The suggestion is rendered as a GitHub
    suggestion block that the author can apply with one click. Rules:
@@ -493,6 +499,8 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 	diffSection := diff
 	if strings.TrimSpace(diffSection) == "" {
 		diffSection = "(no diff provided — judge cannot evaluate code changes)"
+	} else {
+		diffSection = annotateDiff(diffSection)
 	}
 
 	var facts string

--- a/internal/phases/code/phase.go
+++ b/internal/phases/code/phase.go
@@ -74,7 +74,8 @@ func (p *CodePhase) Run(ctx context.Context, task *state.Task, plan string) (*Ph
 		)
 
 		// Build the coder prompt.
-		prompt := buildCoderPrompt(task.Intent, plan, lastFeedback, task.Assumptions)
+		prompt := buildCoderPrompt(task.Intent, plan, lastFeedback, task.Assumptions,
+			state.RewindContextsFor(task.RewindContexts, state.PhaseCode))
 
 		// Run the coder agent.
 		p.notify(loop+1, p.cfg.MaxLoops, "coding", 0, false, nil)
@@ -158,7 +159,15 @@ func (p *CodePhase) Run(ctx context.Context, task *state.Task, plan string) (*Ph
 	}, nil
 }
 
-func buildCoderPrompt(intent string, plan string, feedback string, assumptions []state.Assumption) string {
+// buildCoderPrompt constructs the prompt for the coder agent.
+//
+// When rewindContexts is non-empty, an explicit Rewind Context block is
+// emitted ahead of guidelines and feedback. The block uses the canonical
+// "Previous attempt failed because X. You may not reproduce approach Y.
+// Your plan must explicitly address Z." framing from issue #86 — that
+// constraint is what stops successive rewinds from converging on the
+// same code.
+func buildCoderPrompt(intent string, plan string, feedback string, assumptions []state.Assumption, rewindContexts []state.RewindContext) string {
 	var b strings.Builder
 
 	b.WriteString("## Task Intent\n")
@@ -168,6 +177,15 @@ func buildCoderPrompt(intent string, plan string, feedback string, assumptions [
 	b.WriteString("## Approved Plan\n")
 	b.WriteString(plan)
 	b.WriteString("\n")
+
+	if len(rewindContexts) > 0 {
+		b.WriteString("\n## Rewind Context (previous outer cycles)\n")
+		b.WriteString("Earlier plan→code→quality cycles failed and the outer loop rewound back to code. ")
+		b.WriteString("You must NOT reproduce the approaches below. Your implementation must explicitly address every failure listed.\n")
+		for _, rc := range rewindContexts {
+			rc.RenderPromptBlock(&b)
+		}
+	}
 
 	b.WriteString("\n")
 	b.WriteString(standards.Block)

--- a/internal/phases/code/phase_test.go
+++ b/internal/phases/code/phase_test.go
@@ -14,7 +14,7 @@ import (
 func TestBuildCoderPrompt_IncludesBaseline(t *testing.T) {
 	// #84: the coder must see the non-negotiable standards so it doesn't
 	// write code that would be flagged during quality.
-	prompt := buildCoderPrompt("do stuff", "step 1", "", nil)
+	prompt := buildCoderPrompt("do stuff", "step 1", "", nil, nil)
 	if !strings.Contains(prompt, standards.Block) {
 		t.Error("coder prompt must include the baseline standards block")
 	}
@@ -228,7 +228,7 @@ func TestRun_AttemptsStored(t *testing.T) {
 func TestBuildCoderPrompt(t *testing.T) {
 	prompt := buildCoderPrompt("intent", "plan", "fix tests", []state.Assumption{
 		{Severity: state.SeverityP2, Description: "assumed X"},
-	})
+	}, nil)
 
 	if !containsStr(prompt, "intent") {
 		t.Error("prompt should contain intent")
@@ -245,6 +245,104 @@ func TestBuildCoderPrompt(t *testing.T) {
 	if !containsStr(prompt, "Avoid duplicating logic") {
 		t.Error("prompt should contain code-reuse guidance")
 	}
+}
+
+func TestBuildCoderPrompt_WithRewindContext(t *testing.T) {
+	// #86: when the outer loop rewinds to code, the coder must see
+	// structured context — root cause, prior approach, what to address —
+	// with the mandated framing. Shallow "fix these gaps" feedback
+	// alone lets the coder regenerate the same broken approach.
+	contexts := []state.RewindContext{
+		{
+			Cycle:         2,
+			Target:        state.PhaseCode,
+			RootCause:     "retry loop grew unbounded",
+			TriedApproach: "wrap in for-range without cap",
+			MustAddress:   []string{"cap retries at 3"},
+			Failure:       []string{"[P0] TestRetryLimit failed"},
+		},
+	}
+	prompt := buildCoderPrompt("intent", "plan", "", nil, contexts)
+
+	if !strings.Contains(prompt, "Rewind Context") {
+		t.Error("expected rewind context section header")
+	}
+	if !strings.Contains(prompt, "Previous attempt failed because: retry loop grew unbounded") {
+		t.Error("expected the mandated 'failed because X' framing")
+	}
+	if !strings.Contains(prompt, "You may not reproduce approach") {
+		t.Error("expected the mandated 'may not reproduce' framing")
+	}
+	if !strings.Contains(prompt, "wrap in for-range without cap") {
+		t.Error("expected prior approach text in the 'may not reproduce' block")
+	}
+	if !strings.Contains(prompt, "must explicitly address") {
+		t.Error("expected the mandated 'must explicitly address' framing")
+	}
+	if !strings.Contains(prompt, "cap retries at 3") {
+		t.Error("expected MustAddress entries rendered into the prompt")
+	}
+	if !strings.Contains(prompt, "TestRetryLimit failed") {
+		t.Error("expected observed failure list rendered into the prompt")
+	}
+}
+
+func TestCodePhase_RewindContextPropagatedToCoder(t *testing.T) {
+	// End-to-end: when the task already carries a code-targeted rewind
+	// context, the very next coder invocation must see it in the prompt.
+	// Plan-targeted entries must not leak into the coder prompt.
+	coder := &fakeCoder{results: []state.AgentResult{{Output: "done"}}}
+	judge := &fakeJudge{verdicts: []*state.Verdict{{Score: 100, Pass: true}}}
+
+	task := codingTask()
+	task.RewindContexts = []state.RewindContext{
+		{
+			Cycle:       1,
+			Target:      state.PhaseCode,
+			RootCause:   "previous code crashed on nil map",
+			MustAddress: []string{"guard map writes"},
+		},
+		{
+			Cycle:     1,
+			Target:    state.PhasePlan,
+			RootCause: "plan omitted the cache layer",
+		},
+	}
+
+	phase := New(coder, judge, defaultCfg(), "/work")
+	// Capture prompt via a wrapping coder.
+	capture := &capturingCoder{inner: coder}
+	phase.coder = capture
+
+	_, err := phase.Run(context.Background(), task, "the plan")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(capture.prompts) != 1 {
+		t.Fatalf("expected 1 coder call, got %d", len(capture.prompts))
+	}
+	prompt := capture.prompts[0]
+	if !containsStr(prompt, "previous code crashed on nil map") {
+		t.Error("expected code-targeted rewind context in coder prompt")
+	}
+	if !containsStr(prompt, "guard map writes") {
+		t.Error("expected code-targeted MustAddress in coder prompt")
+	}
+	if containsStr(prompt, "plan omitted the cache layer") {
+		t.Error("plan-targeted rewind context must not leak into coder prompt")
+	}
+}
+
+// capturingCoder wraps another Coder and records every prompt passed
+// to Run, so tests can assert on the exact prompt the phase built.
+type capturingCoder struct {
+	inner   Coder
+	prompts []string
+}
+
+func (c *capturingCoder) Run(ctx context.Context, prompt string, workDir string) (state.AgentResult, error) {
+	c.prompts = append(c.prompts, prompt)
+	return c.inner.Run(ctx, prompt, workDir)
 }
 
 func containsStr(s, substr string) bool {

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -109,7 +109,8 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 		}
 
 		// Build the planner prompt.
-		prompt := buildPlannerPrompt(task.Intent, lastFeedback, task.Assumptions, task.HardConstraints)
+		prompt := buildPlannerPrompt(task.Intent, lastFeedback, task.Assumptions, task.HardConstraints,
+			state.RewindContextsFor(task.RewindContexts, state.PhasePlan))
 
 		// Call the planner agent.
 		p.notify(loop+1, p.cfg.MaxLoops, "generating plan", 0, false, nil)
@@ -226,12 +227,28 @@ func (p *PlanPhase) processGaps(task *state.Task, gaps []state.Gap) {
 }
 
 // buildPlannerPrompt constructs the prompt for the planner agent.
-func buildPlannerPrompt(intent string, feedback string, assumptions []state.Assumption, hardConstraints []string) string {
+//
+// When rewindContexts is non-empty, an explicit Rewind Context block is
+// emitted ahead of the hard constraints. The block uses the exact
+// "Previous attempt failed because X. You may not reproduce approach Y.
+// Your plan must explicitly address Z." framing from issue #86 —
+// without that constraint, successive rewinds tend to converge on the
+// same plan and the outer loop spins instead of terminating.
+func buildPlannerPrompt(intent string, feedback string, assumptions []state.Assumption, hardConstraints []string, rewindContexts []state.RewindContext) string {
 	var b strings.Builder
 
 	b.WriteString("## Task Intent\n")
 	b.WriteString(intent)
 	b.WriteString("\n")
+
+	if len(rewindContexts) > 0 {
+		b.WriteString("\n## Rewind Context (previous outer cycles)\n")
+		b.WriteString("Earlier plan→code→quality cycles failed and the outer loop rewound back to plan. ")
+		b.WriteString("You must NOT reproduce the approaches below. Your new plan must explicitly address every failure listed.\n")
+		for _, rc := range rewindContexts {
+			rc.RenderPromptBlock(&b)
+		}
+	}
 
 	if len(hardConstraints) > 0 {
 		b.WriteString("\n## Hard Constraints (non-negotiable)\n")

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -508,7 +508,7 @@ func TestPlanPhase_ContextCancellation(t *testing.T) {
 }
 
 func TestBuildPlannerPrompt_NoFeedback(t *testing.T) {
-	prompt := buildPlannerPrompt("build an API", "", nil, nil)
+	prompt := buildPlannerPrompt("build an API", "", nil, nil, nil)
 
 	if !strings.Contains(prompt, "## Task Intent") {
 		t.Error("expected intent header")
@@ -528,7 +528,7 @@ func TestBuildPlannerPrompt_NoFeedback(t *testing.T) {
 }
 
 func TestBuildPlannerPrompt_WithFeedback(t *testing.T) {
-	prompt := buildPlannerPrompt("build an API", "missing auth", nil, nil)
+	prompt := buildPlannerPrompt("build an API", "missing auth", nil, nil, nil)
 
 	if !strings.Contains(prompt, "Previous Attempt Feedback") {
 		t.Error("expected feedback section")
@@ -542,7 +542,7 @@ func TestBuildPlannerPrompt_WithAssumptions(t *testing.T) {
 	assumptions := []state.Assumption{
 		{Description: "using PostgreSQL", Severity: state.SeverityP2, Phase: state.PhasePlan},
 	}
-	prompt := buildPlannerPrompt("build an API", "some feedback", assumptions, nil)
+	prompt := buildPlannerPrompt("build an API", "some feedback", assumptions, nil, nil)
 
 	if !strings.Contains(prompt, "Assumptions from Previous Loops") {
 		t.Error("expected assumptions section")
@@ -560,7 +560,7 @@ func TestBuildPlannerPrompt_WithHardConstraints(t *testing.T) {
 		"[quality judge, P0] /admin/users is not protected by auth middleware",
 		"[quality judge, P1] /admin/logs bypasses the same middleware",
 	}
-	prompt := buildPlannerPrompt("build an API", "", nil, constraints)
+	prompt := buildPlannerPrompt("build an API", "", nil, constraints, nil)
 
 	if !strings.Contains(prompt, "Hard Constraints") {
 		t.Error("expected hard constraints section")
@@ -570,6 +570,115 @@ func TestBuildPlannerPrompt_WithHardConstraints(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "/admin/users") || !strings.Contains(prompt, "/admin/logs") {
 		t.Error("expected every constraint to be rendered as its own bullet")
+	}
+}
+
+func TestBuildPlannerPrompt_WithRewindContext(t *testing.T) {
+	// #86: when the outer loop rewinds to plan, the planner must see
+	// structured context — root cause, prior approach, what to address —
+	// with the mandated framing. Without it rewinds converge on the
+	// same plan and the loop spins.
+	contexts := []state.RewindContext{
+		{
+			Cycle:         1,
+			Target:        state.PhasePlan,
+			RootCause:     "plan did not require a rate limiter",
+			TriedApproach: "step 1: add login\nstep 2: add logout",
+			MustAddress:   []string{"rate-limit /login"},
+			Failure:       []string{"[P0] brute-force possible"},
+		},
+	}
+	prompt := buildPlannerPrompt("build an API", "", nil, nil, contexts)
+
+	if !strings.Contains(prompt, "Rewind Context") {
+		t.Error("expected rewind context section header")
+	}
+	if !strings.Contains(prompt, "Previous attempt failed because: plan did not require a rate limiter") {
+		t.Error("expected the mandated 'failed because X' framing")
+	}
+	if !strings.Contains(prompt, "You may not reproduce approach") {
+		t.Error("expected the mandated 'may not reproduce' framing")
+	}
+	if !strings.Contains(prompt, "step 1: add login") {
+		t.Error("expected prior plan body to appear in the 'may not reproduce' block")
+	}
+	if !strings.Contains(prompt, "must explicitly address") {
+		t.Error("expected the mandated 'must explicitly address' framing")
+	}
+	if !strings.Contains(prompt, "rate-limit /login") {
+		t.Error("expected MustAddress entries rendered into the prompt")
+	}
+	if !strings.Contains(prompt, "brute-force possible") {
+		t.Error("expected observed failure list rendered into the prompt")
+	}
+}
+
+func TestBuildPlannerPrompt_MultipleRewindsAccumulate(t *testing.T) {
+	// Multiple outer rewinds must each appear in the prompt with their
+	// own cycle heading — no amnesia. The planner needs to see the full
+	// history to avoid oscillating between two failed approaches.
+	contexts := []state.RewindContext{
+		{Cycle: 1, Target: state.PhasePlan, RootCause: "cause A", TriedApproach: "plan A"},
+		{Cycle: 2, Target: state.PhasePlan, RootCause: "cause B", TriedApproach: "plan B"},
+	}
+	prompt := buildPlannerPrompt("build an API", "", nil, nil, contexts)
+
+	if !strings.Contains(prompt, "Cycle 1") || !strings.Contains(prompt, "Cycle 2") {
+		t.Error("expected headings for every cycle so history accumulates")
+	}
+	if !strings.Contains(prompt, "cause A") || !strings.Contains(prompt, "cause B") {
+		t.Error("expected every cycle's root cause to appear in the prompt")
+	}
+	if !strings.Contains(prompt, "plan A") || !strings.Contains(prompt, "plan B") {
+		t.Error("expected every cycle's prior approach to appear in the prompt")
+	}
+}
+
+func TestPlanPhase_RewindContextPropagatedToPlanner(t *testing.T) {
+	// End-to-end: when the task already has a RewindContext targeted at
+	// plan, the very next planner invocation must see it in the prompt.
+	planner := &multiResponseClient{
+		responses: []any{passingPlanResponse()},
+	}
+	judge := &fakeJudge{
+		verdicts: []*state.Verdict{passingVerdict()},
+	}
+
+	phase := New(planner, judge, testConfig())
+	task := newPendingTask()
+	task.RewindContexts = []state.RewindContext{
+		{
+			Cycle:       1,
+			Target:      state.PhasePlan,
+			RootCause:   "plan forgot auth",
+			MustAddress: []string{"add auth middleware"},
+		},
+		// Code-targeted entries must NOT leak into the planner prompt —
+		// the planner only sees contexts aimed at its phase.
+		{
+			Cycle:     1,
+			Target:    state.PhaseCode,
+			RootCause: "code did not handle 429",
+		},
+	}
+
+	_, err := phase.Run(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(planner.calls) != 1 {
+		t.Fatalf("expected 1 planner call, got %d", len(planner.calls))
+	}
+	prompt := planner.calls[0].prompt
+	if !strings.Contains(prompt, "plan forgot auth") {
+		t.Error("expected plan-targeted rewind context in planner prompt")
+	}
+	if !strings.Contains(prompt, "add auth middleware") {
+		t.Error("expected plan-targeted MustAddress in planner prompt")
+	}
+	if strings.Contains(prompt, "code did not handle 429") {
+		t.Error("code-targeted rewind context must not leak into planner prompt")
 	}
 }
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -73,6 +73,7 @@ func (s *Store) migrate() error {
 		depends_on TEXT NOT NULL DEFAULT '[]',
 		priority   TEXT NOT NULL DEFAULT 'normal',
 		hard_constraints TEXT NOT NULL DEFAULT '[]',
+		rewind_contexts TEXT NOT NULL DEFAULT '[]',
 		created_at TEXT NOT NULL,
 		updated_at TEXT NOT NULL
 	);
@@ -91,6 +92,7 @@ func (s *Store) migrate() error {
 		{"depends_on", `ALTER TABLE tasks ADD COLUMN depends_on TEXT NOT NULL DEFAULT '[]'`},
 		{"priority", `ALTER TABLE tasks ADD COLUMN priority TEXT NOT NULL DEFAULT 'normal'`},
 		{"hard_constraints", `ALTER TABLE tasks ADD COLUMN hard_constraints TEXT NOT NULL DEFAULT '[]'`},
+		{"rewind_contexts", `ALTER TABLE tasks ADD COLUMN rewind_contexts TEXT NOT NULL DEFAULT '[]'`},
 	} {
 		if _, err := s.db.Exec(alter.stmt); err != nil && !isDuplicateColumnErr(err) {
 			return fmt.Errorf("adding %s column: %w", alter.column, err)
@@ -134,6 +136,10 @@ func (s *Store) CreateTask(t *Task) error {
 	if err != nil {
 		return fmt.Errorf("marshaling hard_constraints: %w", err)
 	}
+	rewindContextsJSON, err := json.Marshal(t.RewindContexts)
+	if err != nil {
+		return fmt.Errorf("marshaling rewind_contexts: %w", err)
+	}
 
 	priority := t.Priority
 	if priority == "" {
@@ -141,11 +147,11 @@ func (s *Store) CreateTask(t *Task) error {
 	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO tasks (id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO tasks (id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		t.ID, t.Intent, string(t.State), string(t.Phase),
 		string(loopJSON), string(assumptionsJSON), string(attemptsJSON), string(dependsOnJSON),
-		priority, string(hardConstraintsJSON),
+		priority, string(hardConstraintsJSON), string(rewindContextsJSON),
 		t.CreatedAt.Format(time.RFC3339Nano), t.UpdatedAt.Format(time.RFC3339Nano),
 	)
 	if err != nil {
@@ -157,7 +163,7 @@ func (s *Store) CreateTask(t *Task) error {
 // GetTask retrieves a task by ID. Returns sql.ErrNoRows if not found.
 func (s *Store) GetTask(id string) (*Task, error) {
 	row := s.db.QueryRow(
-		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, created_at, updated_at
+		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, created_at, updated_at
 		 FROM tasks WHERE id = ?`, id,
 	)
 	return s.scanTask(row)
@@ -185,6 +191,10 @@ func (s *Store) UpdateTask(t *Task) error {
 	if err != nil {
 		return fmt.Errorf("marshaling hard_constraints: %w", err)
 	}
+	rewindContextsJSON, err := json.Marshal(t.RewindContexts)
+	if err != nil {
+		return fmt.Errorf("marshaling rewind_contexts: %w", err)
+	}
 
 	priority := t.Priority
 	if priority == "" {
@@ -192,11 +202,11 @@ func (s *Store) UpdateTask(t *Task) error {
 	}
 
 	result, err := s.db.Exec(
-		`UPDATE tasks SET intent=?, state=?, phase=?, loop_count=?, assumptions=?, attempts=?, depends_on=?, priority=?, hard_constraints=?, updated_at=?
+		`UPDATE tasks SET intent=?, state=?, phase=?, loop_count=?, assumptions=?, attempts=?, depends_on=?, priority=?, hard_constraints=?, rewind_contexts=?, updated_at=?
 		 WHERE id=?`,
 		t.Intent, string(t.State), string(t.Phase),
 		string(loopJSON), string(assumptionsJSON), string(attemptsJSON), string(dependsOnJSON),
-		priority, string(hardConstraintsJSON),
+		priority, string(hardConstraintsJSON), string(rewindContextsJSON),
 		t.UpdatedAt.Format(time.RFC3339Nano), t.ID,
 	)
 	if err != nil {
@@ -221,12 +231,12 @@ func (s *Store) ListTasks(filterState TaskState) ([]*Task, error) {
 
 	if filterState == "" {
 		rows, err = s.db.Query(
-			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, created_at, updated_at
+			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, created_at, updated_at
 			 FROM tasks ORDER BY created_at ASC`,
 		)
 	} else {
 		rows, err = s.db.Query(
-			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, created_at, updated_at
+			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, created_at, updated_at
 			 FROM tasks WHERE state = ? ORDER BY created_at ASC`,
 			string(filterState),
 		)
@@ -273,13 +283,14 @@ func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 		dependsOnJSON       string
 		priority            string
 		hardConstraintsJSON string
+		rewindContextsJSON  string
 		createdAt           string
 		updatedAt           string
 	)
 
 	err := sc.Scan(&t.ID, &t.Intent, &state, &phase,
 		&loopJSON, &assumptionsJSON, &attemptsJSON, &dependsOnJSON, &priority,
-		&hardConstraintsJSON,
+		&hardConstraintsJSON, &rewindContextsJSON,
 		&createdAt, &updatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("scanning task: %w", err)
@@ -311,6 +322,12 @@ func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 	if hardConstraintsJSON != "" {
 		if err := json.Unmarshal([]byte(hardConstraintsJSON), &t.HardConstraints); err != nil {
 			return nil, fmt.Errorf("unmarshaling hard_constraints: %w", err)
+		}
+	}
+
+	if rewindContextsJSON != "" {
+		if err := json.Unmarshal([]byte(rewindContextsJSON), &t.RewindContexts); err != nil {
+			return nil, fmt.Errorf("unmarshaling rewind_contexts: %w", err)
 		}
 	}
 

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -90,6 +90,72 @@ func TestCreateAndGetTask_HardConstraintsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCreateAndGetTask_RewindContextsRoundTrip(t *testing.T) {
+	// #86: rewind_contexts column must persist and hydrate so structured
+	// failure context survives a process restart. Without persistence,
+	// a resumed task loses the "must not reproduce" memory and the
+	// outer loop converges on the same output.
+	store := newTestStore(t)
+	task := NewTask("task-rc", "ship it properly")
+	task.RewindContexts = []RewindContext{
+		{
+			Cycle:         1,
+			Target:        PhaseCode,
+			RootCause:     "retry loop unbounded",
+			TriedApproach: "for-range without cap",
+			MustAddress:   []string{"cap at 3"},
+			Failure:       []string{"[P0] TestRetryLimit"},
+			CreatedAt:     time.Now(),
+		},
+		{
+			Cycle:     2,
+			Target:    PhasePlan,
+			RootCause: "plan forgot observability",
+			CreatedAt: time.Now(),
+		},
+	}
+
+	if err := store.CreateTask(task); err != nil {
+		t.Fatalf("creating task: %v", err)
+	}
+
+	got, err := store.GetTask("task-rc")
+	if err != nil {
+		t.Fatalf("getting task: %v", err)
+	}
+	if len(got.RewindContexts) != 2 {
+		t.Fatalf("expected 2 rewind contexts, got %d", len(got.RewindContexts))
+	}
+	if got.RewindContexts[0].RootCause != "retry loop unbounded" {
+		t.Errorf("RootCause[0] = %q, want %q", got.RewindContexts[0].RootCause, "retry loop unbounded")
+	}
+	if got.RewindContexts[0].Target != PhaseCode {
+		t.Errorf("Target[0] = %s, want code", got.RewindContexts[0].Target)
+	}
+	if len(got.RewindContexts[0].MustAddress) != 1 || got.RewindContexts[0].MustAddress[0] != "cap at 3" {
+		t.Errorf("MustAddress[0] did not round-trip: %v", got.RewindContexts[0].MustAddress)
+	}
+	if got.RewindContexts[1].Target != PhasePlan {
+		t.Errorf("Target[1] = %s, want plan", got.RewindContexts[1].Target)
+	}
+
+	// UpdateTask must also round-trip additional entries.
+	got.RewindContexts = append(got.RewindContexts, RewindContext{
+		Cycle: 3, Target: PhaseCode, RootCause: "added later",
+	})
+	got.UpdatedAt = time.Now()
+	if err := store.UpdateTask(got); err != nil {
+		t.Fatalf("updating task: %v", err)
+	}
+	refetched, err := store.GetTask("task-rc")
+	if err != nil {
+		t.Fatalf("refetching: %v", err)
+	}
+	if len(refetched.RewindContexts) != 3 {
+		t.Errorf("expected 3 rewind contexts after update, got %d", len(refetched.RewindContexts))
+	}
+}
+
 func TestGetTaskNotFound(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -213,9 +213,12 @@ func (rc RewindContext) RenderPromptBlock(b *strings.Builder) {
 		fmt.Fprintf(b, "- Previous attempt failed because: %s\n", rc.RootCause)
 	}
 	if rc.TriedApproach != "" {
+		// Indent with plain spaces rather than a markdown blockquote
+		// prefix ('>'), so the block renders consistently across plain
+		// text, markdown viewers, and agent prompts.
 		b.WriteString("- You may not reproduce approach:\n")
 		for _, line := range strings.Split(strings.TrimRight(rc.TriedApproach, "\n"), "\n") {
-			fmt.Fprintf(b, "    > %s\n", line)
+			fmt.Fprintf(b, "      %s\n", line)
 		}
 	}
 	if len(rc.MustAddress) > 0 {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -164,6 +165,90 @@ type Attempt struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// RewindContext captures why the outer loop rewound and what the next
+// attempt must do differently. Without it, successive rewinds have no
+// memory of earlier failures and tend to converge on the same output —
+// the loop spins instead of terminating. Every rewind builds a new
+// RewindContext from the quality verdict and appends it to the task so
+// the history survives across cycles (no amnesia). The planner and
+// coder treat the full slice as a first-class input: the prompt
+// explicitly says "Previous attempt failed because X. You may not
+// reproduce approach Y. Your plan must explicitly address Z."
+type RewindContext struct {
+	// Cycle is the outer-loop cycle number this rewind was diagnosed on
+	// (1-indexed). Lets the prompt and logs distinguish repeats.
+	Cycle int `json:"cycle"`
+	// Target is the phase the outer loop rewound to: PhasePlan or
+	// PhaseCode. Consumers filter the task's rewind history by Target
+	// when they only want contexts aimed at their phase.
+	Target Phase `json:"target"`
+	// RootCause is the quality judge's one-line diagnosis of why the
+	// attempt failed. Drives the "failed because X" line in the prompt.
+	RootCause string `json:"root_cause"`
+	// TriedApproach is a short description of what the previous attempt
+	// produced — the approach the next attempt may not reproduce.
+	TriedApproach string `json:"tried_approach,omitempty"`
+	// Failure lists the concrete symptoms the judge observed (failing
+	// checks, specific gaps). Rendered verbatim into the prompt so the
+	// next attempt has the evidence, not just the diagnosis.
+	Failure []string `json:"failure,omitempty"`
+	// MustAddress is the set of constraints the next attempt must
+	// explicitly satisfy — derived from blocking gaps. Separate from
+	// Task.HardConstraints so the context survives for the coder too,
+	// not just the planner on a ReturnToPlan.
+	MustAddress []string `json:"must_address,omitempty"`
+	// CreatedAt is when the rewind was diagnosed. Useful for ordering
+	// the audit trail when attempts span a long wall-clock window.
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// RenderPromptBlock writes a prompt-ready rendering of the rewind
+// context using the canonical "Previous attempt failed because X. You
+// may not reproduce approach Y. Your plan must explicitly address Z."
+// framing from issue #86. Every phase that consumes rewind contexts
+// (planner, coder) uses this so the framing is identical across agents.
+func (rc RewindContext) RenderPromptBlock(b *strings.Builder) {
+	fmt.Fprintf(b, "\n### Cycle %d (rewind to %s)\n", rc.Cycle, rc.Target)
+	if rc.RootCause != "" {
+		fmt.Fprintf(b, "- Previous attempt failed because: %s\n", rc.RootCause)
+	}
+	if rc.TriedApproach != "" {
+		b.WriteString("- You may not reproduce approach:\n")
+		for _, line := range strings.Split(strings.TrimRight(rc.TriedApproach, "\n"), "\n") {
+			fmt.Fprintf(b, "    > %s\n", line)
+		}
+	}
+	if len(rc.MustAddress) > 0 {
+		b.WriteString("- The next attempt must explicitly address:\n")
+		for _, m := range rc.MustAddress {
+			fmt.Fprintf(b, "    - %s\n", m)
+		}
+	}
+	if len(rc.Failure) > 0 {
+		b.WriteString("- Observed failures:\n")
+		for _, f := range rc.Failure {
+			fmt.Fprintf(b, "    - %s\n", f)
+		}
+	}
+}
+
+// RewindContextsFor returns the subset of rewind contexts targeted at
+// the given phase. Plan and code each consume only entries the outer
+// loop rewound to their phase — a ReturnToPlan rewind isn't addressed
+// to the coder, and vice versa.
+func RewindContextsFor(all []RewindContext, target Phase) []RewindContext {
+	if len(all) == 0 {
+		return nil
+	}
+	out := make([]RewindContext, 0, len(all))
+	for _, rc := range all {
+		if rc.Target == target {
+			out = append(out, rc)
+		}
+	}
+	return out
+}
+
 // Task is the core entity tracked through the VAIrdict pipeline.
 type Task struct {
 	ID     string    `json:"id"`
@@ -183,6 +268,14 @@ type Task struct {
 	// when it rewinds to Plan. The planner must satisfy them in the new
 	// plan, not just acknowledge them.
 	HardConstraints []string `json:"hard_constraints,omitempty"`
+	// RewindContexts accumulate structured failure context across every
+	// outer-loop rewind. Each entry records the cycle it was diagnosed
+	// on, the phase rewound to, and the root cause / approach / failure
+	// details the next attempt must respond to. The slice is append-only
+	// so multiple rewinds build history rather than overwriting earlier
+	// diagnoses. Planner and coder read the entries targeted at their
+	// phase to avoid reproducing failed approaches.
+	RewindContexts []RewindContext `json:"rewind_contexts,omitempty"`
 	// DependsOn lists task IDs this task waits on. The scheduler in
 	// internal/deps uses it to build the DAG; vairdict status reads it
 	// to render the graph. Empty for tasks without dependencies.

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -428,6 +429,63 @@ func TestQualityReviewTransitions_IncludeRewinds(t *testing.T) {
 				t.Errorf("quality_review → %s should be allowed: %v", target, err)
 			}
 		})
+	}
+}
+
+func TestRewindContextsFor_FiltersByTarget(t *testing.T) {
+	all := []RewindContext{
+		{Cycle: 1, Target: PhasePlan, RootCause: "A"},
+		{Cycle: 1, Target: PhaseCode, RootCause: "B"},
+		{Cycle: 2, Target: PhasePlan, RootCause: "C"},
+	}
+
+	plan := RewindContextsFor(all, PhasePlan)
+	if len(plan) != 2 {
+		t.Fatalf("expected 2 plan-targeted contexts, got %d", len(plan))
+	}
+	if plan[0].RootCause != "A" || plan[1].RootCause != "C" {
+		t.Errorf("unexpected plan-targeted contexts: %+v", plan)
+	}
+
+	code := RewindContextsFor(all, PhaseCode)
+	if len(code) != 1 || code[0].RootCause != "B" {
+		t.Errorf("expected one code-targeted context B, got %+v", code)
+	}
+
+	if got := RewindContextsFor(nil, PhasePlan); got != nil {
+		t.Errorf("nil input must yield nil output, got %v", got)
+	}
+}
+
+func TestRewindContext_RenderPromptBlock_Framing(t *testing.T) {
+	// The canonical framing from issue #86 is load-bearing — if any of
+	// the three required phrases disappears the prompt no longer tells
+	// the agent what it must not reproduce, and rewinds converge.
+	rc := RewindContext{
+		Cycle:         2,
+		Target:        PhaseCode,
+		RootCause:     "missing timeout",
+		TriedApproach: "call fn without ctx",
+		MustAddress:   []string{"wire ctx into fn"},
+		Failure:       []string{"[P0] TestTimeout failed"},
+	}
+	var b strings.Builder
+	rc.RenderPromptBlock(&b)
+	out := b.String()
+
+	for _, phrase := range []string{
+		"Previous attempt failed because:",
+		"You may not reproduce approach",
+		"must explicitly address",
+		"missing timeout",
+		"call fn without ctx",
+		"wire ctx into fn",
+		"TestTimeout failed",
+		"Cycle 2",
+	} {
+		if !strings.Contains(out, phrase) {
+			t.Errorf("RenderPromptBlock must include %q — got:\n%s", phrase, out)
+		}
 	}
 }
 

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -13,10 +13,10 @@ Update this file when opening, completing, or blocking an issue.
 - #90 cmd/resume: resume interrupted run from last checkpoint
 - #91 cmd/interactive: status, notes, pause/continue during execution
 - #82 perf: load test 5 concurrent tasks
-- #86 state/rewind-context: structured failure context propagation (unblocked by #87)
 
 ## In Progress
 - #87 state/rewind: verdict ReturnTo field + phase rewind in outer loop
+- #86 state/rewind-context: structured failure context propagation (unblocked by #87)
 
 ## Blocked
 


### PR DESCRIPTION
Every outer-loop rewind now builds a structured RewindContext from the
quality verdict and appends it to the task. The planner and coder read
entries targeted at their phase and see an explicit "Previous attempt
failed because X. You may not reproduce approach Y. Your plan must
explicitly address Z." block in their prompts. Without that framing,
successive rewinds converge on the same output and the outer loop spins.

- New RewindContext type + Task.RewindContexts slice, persisted via an
  additive rewind_contexts column in the SQLite store.
- Orchestrator populates RewindContext on both ReturnToCode (using the
  code diff as the prior approach) and ReturnToPlan (using the prior
  plan) branches; entries accumulate across cycles (no amnesia).
- Shared state.RewindContext.RenderPromptBlock keeps the canonical
  framing identical across planner and coder prompts.
- Tests cover propagation to planner, propagation to coder, multi-rewind
  accumulation, phase-filtering so plan-targeted entries don't leak to
  the coder and vice versa, and store round-trip.