### PR TITLE
fix(judges/plan): break plan judge deadlock by closing assumption feedback loop

### DIFF
--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -44,10 +44,12 @@ the stated intent.
 You care about correctness, clarity, and future maintenance pain. You are
 considered and deliberate — every observation earns its place. A thoughtful
 review surfaces design decisions, risks, and follow-ups — not just bugs.
-On any non-trivial plan (multiple files, new subsystem, external API
-change), 2–3 P3/P2 observations are normal; silence on such a plan almost
-certainly means you missed something worth saying. Only leave gaps empty
-when the plan is small AND genuinely has no design question worth surfacing.
+On a non-trivial plan, surfacing P3/P2 design observations is expected when
+genuine concerns exist. However, if prior concerns have been acknowledged
+(see Acknowledged Assumptions section in the user prompt when present),
+fewer new observations is the correct outcome — do not re-discover concerns
+that have already been accepted. Only leave gaps empty when there is
+genuinely no design question worth surfacing.
 
 Flag real problems (missing requirements, wrong approach, risks the
 planner should know) — and additionally surface the design-level
@@ -88,10 +90,10 @@ as a finding, use a gap.
 
 ## Examples
 
-On a substantive plan, 2–3 design observations (P3/P2) is normal — what a
-senior reviewer would write in a real plan review. Only leave gaps empty
-when the plan is small AND genuinely has no design question worth
-surfacing; never pad with nits to hit a target.
+On a substantive plan, design observations (P3/P2) are expected when genuine
+concerns exist — what a senior reviewer would raise in a real plan review.
+When Acknowledged Assumptions are present, those concerns have already been
+accepted; flag only NEW issues. Never pad with nits to hit a target.
 
 ### Example 1 — pass with texture (non-trivial plan, design observations)
 
@@ -135,8 +137,17 @@ var systemPrompt = systemPromptCore + "\n\n" + standards.Block
 // Pass is determined by whether the score meets the configured coverage
 // threshold AND there are no blocking gaps. Blocking is assigned from the
 // configured severity block-on list, not the LLM's opinion.
-func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string) (*state.Verdict, error) {
+func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string, acknowledged []state.Assumption) (*state.Verdict, error) {
 	prompt := fmt.Sprintf("## Intent\n%s\n\n## Plan\n%s", intent, plan)
+
+	if len(acknowledged) > 0 {
+		prompt += "\n\n## Acknowledged Assumptions (do not re-flag)\n"
+		prompt += "These concerns were already raised in a previous loop, acknowledged by the planner, and accepted by the orchestrator. "
+		prompt += "Do NOT re-flag these as gaps unless the plan has actively regressed on them.\n"
+		for _, a := range acknowledged {
+			prompt += fmt.Sprintf("- [%s] %s\n", a.Severity, a.Description)
+		}
+	}
 
 	var verdict state.Verdict
 	tool := verdictschema.VerdictTool("Submit the plan judge verdict as a structured object. Omit score, pass, and blocking — they are computed from the gap severities.")
@@ -178,7 +189,7 @@ func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string) (*sta
 		}
 	}
 
