### PR TITLE
feat(ui,claudecli): task checklist display and CLI judge retry

### DIFF
--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -1087,7 +1087,8 @@ func phaseProgressHandler(spin *ui.Spinner, r ui.Renderer, phase state.Phase) fu
 				spin.Start()
 			}
 		} else {
-			// Step in progress — update spinner label.
+			// Step in progress — update checklist sub-step and spinner label.
+			r.StepUpdate(phase, step)
 			spin.SetLabel(fmt.Sprintf("loop %d/%d: %s", loop, max, step))
 			if !spin.IsRunning() {
 				spin.Start()

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -302,7 +302,8 @@ type fakeDoneCall struct {
 
 func (f *fakeRenderer) RunStart(string, string, string) {}
 func (f *fakeRenderer) Note(string, string)             {}
-func (f *fakeRenderer) PhaseStart(state.Phase)          {}
+func (f *fakeRenderer) PhaseStart(state.Phase)              {}
+func (f *fakeRenderer) StepUpdate(state.Phase, string)      {}
 func (f *fakeRenderer) PRCreated(string)                {}
 func (f *fakeRenderer) VerdictPosted(float64, bool)     {}
 func (f *fakeRenderer) RunComplete(string)              {}

--- a/internal/agents/claudecli/client.go
+++ b/internal/agents/claudecli/client.go
@@ -133,20 +133,46 @@ func (c *Client) Complete(ctx context.Context, prompt string, target any) error 
 // CompleteWithTool is the CLI-path implementation of the tool-use API.
 // The Claude Code CLI does not expose native tool-use with a forced schema,
 // so this falls back to embedding the tool's JSON Schema into the system
-// prompt and reusing the prose-to-JSON parser. The API client's
-// implementation enforces the schema strictly; this one is best-effort
-// structural. Judges therefore behave the same way from the caller side
-// regardless of which transport is resolved.
+// prompt and reusing the prose-to-JSON parser. Tools are disabled via
+// --tools "" so the CLI produces a single-turn text response instead of
+// spending turns on file reads. On parse failure a single recovery call
+// re-prompts Claude with its own raw output and asks for just the JSON.
 func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error {
 	augmented := system
 	if augmented != "" {
 		augmented += "\n\n"
 	}
 	augmented += fmt.Sprintf(
-		"## Response tool: %s\n%s\n\nRespond with a single JSON object that conforms to this JSON Schema (no markdown, no prose outside the object):\n%s",
+		"## Response tool: %s\n%s\n\n"+
+			"CRITICAL INSTRUCTION — OUTPUT FORMAT:\n"+
+			"Respond with ONLY a single JSON object that conforms to this JSON Schema.\n"+
+			"No prose before or after. No markdown fences. No explanation. Just the raw JSON object.\n\n"+
+			"Schema:\n%s",
 		tool.Name, tool.Description, string(tool.InputSchema),
 	)
-	return c.CompleteWithSystem(ctx, augmented, prompt, target)
+
+	err := c.completeWithOpts(ctx, augmented, prompt, true, target)
+	if err == nil {
+		return nil
+	}
+
+	// If parse failed, attempt a single recovery call: feed the raw output
+	// back and ask Claude to extract/reformat it as valid JSON.
+	parseErr, ok := err.(*ParseError)
+	if !ok || parseErr.Raw == "" {
+		return err
+	}
+
+	slog.Info("claude cli tool call failed, attempting recovery", "original_err", err)
+
+	recoveryPrompt := fmt.Sprintf(
+		"The following text was supposed to be a JSON object conforming to this schema:\n%s\n\n"+
+			"But it was returned as prose. Extract the information and return ONLY the JSON object. "+
+			"No markdown, no explanation, no fences — just the JSON.\n\n"+
+			"Original text:\n%s",
+		string(tool.InputSchema), truncate(parseErr.Raw, 4000),
+	)
+	return c.completeWithOpts(ctx, "", recoveryPrompt, true, target)
 }
 
 // CompleteWithTools falls back to single-turn CompleteWithTool using only the
@@ -169,6 +195,77 @@ type envelope struct {
 	Subtype string `json:"subtype"`
 	IsError bool   `json:"is_error"`
 	Result  string `json:"result"`
+}
+
+// completeWithOpts is the core CLI invocation. When noTools is true it
+// passes --tools "" to disable all tool use, producing a single-turn text
+// response. This is critical for judge calls that must return JSON directly
+// rather than spending turns reading files.
+func (c *Client) completeWithOpts(ctx context.Context, system, prompt string, noTools bool, target any) error {
+	start := time.Now()
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	args := []string{"-p", "--output-format", "json"}
+	if noTools {
+		args = append(args, "--tools", "")
+	}
+	if system != "" {
+		args = append(args, "--append-system-prompt", system)
+	}
+	args = append(args, c.extraArgs...)
+	args = append(args, prompt)
+
+	cmd := c.cmdFactory(ctx, "claude", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	slog.Debug("running claude cli", "args", args, "noTools", noTools, "timeout", c.timeout)
+
+	if err := cmd.Run(); err != nil {
+		if execErr, ok := err.(*exec.Error); ok {
+			return &NotInstalledError{Err: execErr}
+		}
+		if ctx.Err() != nil {
+			return fmt.Errorf("claude cli cancelled: %w", ctx.Err())
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return &ExitError{
+				ExitCode: exitErr.ExitCode(),
+				Stderr:   stderr.String(),
+				Err:      err,
+			}
+		}
+		return fmt.Errorf("running claude cli: %w", err)
+	}
+
+	slog.Debug("claude cli completed", "duration", time.Since(start), "noTools", noTools)
+
+	var env envelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		return &ParseError{Raw: stdout.String(), Err: fmt.Errorf("decoding envelope: %w", err)}
+	}
+	if env.IsError {
+		return &ParseError{Raw: env.Result, Err: fmt.Errorf("claude cli returned is_error=true (subtype=%s)", env.Subtype)}
+	}
+	if env.Result == "" {
+		return &ParseError{Raw: stdout.String(), Err: fmt.Errorf("empty result field in envelope")}
+	}
+
+	cleaned := extractJSON(env.Result)
+	if err := json.Unmarshal([]byte(cleaned), target); err != nil {
+		slog.Debug("claude cli parse failed",
+			"err", err,
+			"raw_len", len(env.Result),
+			"cleaned_len", len(cleaned),
+			"raw_head", truncate(env.Result, 500),
+			"cleaned_head", truncate(cleaned, 500),
+		)
+		return &ParseError{Raw: env.Result, Err: fmt.Errorf("decoding result into target: %w", err)}
+	}
+	return nil
 }
 
 // CompleteWithSystem runs `claude -p --output-format json` with the given

--- a/internal/ui/ci.go
+++ b/internal/ui/ci.go
@@ -40,6 +40,10 @@ func (r *ciRenderer) PhaseStart(phase state.Phase) {
 	r.printf("vairdict: phase start phase=%s\n", phase)
 }
 
+func (r *ciRenderer) StepUpdate(phase state.Phase, step string) {
+	r.printf("vairdict: step phase=%s step=%s\n", phase, step)
+}
+
 func (r *ciRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
 	r.printf("vairdict: phase loop phase=%s loop=%d/%d score=%.0f pass=%v\n", phase, loop, max, score, pass)
 }

--- a/internal/ui/cli.go
+++ b/internal/ui/cli.go
@@ -9,6 +9,19 @@ import (
 	"github.com/vairdict/vairdict/internal/state"
 )
 
+// allPhases is the ordered list of phases shown in the task checklist.
+var allPhases = []state.Phase{state.PhasePlan, state.PhaseCode, state.PhaseQuality}
+
+// phaseStatus tracks what happened to a phase for checklist rendering.
+type phaseStatus int
+
+const (
+	phasePending  phaseStatus = iota
+	phaseActive               // currently running
+	phasePassed               // completed successfully
+	phaseFailed               // completed with failure
+)
+
 // cliRenderer prints sectioned, colored, emoji-decorated output for human
 // consumption in a terminal. It buffers via bufio for efficient writes and
 // flushes on every public method so output appears immediately even if the
@@ -19,6 +32,12 @@ type cliRenderer struct {
 	glyphs  glyphSet
 	colors  ColorScheme
 	useASCI bool
+
+	// Task-list state: tracks each phase's status for checklist display.
+	phases    map[state.Phase]phaseStatus
+	scores    map[state.Phase]float64
+	activeStep string // current sub-step within the active phase
+	doneSteps  map[state.Phase][]string // completed sub-steps per phase
 }
 
 func newCLIRenderer(out io.Writer, colors ColorScheme, ascii bool) *cliRenderer {
@@ -27,6 +46,9 @@ func newCLIRenderer(out io.Writer, colors ColorScheme, ascii bool) *cliRenderer 
 		pal:     paletteFor(colors),
 		colors:  colors,
 		useASCI: ascii,
+		phases:    make(map[state.Phase]phaseStatus),
+		scores:    make(map[state.Phase]float64),
+		doneSteps: make(map[state.Phase][]string),
 	}
 	if ascii {
 		r.glyphs = asciiGlyphs()
@@ -89,12 +111,24 @@ func (r *cliRenderer) Note(label, value string) {
 
 func (r *cliRenderer) PhaseStart(phase state.Phase) {
 	defer r.flush()
+	r.phases[phase] = phaseActive
+	r.activeStep = ""
 	r.println("")
-	r.printf("%s%s %s%s\n", r.pal.bold, r.glyphs.phase(phase), phaseTitle(phase), r.pal.reset)
+	r.renderChecklist()
+}
+
+func (r *cliRenderer) StepUpdate(phase state.Phase, step string) {
+	defer r.flush()
+	// Mark the previous active step as done before moving to the new one.
+	if r.activeStep != "" && r.activeStep != step {
+		r.doneSteps[phase] = append(r.doneSteps[phase], r.activeStep)
+	}
+	r.activeStep = step
 }
 
 func (r *cliRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
 	defer r.flush()
+	r.scores[phase] = score
 	mark := r.glyphs.fail
 	if pass {
 		mark = r.glyphs.pass
@@ -134,6 +168,17 @@ func (r *cliRenderer) PhaseDone(
 	gaps []state.Gap,
 ) {
 	defer r.flush()
+
+	if outcome == OutcomePass {
+		r.phases[phase] = phasePassed
+	} else {
+		r.phases[phase] = phaseFailed
+	}
+	r.scores[phase] = score
+
+	// Re-render the checklist to reflect the completed phase.
+	r.println("")
+	r.renderChecklist()
 
 	if summary != "" {
 		r.println("")
@@ -192,6 +237,88 @@ func (r *cliRenderer) Error(err error) {
 	defer r.flush()
 	r.println("")
 	r.printf("%s%s%s error%s: %s\n", r.pal.bold, r.pal.red, r.glyphs.fail, r.pal.reset, err.Error())
+}
+
+// ── checklist rendering ──────────────────────────────────────────────────
+
+// phaseSubSteps defines the known sub-steps for each phase, in order.
+// These match the step strings emitted by phase.OnProgress callbacks.
+var phaseSubSteps = map[state.Phase][]string{
+	state.PhasePlan:    {"generating plan", "judging plan"},
+	state.PhaseCode:    {"coding", "judging code"},
+	state.PhaseQuality: {"reviewing"},
+}
+
+// renderChecklist prints the task-list style progress overview showing all
+// phases with their current status: pending (☐), active (▸), passed (☑ ✅),
+// or failed (☑ ❌). Active phases also show their sub-steps.
+func (r *cliRenderer) renderChecklist() {
+	r.printf("   %sTasks%s\n", r.pal.bold, r.pal.reset)
+	for _, p := range allPhases {
+		status := r.phases[p]
+		icon := r.glyphs.phase(p)
+		title := phaseTitle(p)
+
+		switch status {
+		case phaseActive:
+			r.printf("   %s%s%s %s %s\n", r.pal.cyan, r.glyphs.todoActive, r.pal.reset, icon, title)
+			// Show sub-steps under the active phase.
+			r.renderSubSteps(p)
+		case phasePassed:
+			score := r.scores[p]
+			scoreColor := r.pal.scoreColor(score)
+			r.printf("   %s%s%s %s %s %s%.0f%%%s %s\n",
+				r.pal.green, r.glyphs.todoDone, r.pal.reset,
+				icon, title, scoreColor, score, r.pal.reset, r.glyphs.pass)
+		case phaseFailed:
+			score := r.scores[p]
+			r.printf("   %s%s%s %s %s %s%.0f%%%s %s\n",
+				r.pal.red, r.glyphs.todoDone, r.pal.reset,
+				icon, title, r.pal.red, score, r.pal.reset, r.glyphs.fail)
+		default: // phasePending
+			r.printf("   %s%s %s %s%s\n", r.pal.dim, r.glyphs.todoPend, icon, title, r.pal.reset)
+		}
+	}
+}
+
+// renderSubSteps prints sub-steps for the given phase. Completed sub-steps
+// show ☑, the current active step shows ▸, and future steps show ☐.
+func (r *cliRenderer) renderSubSteps(phase state.Phase) {
+	steps := phaseSubSteps[phase]
+	done := r.doneSteps[phase]
+	doneSet := make(map[string]bool, len(done))
+	for _, d := range done {
+		doneSet[d] = true
+	}
+
+	for _, step := range steps {
+		label := stepLabel(step)
+		if doneSet[step] {
+			r.printf("     %s%s%s %s\n", r.pal.green, r.glyphs.todoDone, r.pal.reset, label)
+		} else if step == r.activeStep {
+			r.printf("     %s%s%s %s\n", r.pal.cyan, r.glyphs.todoActive, r.pal.reset, label)
+		} else {
+			r.printf("     %s%s %s%s\n", r.pal.dim, r.glyphs.todoPend, label, r.pal.reset)
+		}
+	}
+}
+
+// stepLabel returns a human-friendly label for a sub-step identifier.
+func stepLabel(step string) string {
+	switch step {
+	case "generating plan":
+		return "Generate plan"
+	case "judging plan":
+		return "Judge plan"
+	case "coding":
+		return "Write code"
+	case "judging code":
+		return "Judge code"
+	case "reviewing":
+		return "Quality review"
+	default:
+		return step
+	}
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────

--- a/internal/ui/glyphs.go
+++ b/internal/ui/glyphs.go
@@ -17,6 +17,9 @@ type glyphSet struct {
 	rule       string
 	prCreated  string
 	branchIcon string
+	todoPend   string // ☐ pending step
+	todoDone   string // ☑ completed step
+	todoActive string // ▸ currently running step
 }
 
 func unicodeGlyphs() glyphSet {
@@ -33,6 +36,9 @@ func unicodeGlyphs() glyphSet {
 		rule:       "─",
 		prCreated:  "✅",
 		branchIcon: "↳",
+		todoPend:   "☐",
+		todoDone:   "☑",
+		todoActive: "▸",
 	}
 }
 
@@ -50,6 +56,9 @@ func asciiGlyphs() glyphSet {
 		rule:       "-",
 		prCreated:  "[OK]",
 		branchIcon: "->",
+		todoPend:   "[ ]",
+		todoDone:   "[x]",
+		todoActive: "[>]",
 	}
 }
 

--- a/internal/ui/json.go
+++ b/internal/ui/json.go
@@ -54,6 +54,10 @@ func (r *jsonRenderer) PhaseStart(phase state.Phase) {
 	r.emit("phase_start", map[string]any{"phase": string(phase)})
 }
 
+func (r *jsonRenderer) StepUpdate(phase state.Phase, step string) {
+	r.emit("step_update", map[string]any{"phase": string(phase), "step": step})
+}
+
 func (r *jsonRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
 	r.emit("phase_loop", map[string]any{
 		"phase": string(phase),

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -104,6 +104,12 @@ type Renderer interface {
 	// PhaseStart prints the section header for a phase.
 	PhaseStart(phase state.Phase)
 
+	// StepUpdate records a sub-step within the active phase. The step
+	// string is one of the values emitted by phase.OnProgress (e.g.
+	// "generating plan", "judging plan", "coding", "reviewing").
+	// Renderers may use this to show sub-step progress in the checklist.
+	StepUpdate(phase state.Phase, step string)
+
 	// PhaseLoop prints one loop's progress line within a phase.
 	PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool)
 


### PR DESCRIPTION
## Summary
- **Task checklist UI**: Phases render as a progressive todo list with sub-steps (☐ pending / ▸ active / ☑ done) that update in real-time, similar to Claude Code's task display
- **CLI judge retry**: When Claude CLI returns prose instead of JSON, a recovery call re-prompts with the raw output to extract valid JSON. Tool use disabled (`--tools ""`) for judge calls to prevent multi-turn empty-result behavior
- Adds `StepUpdate` to the `Renderer` interface, implemented across CLI, CI, and JSON modes

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all 21 packages)
- [ ] Manual: `vairdict run --issue <n>` shows checklist with sub-steps
- [ ] Manual: judge parse failures trigger recovery retry instead of immediate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)