-	verdict.Score = verdictschema.ComputeScore(verdict.Gaps)
+	verdict.Score = verdictschema.ComputeScoreWithAcknowledged(verdict.Gaps, acknowledged)
 	verdict.Pass = verdict.Score >= j.cfg.CoverageThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
 
 	return &verdict, nil

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -47,7 +47,7 @@ func TestJudge_BaselineViolationForcedBlocking_UnderPermissiveConfig(t *testing.
 	}
 	judge := New(fake, cfg)
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestJudge_NonBaselineP1StillGovernedByConfig(t *testing.T) {
 	}
 	judge := New(fake, cfg)
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestJudge_Pass_NoGapsScoresFull(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes\n3. Write tests")
+	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes\n3. Write tests", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestJudge_Fail_BlockingGapsDriveScoreDown(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers")
+	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestJudge_BlockingIgnoresLLMOpinion(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestJudge_AccumulatedP2sDragScoreBelowThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestJudge_PassTrueAtExactThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestJudge_P3GapsDeferred(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestJudge_ClientError(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	_, err := judge.Judge(context.Background(), "intent", "plan")
+	_, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err == nil {
 		t.Fatal("expected error when client fails")
 	}
@@ -300,7 +300,7 @@ func TestJudge_CustomSeverityConfig(t *testing.T) {
 	}
 
 	judge := New(fake, cfg)
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestJudge_EmptyGapsAndQuestions(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestJudge_SummaryRoundTrip(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -379,5 +379,69 @@ func TestJudge_SystemPromptIncludesFewShotExamples(t *testing.T) {
 		if !strings.Contains(systemPrompt, needle) {
 			t.Errorf("system prompt missing few-shot anchor %q", needle)
 		}
+	}
+}
+
+func TestJudge_AcknowledgedAssumptionsInPrompt(t *testing.T) {
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{},
+		},
+	}
+
+	judge := New(fake, defaultCfg())
+	assumptions := []state.Assumption{
+		{Description: "database choice unclear", Severity: state.SeverityP2, Phase: state.PhasePlan},
+		{Description: "caching strategy TBD", Severity: state.SeverityP2, Phase: state.PhasePlan},
+	}
+
+	_, err := judge.Judge(context.Background(), "intent", "plan", assumptions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.Calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
+	}
+	prompt := fake.Calls[0].Prompt
+	if !strings.Contains(prompt, "Acknowledged Assumptions") {
+		t.Error("expected prompt to contain Acknowledged Assumptions section")
+	}
+	if !strings.Contains(prompt, "database choice unclear") {
+		t.Error("expected prompt to contain first assumption")
+	}
+	if !strings.Contains(prompt, "caching strategy TBD") {
+		t.Error("expected prompt to contain second assumption")
+	}
+	if !strings.Contains(prompt, "do not re-flag") {
+		t.Error("expected prompt to instruct judge not to re-flag")
+	}
+}
+
+func TestJudge_ReflaggedGapHalvedPenalty(t *testing.T) {
+	// When the judge re-flags an already-acknowledged P2 gap, its
+	// penalty should be halved (5 instead of 10).
+	fake := &claude.FakeClient{
+		Response: state.Verdict{
+			Gaps: []state.Gap{
+				{Severity: state.SeverityP2, Description: "database choice unclear"},
+				{Severity: state.SeverityP2, Description: "new naming concern"},
+			},
+		},
+	}
+
+	judge := New(fake, defaultCfg())
+	acknowledged := []state.Assumption{
+		{Description: "database choice unclear", Severity: state.SeverityP2},
+	}
+
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", acknowledged)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 100 - 5 (halved re-flag) - 10 (new) = 85
+	if verdict.Score != 85 {
+		t.Errorf("expected score 85 (halved re-flag penalty), got %f", verdict.Score)
 	}
 }

--- a/internal/judges/verdictschema/schema.go
+++ b/internal/judges/verdictschema/schema.go
@@ -6,6 +6,7 @@ package verdictschema
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/state"
@@ -139,4 +140,64 @@ func HasBlockingGap(gaps []state.Gap) bool {
 		}
 	}
 	return false
+}
+
+// IsReflagged reports whether a gap is substantially similar to an
+// already-acknowledged assumption. It uses bidirectional case-insensitive
+// substring matching: if the assumption description appears in the gap
+// description or vice versa, the gap is considered a re-flag.
+func IsReflagged(gap state.Gap, acknowledged []state.Assumption) bool {
+	if gap.Description == "" {
+		return false
+	}
+	gapLower := strings.ToLower(gap.Description)
+	for _, a := range acknowledged {
+		if a.Description == "" {
+			continue
+		}
+		aLower := strings.ToLower(a.Description)
+		if strings.Contains(gapLower, aLower) || strings.Contains(aLower, gapLower) {
+			return true
+		}
+	}
+	return false
+}
+
+// ComputeScoreWithAcknowledged returns a deterministic score like
+// ComputeScore, but halves the penalty for gaps that match an
+// already-acknowledged assumption. This prevents re-flagged advisory
+// gaps from dragging the score below the pass threshold on retries.
+func ComputeScoreWithAcknowledged(gaps []state.Gap, acknowledged []state.Assumption) float64 {
+	if len(acknowledged) == 0 {
+		return ComputeScore(gaps)
+	}
+
+	penalty := 0.0
+	for _, g := range gaps {
+		w := 0.0
+		switch g.Severity {
+		case state.SeverityP0:
+			w = weightP0
+		case state.SeverityP1:
+			w = weightP1
+		case state.SeverityP2:
+			w = weightP2
+		case state.SeverityP3:
+			w = weightP3
+		}
+		if IsReflagged(g, acknowledged) {
+			w /= 2
+		}
+		penalty += w
+	}
+
+	score := 100.0 - penalty
+	switch {
+	case score < 0:
+		return 0
+	case score > 100:
+		return 100
+	default:
+		return score
+	}
 }

--- a/internal/judges/verdictschema/schema_test.go
+++ b/internal/judges/verdictschema/schema_test.go
@@ -104,6 +104,68 @@ func TestHasBlockingGap(t *testing.T) {
 	}
 }
 
+func TestIsReflagged(t *testing.T) {
+	ack := []state.Assumption{
+		{Description: "database choice unclear", Severity: state.SeverityP2},
+		{Description: "caching strategy not defined", Severity: state.SeverityP2},
+	}
+
+	tests := []struct {
+		name string
+		gap  state.Gap
+		want bool
+	}{
+		{"exact match", state.Gap{Description: "database choice unclear"}, true},
+		{"gap contains assumption", state.Gap{Description: "the database choice unclear — still ambiguous"}, true},
+		{"assumption contains gap", state.Gap{Description: "caching strategy"}, true},
+		{"case insensitive", state.Gap{Description: "Database Choice Unclear"}, true},
+		{"no match", state.Gap{Description: "missing error handling"}, false},
+		{"empty description", state.Gap{Description: ""}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsReflagged(tt.gap, ack); got != tt.want {
+				t.Errorf("IsReflagged(%q) = %v, want %v", tt.gap.Description, got, tt.want)
+			}
+		})
+	}
+
+	// Empty acknowledged list should never match.
+	if IsReflagged(state.Gap{Description: "anything"}, nil) {
+		t.Error("expected no match with nil acknowledged list")
+	}
+}
+
+func TestComputeScoreWithAcknowledged_HalvesPenalty(t *testing.T) {
+	ack := []state.Assumption{
+		{Description: "database choice unclear", Severity: state.SeverityP2},
+	}
+	gaps := []state.Gap{
+		{Severity: state.SeverityP2, Description: "database choice unclear"},  // re-flagged: 10/2 = 5
+		{Severity: state.SeverityP2, Description: "new concern about naming"}, // fresh: 10
+	}
+
+	got := ComputeScoreWithAcknowledged(gaps, ack)
+	// 100 - 5 - 10 = 85
+	if got != 85 {
+		t.Errorf("expected 85, got %f", got)
+	}
+}
+
+func TestComputeScoreWithAcknowledged_NoAcknowledged(t *testing.T) {
+	gaps := []state.Gap{
+		{Severity: state.SeverityP2, Description: "a"},
+		{Severity: state.SeverityP2, Description: "b"},
+	}
+
+	withAck := ComputeScoreWithAcknowledged(gaps, nil)
+	plain := ComputeScore(gaps)
+	if withAck != plain {
+		t.Errorf("expected identical to ComputeScore (%f), got %f", plain, withAck)
+	}
+}
+
 func TestVerdictTool_SchemaIsValidJSON(t *testing.T) {
 	tool := VerdictTool("test")
 	if tool.Name != ToolName {

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -38,7 +38,7 @@ type Planner interface {
 
 // Judge is the interface for the plan judge that evaluates plans.
 type Judge interface {
-	Judge(ctx context.Context, intent string, plan string) (*state.Verdict, error)
+	Judge(ctx context.Context, intent string, plan string, acknowledged []state.Assumption) (*state.Verdict, error)
 }
 
 // PlanPhase orchestrates the plan phase: planner agent + judge loop.
@@ -129,7 +129,7 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 
 		// Run the judge.
 		p.notify(loop+1, p.cfg.MaxLoops, "judging plan", 0, false, nil)
-		verdict, err := p.judge.Judge(ctx, task.Intent, fullPlan)
+		verdict, err := p.judge.Judge(ctx, task.Intent, fullPlan, task.Assumptions)
 		if err != nil {
 			return nil, fmt.Errorf("running plan judge: %w", err)
 		}

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -67,7 +67,7 @@ type fakeJudge struct {
 	calls    int
 }
 
-func (f *fakeJudge) Judge(_ context.Context, _, _ string) (*state.Verdict, error) {
+func (f *fakeJudge) Judge(_ context.Context, _, _ string, _ []state.Assumption) (*state.Verdict, error) {
 	i := f.calls
 	f.calls++
 


### PR DESCRIPTION
## Summary

- **Pass acknowledged assumptions to the judge** — the plan phase already collected P2 gaps as assumptions, but the judge never saw them. Now the judge receives them in the prompt with "do not re-flag" instructions, closing the feedback loop.
- **Soften "always find gaps" prompt language** — the old system prompt pressured the LLM into finding 2-3 P2/P3 gaps on every plan, even when prior concerns were already addressed. The new language allows fewer gaps when acknowledged assumptions cover the concerns.
- **Halve score penalty for re-flagged gaps** — safety net via `ComputeScoreWithAcknowledged`: if a new gap matches an existing assumption (bidirectional case-insensitive substring), its penalty is halved so it can't single-handedly hold the score below threshold.

## Test plan

- [x] `TestIsReflagged` — exact match, substring both directions, case insensitivity, empty descriptions, no match
- [x] `TestComputeScoreWithAcknowledged_HalvesPenalty` — re-flagged P2 contributes 5 instead of 10
- [x] `TestComputeScoreWithAcknowledged_NoAcknowledged` — identical to `ComputeScore` when no assumptions
- [x] `TestJudge_AcknowledgedAssumptionsInPrompt` — prompt contains assumptions section with descriptions
- [x] `TestJudge_ReflaggedGapHalvedPenalty` — end-to-end: 2 P2 gaps, one re-flagged → score 85 (passes 85 threshold)
- [x] All 21 packages pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)