### PR TITLE
feat(cmd): vairdict resume, logs, and --background (#90)

### DIFF
--- a/cmd/vairdict/background.go
+++ b/cmd/vairdict/background.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// spawnBackground re-executes the current binary with the given args
+// in a detached session and returns the child's PID. The child's
+// stdout/stderr are redirected to the per-task log file at
+// ~/.vairdict/logs/<taskID>.log so the work proceeds identically to
+// a foreground run.
+//
+// The parent then writes a short "started in background" banner to
+// `banner` (os.Stdout for humans) and returns — the child keeps
+// running after the parent exits.
+//
+// Not supported on non-unix platforms: `setsid` is a unix concept.
+// Windows users can still run vairdict in the foreground.
+func spawnBackground(taskID string, passthroughArgs []string, banner io.Writer) error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving own binary: %w", err)
+	}
+
+	logPath, err := logPathForTask(taskID)
+	if err != nil {
+		return fmt.Errorf("resolving log path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		return fmt.Errorf("creating log dir: %w", err)
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening log file for background run: %w", err)
+	}
+
+	cmd := exec.Command(self, passthroughArgs...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Stdin = nil
+	// Detach: new session so the child outlives the controlling terminal.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// Inherit VAIRDICT_FOREGROUND=1 into the child so it bypasses the
+	// --background re-exec and runs the real work.
+	cmd.Env = append(os.Environ(), "VAIRDICT_FOREGROUND=1")
+
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("starting background process: %w", err)
+	}
+
+	// The parent keeps the file descriptor to the log just long enough
+	// to finish Start — the child has its own copy via fork. Close ours
+	// so the parent doesn't hold the file open unnecessarily.
+	_ = logFile.Close()
+
+	fmt.Fprintf(banner, "task %s running in background (pid %d)\n", taskID, cmd.Process.Pid)
+	fmt.Fprintf(banner, "  status: vairdict status %s\n", taskID)
+	fmt.Fprintf(banner, "  logs:   vairdict logs %s -f\n", taskID)
+	fmt.Fprintf(banner, "  resume: vairdict resume %s\n", taskID)
+
+	// Release the child so the parent can exit cleanly without waiting.
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("releasing background process: %w", err)
+	}
+	return nil
+}
+
+// shouldRunForeground reports whether the current invocation is either
+// the re-exec child of a --background spawn, or a user-invoked
+// foreground command. Used by `run` and `resume` to decide whether to
+// detach or actually do the work.
+func shouldRunForeground() bool {
+	return os.Getenv("VAIRDICT_FOREGROUND") == "1"
+}
+
+// backgroundArgsForRun builds the argv to pass to the detached child so
+// it re-runs `vairdict run` with the same flags and intent arguments,
+// minus --background itself. Extracted for testability.
+func backgroundArgsForRun(intents []string, issues []int, envName, priority string, dependsOn []string) []string {
+	args := []string{"run"}
+	for _, i := range issues {
+		if i > 0 {
+			args = append(args, "--issue", strconv.Itoa(i))
+		}
+	}
+	if envName != "" {
+		args = append(args, "--env", envName)
+	}
+	if priority != "" {
+		args = append(args, "--priority", priority)
+	}
+	for _, d := range dependsOn {
+		args = append(args, "--depends-on", d)
+	}
+	args = append(args, intents...)
+	return args
+}
+
+// backgroundArgsForResume builds the argv for a detached resume.
+func backgroundArgsForResume(taskID, envName string) []string {
+	args := []string{"resume"}
+	if envName != "" {
+		args = append(args, "--env", envName)
+	}
+	args = append(args, taskID)
+	return args
+}

--- a/cmd/vairdict/background.go
+++ b/cmd/vairdict/background.go
@@ -60,10 +60,10 @@ func spawnBackground(taskID string, passthroughArgs []string, banner io.Writer) 
 	// so the parent doesn't hold the file open unnecessarily.
 	_ = logFile.Close()
 
-	fmt.Fprintf(banner, "task %s running in background (pid %d)\n", taskID, cmd.Process.Pid)
-	fmt.Fprintf(banner, "  status: vairdict status %s\n", taskID)
-	fmt.Fprintf(banner, "  logs:   vairdict logs %s -f\n", taskID)
-	fmt.Fprintf(banner, "  resume: vairdict resume %s\n", taskID)
+	_, _ = fmt.Fprintf(banner, "task %s running in background (pid %d)\n", taskID, cmd.Process.Pid)
+	_, _ = fmt.Fprintf(banner, "  status: vairdict status %s\n", taskID)
+	_, _ = fmt.Fprintf(banner, "  logs:   vairdict logs %s -f\n", taskID)
+	_, _ = fmt.Fprintf(banner, "  resume: vairdict resume %s\n", taskID)
 
 	// Release the child so the parent can exit cleanly without waiting.
 	if err := cmd.Process.Release(); err != nil {

--- a/cmd/vairdict/background_test.go
+++ b/cmd/vairdict/background_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBackgroundArgsForRun_PassesFlagsAndIntents(t *testing.T) {
+	got := backgroundArgsForRun(
+		[]string{"add login"},
+		[]int{32, 0, 45},
+		"ci",
+		"high",
+		[]string{"abc123", "def456"},
+	)
+	want := []string{
+		"run",
+		"--issue", "32",
+		"--issue", "45",
+		"--env", "ci",
+		"--priority", "high",
+		"--depends-on", "abc123",
+		"--depends-on", "def456",
+		"add login",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("args mismatch:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestBackgroundArgsForRun_OmitsEmpty(t *testing.T) {
+	got := backgroundArgsForRun([]string{"x"}, nil, "", "", nil)
+	want := []string{"run", "x"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("args with no flags should be minimal: got %v want %v", got, want)
+	}
+}
+
+func TestBackgroundArgsForResume(t *testing.T) {
+	got := backgroundArgsForResume("a1b2c3d4", "dev")
+	want := []string{"resume", "--env", "dev", "a1b2c3d4"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v want %v", got, want)
+	}
+
+	got = backgroundArgsForResume("a1b2c3d4", "")
+	want = []string{"resume", "a1b2c3d4"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("no-env: got %v want %v", got, want)
+	}
+}
+
+func TestShouldRunForeground(t *testing.T) {
+	t.Setenv("VAIRDICT_FOREGROUND", "1")
+	if !shouldRunForeground() {
+		t.Error("VAIRDICT_FOREGROUND=1 should force foreground")
+	}
+	t.Setenv("VAIRDICT_FOREGROUND", "")
+	if shouldRunForeground() {
+		t.Error("unset VAIRDICT_FOREGROUND should not force foreground")
+	}
+}

--- a/cmd/vairdict/logs.go
+++ b/cmd/vairdict/logs.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	logsFollowFlag bool
+	logsLinesFlag  int
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs <task-id>",
+	Short: "Show logs for a task in human-readable form",
+	Long: `Pretty-prints the per-task log file at ~/.vairdict/logs/<task-id>.log.
+
+The file is JSON per line (slog). This command formats each line as
+  HH:MM:SS  [phase/state]  message
+so tailing a run is readable without an external parser.
+
+Flags:
+  -n, --lines N   show only the last N lines (default 200; 0 for all)
+  -f, --follow    keep reading as new log lines are written`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return showLogs(args[0], logsLinesFlag, logsFollowFlag, os.Stdout)
+	},
+}
+
+func init() {
+	logsCmd.Flags().BoolVarP(&logsFollowFlag, "follow", "f", false, "follow the log as new lines are written (like tail -f)")
+	logsCmd.Flags().IntVarP(&logsLinesFlag, "lines", "n", 200, "show the last N lines (0 for all)")
+	rootCmd.AddCommand(logsCmd)
+}
+
+// showLogs opens the per-task log file, prints (optionally) the last N
+// lines formatted, then optionally follows for new lines. Extracted so
+// tests can point it at a temp file with an injected writer.
+func showLogs(taskID string, lines int, follow bool, out io.Writer) error {
+	path, err := logPathForTask(taskID)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no log file for task %s (expected %s)", taskID, path)
+		}
+		return fmt.Errorf("opening log file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Print the last `lines` lines. When lines <= 0, print everything.
+	// Done by reading once, buffering up to `lines` recent lines via a
+	// ring, then flushing. For large logs this is O(n) in scan but
+	// O(lines) in memory.
+	if err := tailPrint(f, lines, out); err != nil {
+		return err
+	}
+
+	if !follow {
+		return nil
+	}
+
+	// Follow: re-read from current position as the file grows. Simple
+	// poll loop (200ms) — good enough for a dev-tool tail and avoids a
+	// platform-specific fsnotify dep.
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			fmt.Fprint(out, formatLogLine(line))
+		}
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, io.EOF) {
+			return fmt.Errorf("reading log: %w", err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// logPathForTask returns the absolute log path for a task id.
+func logPathForTask(taskID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home dir: %w", err)
+	}
+	return filepath.Join(home, ".vairdict", "logs", taskID+".log"), nil
+}
+
+// tailPrint emits the formatted form of the last `lines` lines from r.
+// Non-positive lines means "print everything". Each line goes through
+// formatLogLine so JSON events render as human-readable text.
+func tailPrint(r io.Reader, lines int, out io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	// Log messages include full prompts which can be large; bump the
+	// default 64KB buffer to 1MB so scanning doesn't fail on a single
+	// long line.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	if lines <= 0 {
+		for scanner.Scan() {
+			fmt.Fprint(out, formatLogLine(scanner.Text()+"\n"))
+		}
+		return scanner.Err()
+	}
+
+	ring := make([]string, 0, lines)
+	for scanner.Scan() {
+		if len(ring) < lines {
+			ring = append(ring, scanner.Text())
+			continue
+		}
+		// Shift left by one (cheap at these sizes) and append.
+		copy(ring, ring[1:])
+		ring[len(ring)-1] = scanner.Text()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanning log: %w", err)
+	}
+	for _, l := range ring {
+		fmt.Fprint(out, formatLogLine(l+"\n"))
+	}
+	return nil
+}
+
+// formatLogLine turns one JSON slog line into a readable single line:
+//
+//	HH:MM:SS  [phase/state]  msg  key=val key=val
+//
+// Unknown fields (any beyond time/level/msg/phase/state/task_id) are
+// appended as key=val pairs so debug info isn't lost, but common
+// orchestration metadata is given a fixed slot at the front.
+//
+// If the line isn't valid JSON (e.g. stray stderr the runner wrote
+// directly to the file), it is returned unchanged so nothing is
+// silently dropped.
+func formatLogLine(raw string) string {
+	trimmed := strings.TrimRight(raw, "\n")
+	if trimmed == "" {
+		return raw
+	}
+
+	var event map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &event); err != nil {
+		// Not JSON — pass through as-is.
+		return raw
+	}
+
+	// Clock (just HH:MM:SS — date is in the filename / rotation).
+	clock := "        "
+	if ts, ok := event["time"].(string); ok {
+		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+			clock = t.Local().Format("15:04:05")
+		}
+	}
+
+	msg, _ := event["msg"].(string)
+
+	phase, _ := event["phase"].(string)
+	if phase == "" {
+		phase, _ = event["task_phase"].(string)
+	}
+	stateStr, _ := event["state"].(string)
+	if stateStr == "" {
+		stateStr, _ = event["task_state"].(string)
+	}
+
+	var header string
+	switch {
+	case phase != "" && stateStr != "":
+		header = fmt.Sprintf("[%s/%s]", phase, stateStr)
+	case phase != "":
+		header = fmt.Sprintf("[%s]", phase)
+	case stateStr != "":
+		header = fmt.Sprintf("[%s]", stateStr)
+	default:
+		if lvl, ok := event["level"].(string); ok && lvl != "" && lvl != "INFO" {
+			header = fmt.Sprintf("[%s]", strings.ToLower(lvl))
+		}
+	}
+
+	// Collect remaining key=val extras (skip well-known fields).
+	skip := map[string]bool{
+		"time": true, "level": true, "msg": true,
+		"phase": true, "state": true,
+		"task_phase": true, "task_state": true,
+	}
+	var extras []string
+	for k, v := range event {
+		if skip[k] {
+			continue
+		}
+		extras = append(extras, fmt.Sprintf("%s=%v", k, v))
+	}
+
+	var b strings.Builder
+	b.WriteString(clock)
+	b.WriteString("  ")
+	if header != "" {
+		b.WriteString(header)
+		b.WriteString("  ")
+	}
+	b.WriteString(msg)
+	if len(extras) > 0 {
+		b.WriteString("  ")
+		b.WriteString(strings.Join(extras, " "))
+	}
+	b.WriteString("\n")
+	return b.String()
+}

--- a/cmd/vairdict/logs.go
+++ b/cmd/vairdict/logs.go
@@ -79,7 +79,7 @@ func showLogs(taskID string, lines int, follow bool, out io.Writer) error {
 	for {
 		line, err := reader.ReadString('\n')
 		if line != "" {
-			fmt.Fprint(out, formatLogLine(line))
+			_, _ = fmt.Fprint(out, formatLogLine(line))
 		}
 		if err == nil {
 			continue
@@ -112,7 +112,7 @@ func tailPrint(r io.Reader, lines int, out io.Writer) error {
 
 	if lines <= 0 {
 		for scanner.Scan() {
-			fmt.Fprint(out, formatLogLine(scanner.Text()+"\n"))
+			_, _ = fmt.Fprint(out, formatLogLine(scanner.Text()+"\n"))
 		}
 		return scanner.Err()
 	}
@@ -131,7 +131,7 @@ func tailPrint(r io.Reader, lines int, out io.Writer) error {
 		return fmt.Errorf("scanning log: %w", err)
 	}
 	for _, l := range ring {
-		fmt.Fprint(out, formatLogLine(l+"\n"))
+		_, _ = fmt.Fprint(out, formatLogLine(l+"\n"))
 	}
 	return nil
 }

--- a/cmd/vairdict/logs_test.go
+++ b/cmd/vairdict/logs_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestFormatLogLine_JSON(t *testing.T) {
+	raw := `{"time":"2026-04-24T15:04:05Z","level":"INFO","msg":"plan loop","phase":"plan","state":"planning","task_id":"a1b2c3d4","loop":2}` + "\n"
+
+	got := formatLogLine(raw)
+	// Time portion will vary by local tz; only assert the bracketed
+	// section and message, which are tz-independent.
+	if !strings.Contains(got, "[plan/planning]") {
+		t.Errorf("missing phase/state header: %q", got)
+	}
+	if !strings.Contains(got, "plan loop") {
+		t.Errorf("missing message: %q", got)
+	}
+	if !strings.Contains(got, "loop=2") {
+		t.Errorf("missing extras: %q", got)
+	}
+	if !strings.Contains(got, "task_id=a1b2c3d4") {
+		t.Errorf("missing task_id: %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("output must end in newline: %q", got)
+	}
+}
+
+func TestFormatLogLine_NotJSON(t *testing.T) {
+	// Stray stderr written directly to the log should pass through
+	// unchanged so no information is silently dropped.
+	raw := "panic: runtime error\n"
+	if got := formatLogLine(raw); got != raw {
+		t.Errorf("non-JSON input mutated: want %q got %q", raw, got)
+	}
+}
+
+func TestFormatLogLine_NoPhaseNoState(t *testing.T) {
+	// Events without phase/state still format, using level as a
+	// fallback header for non-INFO.
+	raw := `{"time":"2026-04-24T15:04:05Z","level":"WARN","msg":"stale pid"}` + "\n"
+	got := formatLogLine(raw)
+	if !strings.Contains(got, "[warn]") {
+		t.Errorf("expected [warn] fallback header, got %q", got)
+	}
+	if !strings.Contains(got, "stale pid") {
+		t.Errorf("missing message: %q", got)
+	}
+}
+
+func TestTailPrint_LastN(t *testing.T) {
+	lines := []string{
+		`{"time":"2026-04-24T15:00:00Z","msg":"one"}`,
+		`{"time":"2026-04-24T15:00:01Z","msg":"two"}`,
+		`{"time":"2026-04-24T15:00:02Z","msg":"three"}`,
+		`{"time":"2026-04-24T15:00:03Z","msg":"four"}`,
+	}
+	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var out bytes.Buffer
+	if err := tailPrint(in, 2, &out); err != nil {
+		t.Fatalf("tailPrint: %v", err)
+	}
+	if strings.Contains(out.String(), "one") || strings.Contains(out.String(), "two") {
+		t.Errorf("first two lines should be dropped: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "three") || !strings.Contains(out.String(), "four") {
+		t.Errorf("last two lines should be present: %s", out.String())
+	}
+}
+
+func TestTailPrint_All(t *testing.T) {
+	// lines <= 0 means print everything.
+	lines := []string{
+		`{"time":"2026-04-24T15:00:00Z","msg":"first"}`,
+		`{"time":"2026-04-24T15:00:01Z","msg":"second"}`,
+	}
+	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var out bytes.Buffer
+	if err := tailPrint(in, 0, &out); err != nil {
+		t.Fatalf("tailPrint: %v", err)
+	}
+	if !strings.Contains(out.String(), "first") || !strings.Contains(out.String(), "second") {
+		t.Errorf("expected both lines, got: %s", out.String())
+	}
+}

--- a/cmd/vairdict/resume.go
+++ b/cmd/vairdict/resume.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/github"
+	"github.com/vairdict/vairdict/internal/state"
+	"github.com/vairdict/vairdict/internal/ui"
+	"github.com/vairdict/vairdict/internal/workspace"
+)
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume [task-id]",
+	Short: "Resume an interrupted task from its last persisted state",
+	Long: `Resume a task that was interrupted (ctrl-c, crash, laptop close) by
+picking up from the phase it was last in. The plan text and branch are
+restored from the local state database and git — no re-planning, no lost
+code.
+
+With no argument, lists resumable tasks (non-terminal state) sorted by
+most-recently-updated first.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mode, err := ui.ParseMode(outputFlag)
+		if err != nil {
+			return err
+		}
+		colors, err := ui.ParseColorScheme(colorsFlag)
+		if err != nil {
+			return err
+		}
+
+		dbPath, err := state.DefaultDBPath()
+		if err != nil {
+			return fmt.Errorf("resolving database path: %w", err)
+		}
+		store, err := state.NewStore(dbPath)
+		if err != nil {
+			return fmt.Errorf("opening state store: %w", err)
+		}
+		defer func() { _ = store.Close() }()
+
+		if len(args) == 0 {
+			if backgroundFlag {
+				return fmt.Errorf("--background requires a task id")
+			}
+			return listResumable(store)
+		}
+
+		if backgroundFlag && !shouldRunForeground() {
+			return spawnBackground(args[0], backgroundArgsForResume(args[0], envFlag), os.Stdout)
+		}
+
+		return resumeTask(args[0], store, mode, colors, asciiFlag)
+	},
+}
+
+func init() {
+	resumeCmd.Flags().StringVar(&outputFlag, "output", "", "output mode: cli|ci|json (default: auto-detect)")
+	resumeCmd.Flags().StringVar(&colorsFlag, "colors", "", "color scheme: default|accessible|no-color (default: auto-detect)")
+	resumeCmd.Flags().BoolVar(&asciiFlag, "ascii", false, "use ASCII glyphs instead of unicode emoji")
+	resumeCmd.Flags().StringVar(&envFlag, "env", "", "config environment to load (e.g. dev, test, ci)")
+	resumeCmd.Flags().BoolVarP(&backgroundFlag, "background", "b", false, "run detached so the resume survives terminal exit. Prints the task id, then returns.")
+	rootCmd.AddCommand(resumeCmd)
+}
+
+// listResumable prints every non-terminal task in a tabular form so the
+// user can pick one to resume. Sorted most-recently-updated first so the
+// task that was just interrupted is at the top.
+func listResumable(store *state.Store) error {
+	tasks, err := store.ListResumable()
+	if err != nil {
+		return fmt.Errorf("listing resumable tasks: %w", err)
+	}
+	if len(tasks) == 0 {
+		fmt.Println("no resumable tasks. start one with 'vairdict run \"<intent>\"'.")
+		return nil
+	}
+
+	fmt.Printf("%d resumable task(s):\n\n", len(tasks))
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tSTATE\tPHASE\tUPDATED\tINTENT")
+	_, _ = fmt.Fprintln(w, "--\t-----\t-----\t-------\t------")
+	for _, t := range tasks {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			t.ID, t.State, t.Phase,
+			t.UpdatedAt.Format("2006-01-02 15:04"),
+			truncate(t.Intent, 50))
+	}
+	_ = w.Flush()
+	fmt.Println("\nresume with: vairdict resume <id>")
+	return nil
+}
+
+// resumeTask loads a task, validates it's resumable, and hands it to the
+// orchestration loop with a pre-populated resumeState so the plan phase
+// and already-completed code phases are skipped.
+func resumeTask(taskID string, store *state.Store, mode ui.Mode, colors ui.ColorScheme, ascii bool) error {
+	task, err := store.GetTask(taskID)
+	if err != nil {
+		return fmt.Errorf("task %q not found", taskID)
+	}
+
+	// Terminal states — print status and exit. Matches the AC: resume
+	// on a done/escalated task is a no-op, not an error.
+	switch task.State {
+	case state.StateDone:
+		fmt.Printf("task %s is already done — nothing to resume.\n", task.ID)
+		return nil
+	case state.StateEscalated:
+		fmt.Printf("task %s escalated to human review — nothing to resume.\n", task.ID)
+		return nil
+	case state.StateBlocked:
+		fmt.Printf("task %s is blocked on dependencies — nothing to resume.\n", task.ID)
+		return nil
+	case state.StatePending:
+		return fmt.Errorf("task %s has not started yet; run it with 'vairdict run'", task.ID)
+	}
+
+	if !task.IsResumable() {
+		return fmt.Errorf("task %s is in state %s and cannot be resumed", task.ID, task.State)
+	}
+
+	// A resume to code/quality needs the plan text that produced the
+	// existing branch. Without it, the coder would work from a
+	// regenerated (different) plan and desync from the committed code.
+	if task.Phase != state.PhasePlan && task.PlanOutput == "" {
+		return fmt.Errorf("task %s has no persisted plan output — this task predates resume support and cannot be resumed", task.ID)
+	}
+
+	// Normalize review states: the phase runners expect to start from
+	// the active state of their phase (planning/coding/quality), not
+	// the review state. Requeueing-through-Transition is idempotent if
+	// the task is already in the active state.
+	switch task.State {
+	case state.StatePlanReview:
+		if err := task.Transition(state.StatePlanning); err != nil {
+			return fmt.Errorf("normalizing plan_review for resume: %w", err)
+		}
+	case state.StateCodeReview:
+		if err := task.Transition(state.StateCoding); err != nil {
+			return fmt.Errorf("normalizing code_review for resume: %w", err)
+		}
+	case state.StateQualityReview:
+		if err := task.Transition(state.StateQuality); err != nil {
+			return fmt.Errorf("normalizing quality_review for resume: %w", err)
+		}
+	}
+	if err := store.UpdateTask(task); err != nil {
+		return fmt.Errorf("persisting normalized state: %w", err)
+	}
+
+	// Load config.
+	overlayPath, err := config.ResolveOverlayPath(envFlag, config.IsCI(), ".", fileExistsFunc)
+	if err != nil {
+		return fmt.Errorf("resolving env: %w", err)
+	}
+	cfg, err := config.LoadConfigWithOverlay("vairdict.yaml", overlayPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	client, backend, err := resolveCompleter(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Route slog into the task's log file so resume output goes to the
+	// same place as the original run.
+	logFile, logErr := ui.OpenLogFile(task.ID)
+	logPath := ""
+	if logErr == nil {
+		slog.SetDefault(slog.New(logFile.Handler()))
+		logPath = logFile.Path()
+		defer func() { _ = logFile.Close() }()
+	} else {
+		slog.Warn("falling back to default log handler", "error", logErr)
+	}
+
+	r := ui.New(ui.Options{
+		Mode:       mode,
+		Colors:     colors,
+		ASCII:      ascii,
+		IsTTY:      ui.IsTerminal(os.Stdout),
+		NoColorEnv: ui.NoColorEnv(),
+		Out:        os.Stdout,
+	})
+	defer func() { _ = r.Close() }()
+
+	r.RunStart(task.ID, task.Intent, logPath)
+	r.Note("completer", string(backend))
+	r.Note("resume", fmt.Sprintf("from [%s/%s]", task.Phase, task.State))
+
+	slog.Info("task resumed", "id", task.ID, "phase", task.Phase, "state", task.State)
+
+	ctx, done := withInterruptHandler(context.Background(), task.ID)
+	defer done()
+
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving working directory: %w", err)
+	}
+
+	// Attach to the existing worktree (or recreate it from the branch
+	// if it was cleaned up). The branch is deterministic from task ID.
+	wsMgr := workspace.New(repoRoot, "", &workspace.ExecRunner{})
+	ws, err := wsMgr.Attach(ctx, task.ID)
+	if err != nil {
+		return fmt.Errorf("attaching workspace for resume: %w", err)
+	}
+	defer func() { _ = ws.Cleanup(ctx) }()
+
+	workDir := ws.Path
+	r.Note("workspace", workDir)
+
+	ghRunner := &github.ExecRunner{Dir: repoRoot}
+	ghClient := github.New(ghRunner)
+	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient, 0)
+
+	// Claim the run with this PID so `vairdict status` shows it as
+	// running while the resumed orchestration is in flight.
+	task.PID = os.Getpid()
+	task.UpdatedAt = time.Now()
+	if err := store.UpdateTask(task); err != nil {
+		slog.Warn("failed to claim pid", "error", err)
+	}
+	defer clearPID(store, task)
+
+	return runOrchestrationWithResume(ctx, deps, task, r, resumeState{
+		plan:      task.PlanOutput,
+		branch:    ws.Branch,
+		fromPhase: task.Phase,
+	})
+}
+
+// clearPID unsets the task's PID on exit so stale pid entries don't
+// make `status` misreport a dead task as running. Called via defer from
+// resumeTask; errors are logged but do not fail the run.
+func clearPID(store *state.Store, task *state.Task) {
+	task.PID = 0
+	task.UpdatedAt = time.Now()
+	if err := store.UpdateTask(task); err != nil {
+		slog.Debug("failed to clear pid", "task", task.ID, "error", err)
+	}
+}
+
+// withInterruptHandler wraps a parent context with SIGINT/SIGTERM
+// handling tailored to resume-able tasks. First signal cancels the
+// context and prints a resume hint on stderr. A second signal within
+// the same session force-exits immediately — protects against a hung
+// subprocess that ignores the cancelled context.
+//
+// The returned done() should be deferred by the caller to restore
+// default signal handling once orchestration completes normally.
+func withInterruptHandler(parent context.Context, taskID string) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(parent)
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt)
+
+	go func() {
+		sig, ok := <-sigCh
+		if !ok {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "\nreceived %s — shutting down gracefully. press ctrl-c again to force exit.\n", sig)
+		fmt.Fprintf(os.Stderr, "resume with: vairdict resume %s\n", taskID)
+		cancel()
+		// Second signal force-exits.
+		if _, ok := <-sigCh; ok {
+			fmt.Fprintln(os.Stderr, "forced exit.")
+			os.Exit(130)
+		}
+	}()
+
+	done := func() {
+		signal.Stop(sigCh)
+		close(sigCh)
+		cancel()
+	}
+	return ctx, done
+}

--- a/cmd/vairdict/resume.go
+++ b/cmd/vairdict/resume.go
@@ -243,12 +243,16 @@ func resumeTask(taskID string, store *state.Store, mode ui.Mode, colors ui.Color
 
 // clearPID unsets the task's PID on exit so stale pid entries don't
 // make `status` misreport a dead task as running. Called via defer from
-// resumeTask; errors are logged but do not fail the run.
+// resumeTask; errors are logged at Error level since a failure here
+// leaves a stale PID in the database that will confuse future `status`
+// calls (they will show a dead task as running). Returning the error
+// would force every caller into bool-coerced teardown for a condition
+// they can't meaningfully react to.
 func clearPID(store *state.Store, task *state.Task) {
 	task.PID = 0
 	task.UpdatedAt = time.Now()
 	if err := store.UpdateTask(task); err != nil {
-		slog.Debug("failed to clear pid", "task", task.ID, "error", err)
+		slog.Error("failed to clear pid — status may report stale running state", "task", task.ID, "error", err)
 	}
 }
 

--- a/cmd/vairdict/resume_test.go
+++ b/cmd/vairdict/resume_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// TestRunOrchestrationWithResume_SkipsPlanWhenPlanProvided verifies the
+// resume-from-code path: when a resumeState carries the plan text, the
+// plan phase must be skipped and the pre-existing plan threaded into
+// the code and quality phases so they work from the same plan the
+// branch was originally built against.
+func TestRunOrchestrationWithResume_SkipsPlanWhenPlanProvided(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	task := state.NewTask("t-resume-code", "pick up where we left off")
+	r := &fakeRenderer{}
+
+	resume := resumeState{
+		plan:      "original plan text",
+		branch:    "vairdict/t-resume-code",
+		fromPhase: state.PhaseCode,
+	}
+
+	err := runOrchestrationWithResume(context.Background(), b.deps(), task, r, resume)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.plan.called {
+		t.Error("plan runner should be skipped when resume.plan is set")
+	}
+	if b.gh.branchCalled {
+		t.Error("CreateBranch should be skipped when resume.branch is set")
+	}
+	if !b.code.called {
+		t.Error("code runner should run on a code-phase resume")
+	}
+	if b.code.plan != "original plan text" {
+		t.Errorf("code runner got plan %q, want original", b.code.plan)
+	}
+	if !b.quality.called {
+		t.Error("quality runner should still run after code")
+	}
+	if b.quality.plan != "original plan text" {
+		t.Errorf("quality runner got plan %q, want original", b.quality.plan)
+	}
+}
+
+// TestRunOrchestrationWithResume_SkipsCodeForQualityPhase verifies that
+// resuming from the quality phase skips the coder entirely — the code
+// is already committed to the branch and re-running would overwrite it.
+func TestRunOrchestrationWithResume_SkipsCodeForQualityPhase(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	task := state.NewTask("t-resume-quality", "re-run the judge")
+	r := &fakeRenderer{}
+
+	resume := resumeState{
+		plan:      "the plan",
+		branch:    "vairdict/t-resume-quality",
+		fromPhase: state.PhaseQuality,
+	}
+
+	err := runOrchestrationWithResume(context.Background(), b.deps(), task, r, resume)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.plan.called {
+		t.Error("plan runner should be skipped")
+	}
+	if b.code.called {
+		t.Error("code runner must NOT run on a quality-phase resume (code already committed)")
+	}
+	if b.commitCalled {
+		t.Error("commit must NOT run on a quality-phase resume")
+	}
+	if !b.quality.called {
+		t.Error("quality runner should run")
+	}
+	if b.quality.plan != "the plan" {
+		t.Errorf("quality runner got plan %q, want original", b.quality.plan)
+	}
+}
+
+// TestRunOrchestrationWithResume_EmptyResumeIsNoop verifies that a
+// zero-value resumeState is equivalent to a fresh run — the existing
+// runOrchestration wrapper relies on this.
+func TestRunOrchestrationWithResume_EmptyResumeIsNoop(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	task := state.NewTask("t-fresh", "fresh run")
+	r := &fakeRenderer{}
+
+	err := runOrchestrationWithResume(context.Background(), b.deps(), task, r, resumeState{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !b.plan.called {
+		t.Error("plan runner should run on a fresh run")
+	}
+	if !b.gh.branchCalled {
+		t.Error("CreateBranch should run on a fresh run")
+	}
+	if !b.code.called || !b.quality.called {
+		t.Error("both code and quality should run on a fresh run")
+	}
+}
+
+// TestRunOrchestrationWithResume_PersistsPlanOutputOnFreshPlan verifies
+// that when the plan phase runs (no resume.plan), its output is
+// captured on the task so a later `vairdict resume` can reuse it.
+func TestRunOrchestrationWithResume_PersistsPlanOutputOnFreshPlan(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	task := state.NewTask("t-fresh-persist", "persist the plan")
+	r := &fakeRenderer{}
+
+	var persisted *state.Task
+	deps := b.deps()
+	deps.persistTask = func(tk *state.Task) error {
+		persisted = tk
+		return nil
+	}
+
+	err := runOrchestrationWithResume(context.Background(), deps, task, r, resumeState{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if persisted == nil {
+		t.Fatal("persistTask should have been called after plan phase")
+	}
+	if persisted.PlanOutput != "the plan" {
+		t.Errorf("persisted PlanOutput = %q, want %q", persisted.PlanOutput, "the plan")
+	}
+}

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -37,14 +37,15 @@ const (
 )
 
 var (
-	issueFlags    []int
-	outputFlag    string
-	colorsFlag    string
-	asciiFlag     bool
-	envFlag       string
-	manifestFlag  string
-	dependsOnFlag []string
-	priorityFlag  string
+	issueFlags     []int
+	outputFlag     string
+	colorsFlag     string
+	asciiFlag      bool
+	envFlag        string
+	manifestFlag   string
+	dependsOnFlag  []string
+	priorityFlag   string
+	backgroundFlag bool
 )
 
 var runCmd = &cobra.Command{
@@ -115,7 +116,28 @@ Use --issue to fetch intents from GitHub issues:
 			if len(issues) > 0 {
 				issueNum = issues[0]
 			}
+
+			// --background: re-exec this binary detached so the run
+			// survives the terminal closing, then exit with a banner
+			// pointing at `status` and `logs`. The re-exec child sets
+			// VAIRDICT_FOREGROUND=1 to bypass this branch and actually
+			// do the work.
+			if backgroundFlag && !shouldRunForeground() {
+				taskID := uuid.New().String()[:8]
+				args := backgroundArgsForRun(intents, issues, envFlag, priorityFlag, dependsOnFlag)
+				// Pass the pre-generated task id through so the banner the
+				// parent prints matches the id the child uses.
+				if err := os.Setenv("VAIRDICT_TASK_ID", taskID); err != nil {
+					return fmt.Errorf("setting task id env: %w", err)
+				}
+				return spawnBackground(taskID, args, os.Stdout)
+			}
+
 			return runTask(intents[0], issueNum, mode, colors, asciiFlag, dependsOnFlag, priorityFlag)
+		}
+
+		if backgroundFlag {
+			return fmt.Errorf("--background is only supported with a single intent")
 		}
 
 		if len(dependsOnFlag) > 0 {
@@ -137,6 +159,7 @@ func init() {
 	runCmd.Flags().StringVar(&manifestFlag, "manifest", "", "path to a YAML manifest declaring multiple tasks with dependencies (see docs for format)")
 	runCmd.Flags().StringSliceVar(&dependsOnFlag, "depends-on", nil, "task ID(s) this run depends on. The new task will wait (or start blocked) until each listed task is StateDone in the store.")
 	runCmd.Flags().StringVar(&priorityFlag, "priority", "", "task priority: high|normal|low (default: normal). Higher-priority tasks are dispatched first when multiple are ready.")
+	runCmd.Flags().BoolVarP(&backgroundFlag, "background", "b", false, "run detached so the task survives terminal exit. Prints the task id, then returns. Use 'vairdict status <id>' and 'vairdict logs <id> -f' to follow progress.")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -203,6 +226,7 @@ type runDeps struct {
 	conflicts    conflictChecker
 	workDir      string
 	commit       func(ctx context.Context, task *state.Task) error
+	persistTask  func(task *state.Task) error
 	onEscalation func(ctx context.Context, task *state.Task, result escalation.Result) error
 	issueNumber  int
 	autoMerge    bool
@@ -255,6 +279,10 @@ func defaultRunDeps(cfg *config.Config, client completer, store *state.Store, wo
 		commit: func(ctx context.Context, task *state.Task) error {
 			return commitChanges(ctx, task, workDir, r)
 		},
+		persistTask: func(task *state.Task) error {
+			task.UpdatedAt = time.Now()
+			return store.UpdateTask(task)
+		},
 		onEscalation: func(ctx context.Context, task *state.Task, result escalation.Result) error {
 			return escalateAndExit(ctx, task, result, cfg.Escalation, ghClient)
 		},
@@ -295,8 +323,14 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 		return err
 	}
 
-	// Create task.
-	taskID := uuid.New().String()[:8]
+	// Create task. When spawned detached via --background, the parent
+	// pre-generates the id and hands it over so its banner references
+	// the same task the child actually runs.
+	taskID := os.Getenv("VAIRDICT_TASK_ID")
+	if taskID == "" {
+		taskID = uuid.New().String()[:8]
+	}
+	_ = os.Unsetenv("VAIRDICT_TASK_ID")
 	task := state.NewTask(taskID, intent)
 	task.DependsOn = dependsOn
 	task.Priority = priority
@@ -355,9 +389,11 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 
 	slog.Info("task created", "id", task.ID, "intent", intent)
 
-	// Set up context with signal handling.
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
+	// Context + interrupt handler: first signal cancels gracefully and
+	// prints a resume hint; second force-exits. `vairdict resume` uses
+	// the same plumbing.
+	ctx, done := withInterruptHandler(context.Background(), task.ID)
+	defer done()
 
 	// Resolve working directory — the repo root where vairdict was invoked.
 	repoRoot, err := os.Getwd()
@@ -381,6 +417,17 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 	ghClient := github.New(ghRunner)
 
 	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient, issueNumber)
+
+	// Claim the run with this PID so `vairdict status` shows it as
+	// running. Cleared on normal exit; a crash leaves a stale PID, which
+	// the liveness check (kill -0) treats as not-running.
+	task.PID = os.Getpid()
+	task.UpdatedAt = time.Now()
+	if err := store.UpdateTask(task); err != nil {
+		slog.Warn("failed to claim pid", "error", err)
+	}
+	defer clearPID(store, task)
+
 	return runOrchestration(ctx, deps, task, r)
 }
 
@@ -566,6 +613,26 @@ func runSingleTask(
 // with one spare attempt.
 const maxOuterCycles = 3
 
+// resumeState carries the starting point for `vairdict resume` into the
+// orchestration loop. When empty (normal `vairdict run`), the loop starts
+// from the plan phase on a new branch. When populated, the loop skips
+// past phases the task already completed in an earlier invocation.
+type resumeState struct {
+	// plan, when non-empty, is the rendered plan text from the task's
+	// original plan phase. Seeds planResult so the plan phase is
+	// skipped on the first outer cycle — a resume must use the exact
+	// plan the existing code on the branch was built from.
+	plan string
+	// branch, when non-empty, is the existing branch name created in
+	// the original run. Skips CreateBranch on the first outer cycle.
+	branch string
+	// fromPhase is the phase the task was in when it was interrupted
+	// (plan / code / quality). PhaseQuality additionally skips the
+	// code phase on the first outer cycle because the code has
+	// already been committed.
+	fromPhase state.Phase
+}
+
 // runOrchestration is the testable core of runTask. It receives all
 // dependencies via deps so tests can substitute fakes for every
 // external interaction (phases, GitHub, git commit, escalation).
@@ -575,12 +642,29 @@ const maxOuterCycles = 3
 // to Plan, in which case HardConstraints capture the quality failure and
 // the plan phase runs again to produce a new plan that addresses them.
 func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.Renderer) error {
+	return runOrchestrationWithResume(ctx, deps, task, r, resumeState{})
+}
+
+// runOrchestrationWithResume is runOrchestration with an explicit resume
+// entry point. Exported-ish only to resume.go within the same package;
+// external callers go through runOrchestration with zero-value resume
+// state.
+func runOrchestrationWithResume(ctx context.Context, deps runDeps, task *state.Task, r ui.Renderer, resume resumeState) error {
 	var (
 		planResult    *planphase.PhaseResult
 		branch        string
 		branchCreated bool
 		qualityResult *qualityphase.PhaseResult
 	)
+
+	if resume.plan != "" {
+		planResult = &planphase.PhaseResult{Plan: resume.plan, Pass: true}
+	}
+	if resume.branch != "" {
+		branch = resume.branch
+		branchCreated = true
+	}
+	skipCodeFirstCycle := resume.fromPhase == state.PhaseQuality
 
 	for cycle := 0; cycle < maxOuterCycles; cycle++ {
 		// --- Plan phase (first cycle, or after rewind to plan) ---
@@ -602,6 +686,15 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 					Gaps:      gaps,
 				})
 			}
+
+			// Persist the plan text so `vairdict resume` can reuse the
+			// exact plan the branch was built from after an interrupt.
+			task.PlanOutput = planResult.Plan
+			if deps.persistTask != nil {
+				if err := deps.persistTask(task); err != nil {
+					slog.Warn("failed to persist plan output", "error", err)
+				}
+			}
 		}
 
 		// --- Create branch once, before the first code phase ---
@@ -617,31 +710,44 @@ func runOrchestration(ctx context.Context, deps runDeps, task *state.Task, r ui.
 		}
 
 		// --- Code phase ---
-		codeResult, err := deps.code.Run(ctx, task, planResult.Plan)
-		if err != nil {
-			r.Error(err)
-			return err
-		}
+		// On a quality-phase resume the code has already been committed
+		// in an earlier invocation; re-running the coder would overwrite
+		// it. Skip the code phase and its commit for the first outer
+		// cycle only — subsequent cycles (after a ReturnToCode rewind)
+		// must run the coder normally.
+		var codeFeedback string
+		if cycle == 0 && skipCodeFirstCycle {
+			if v := lastVerdictForPhase(task, state.PhaseCode); v != nil {
+				codeFeedback = v.Summary
+			}
+		} else {
+			codeResult, err := deps.code.Run(ctx, task, planResult.Plan)
+			if err != nil {
+				r.Error(err)
+				return err
+			}
 
-		if codeResult.Escalate {
-			gaps := lastGapsForPhase(task, state.PhaseCode)
-			r.Escalation(task.ID, state.PhaseCode, codeResult.Loops, codeResult.LastScore, gaps)
-			return deps.onEscalation(ctx, task, escalation.Result{
-				Phase:     state.PhaseCode,
-				Loops:     codeResult.Loops,
-				LastScore: codeResult.LastScore,
-				Gaps:      gaps,
-			})
-		}
+			if codeResult.Escalate {
+				gaps := lastGapsForPhase(task, state.PhaseCode)
+				r.Escalation(task.ID, state.PhaseCode, codeResult.Loops, codeResult.LastScore, gaps)
+				return deps.onEscalation(ctx, task, escalation.Result{
+					Phase:     state.PhaseCode,
+					Loops:     codeResult.Loops,
+					LastScore: codeResult.LastScore,
+					Gaps:      gaps,
+				})
+			}
 
-		// --- Commit any changes the coder made ---
-		if err := deps.commit(ctx, task); err != nil {
-			r.Error(err)
-			return err
+			// --- Commit any changes the coder made ---
+			if err := deps.commit(ctx, task); err != nil {
+				r.Error(err)
+				return err
+			}
+			codeFeedback = codeResult.Feedback
 		}
 
 		// --- Quality phase (gates the PR) ---
-		qResult, err := deps.quality.Run(ctx, task, planResult.Plan, codeResult.Feedback)
+		qResult, err := deps.quality.Run(ctx, task, planResult.Plan, codeFeedback)
 		if err != nil {
 			r.Error(err)
 			return err

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -302,8 +302,8 @@ type fakeDoneCall struct {
 
 func (f *fakeRenderer) RunStart(string, string, string) {}
 func (f *fakeRenderer) Note(string, string)             {}
-func (f *fakeRenderer) PhaseStart(state.Phase)              {}
-func (f *fakeRenderer) StepUpdate(state.Phase, string)      {}
+func (f *fakeRenderer) PhaseStart(state.Phase)          {}
+func (f *fakeRenderer) StepUpdate(state.Phase, string)  {}
 func (f *fakeRenderer) PRCreated(string)                {}
 func (f *fakeRenderer) VerdictPosted(float64, bool)     {}
 func (f *fakeRenderer) RunComplete(string)              {}

--- a/cmd/vairdict/status.go
+++ b/cmd/vairdict/status.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
+	"syscall"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -62,9 +64,16 @@ func listTasks(store *state.Store) error {
 		return nil
 	}
 
+	// Sort most-recently-updated first so running/recent tasks bubble
+	// to the top. The ListTasks default order is created_at ASC, which
+	// buries the task you just started.
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].UpdatedAt.After(tasks[j].UpdatedAt)
+	})
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "ID\tSTATE\tPHASE\tLOOPS\tLAST SCORE\tPRIORITY\tDEPS\tINTENT")
-	_, _ = fmt.Fprintln(w, "--\t-----\t-----\t-----\t----------\t--------\t----\t------")
+	_, _ = fmt.Fprintln(w, "ID\tRUN\tSTATE\tPHASE\tLOOPS\tLAST SCORE\tPRIORITY\tDEPS\tINTENT")
+	_, _ = fmt.Fprintln(w, "--\t---\t-----\t-----\t-----\t----------\t--------\t----\t------")
 
 	for _, t := range tasks {
 		loops := totalLoops(t)
@@ -78,11 +87,32 @@ func listTasks(store *state.Store) error {
 		if priority == "" {
 			priority = "normal"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
-			t.ID, t.State, t.Phase, loops, score, priority, deps, intent)
+		run := "-"
+		if isRunning(t) {
+			run = "*"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
+			t.ID, run, t.State, t.Phase, loops, score, priority, deps, intent)
 	}
 
 	return w.Flush()
+}
+
+// isRunning reports whether the task's stored PID corresponds to a live
+// process on this machine. Uses kill(pid, 0) which does not deliver a
+// signal but returns success iff the process exists and the caller has
+// permission to signal it. Works on unix; on Windows it degrades to a
+// "probably not running" no-op (acceptable — Windows support is not a
+// current dogfood surface).
+func isRunning(t *state.Task) bool {
+	if t == nil || t.PID <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(t.PID)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 func showTaskDetail(store *state.Store, id string) error {
@@ -105,6 +135,13 @@ func showTaskDetail(store *state.Store, id string) error {
 	}
 	fmt.Printf("Created: %s\n", task.CreatedAt.Format("2006-01-02 15:04:05"))
 	fmt.Printf("Updated: %s\n", task.UpdatedAt.Format("2006-01-02 15:04:05"))
+
+	if isRunning(task) {
+		logPath, _ := logPathForTask(task.ID)
+		fmt.Printf("Running: yes (pid %d, log %s)\n", task.PID, logPath)
+	} else if task.PID > 0 {
+		fmt.Printf("Running: no (stale pid %d recorded — process likely crashed; resumable with 'vairdict resume %s')\n", task.PID, task.ID)
+	}
 
 	// Loop counts.
 	fmt.Println("\nLoop Counts:")

--- a/internal/state/resume_test.go
+++ b/internal/state/resume_test.go
@@ -1,0 +1,126 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsResumable(t *testing.T) {
+	cases := []struct {
+		state TaskState
+		want  bool
+	}{
+		{StatePending, false},
+		{StatePlanning, true},
+		{StatePlanReview, true},
+		{StateCoding, true},
+		{StateCodeReview, true},
+		{StateQuality, true},
+		{StateQualityReview, true},
+		{StateDone, false},
+		{StateEscalated, false},
+		{StateBlocked, false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.state), func(t *testing.T) {
+			task := &Task{State: tc.state}
+			if got := task.IsResumable(); got != tc.want {
+				t.Errorf("IsResumable() for %s = %v, want %v", tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlanOutputAndPID_RoundTrip(t *testing.T) {
+	// #90: plan_output + pid columns are persisted so `vairdict resume`
+	// reuses the exact plan the worktree was built from, and `vairdict
+	// status` can show a RUNNING indicator.
+	store := newTestStore(t)
+	task := NewTask("task-resume", "build a resumable thing")
+	task.PlanOutput = "## Requirements\n...\n## Plan\n1. do it\n2. test it"
+	task.PID = 4242
+
+	if err := store.CreateTask(task); err != nil {
+		t.Fatalf("creating task: %v", err)
+	}
+
+	got, err := store.GetTask("task-resume")
+	if err != nil {
+		t.Fatalf("getting task: %v", err)
+	}
+	if got.PlanOutput != task.PlanOutput {
+		t.Errorf("PlanOutput not round-tripped:\nwant: %q\ngot:  %q", task.PlanOutput, got.PlanOutput)
+	}
+	if got.PID != task.PID {
+		t.Errorf("PID = %d, want %d", got.PID, task.PID)
+	}
+
+	// Mutate and UpdateTask — confirm the update path also persists.
+	got.PID = 0
+	got.PlanOutput = got.PlanOutput + "\n3. resume from here"
+	got.UpdatedAt = time.Now()
+	if err := store.UpdateTask(got); err != nil {
+		t.Fatalf("updating task: %v", err)
+	}
+
+	after, err := store.GetTask("task-resume")
+	if err != nil {
+		t.Fatalf("getting task after update: %v", err)
+	}
+	if after.PID != 0 {
+		t.Errorf("PID after clear = %d, want 0", after.PID)
+	}
+	if after.PlanOutput != got.PlanOutput {
+		t.Errorf("PlanOutput after update not persisted")
+	}
+}
+
+func TestListResumable(t *testing.T) {
+	store := newTestStore(t)
+
+	// Mix of resumable and non-resumable tasks.
+	tasks := []struct {
+		id    string
+		state TaskState
+	}{
+		{"a-done", StateDone},
+		{"b-planning", StatePlanning},
+		{"c-escalated", StateEscalated},
+		{"d-coding", StateCoding},
+		{"e-blocked", StateBlocked},
+		{"f-quality-review", StateQualityReview},
+	}
+	for i, tc := range tasks {
+		tk := NewTask(tc.id, "intent "+tc.id)
+		tk.State = tc.state
+		// Spread UpdatedAt so the sort can be verified deterministically:
+		// later entries update later, so they should appear first.
+		tk.UpdatedAt = time.Now().Add(time.Duration(i) * time.Second)
+		if err := store.CreateTask(tk); err != nil {
+			t.Fatalf("creating %s: %v", tc.id, err)
+		}
+	}
+
+	got, err := store.ListResumable()
+	if err != nil {
+		t.Fatalf("ListResumable: %v", err)
+	}
+
+	wantIDs := []string{"f-quality-review", "d-coding", "b-planning"}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("got %d resumable tasks, want %d: %+v", len(got), len(wantIDs), got)
+	}
+	for i, id := range wantIDs {
+		if got[i].ID != id {
+			t.Errorf("position %d: got %s, want %s (full order: %v)", i, got[i].ID, id, taskIDs(got))
+		}
+	}
+}
+
+func taskIDs(ts []*Task) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.ID
+	}
+	return out
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -93,6 +93,8 @@ func (s *Store) migrate() error {
 		{"priority", `ALTER TABLE tasks ADD COLUMN priority TEXT NOT NULL DEFAULT 'normal'`},
 		{"hard_constraints", `ALTER TABLE tasks ADD COLUMN hard_constraints TEXT NOT NULL DEFAULT '[]'`},
 		{"rewind_contexts", `ALTER TABLE tasks ADD COLUMN rewind_contexts TEXT NOT NULL DEFAULT '[]'`},
+		{"plan_output", `ALTER TABLE tasks ADD COLUMN plan_output TEXT NOT NULL DEFAULT ''`},
+		{"pid", `ALTER TABLE tasks ADD COLUMN pid INTEGER NOT NULL DEFAULT 0`},
 	} {
 		if _, err := s.db.Exec(alter.stmt); err != nil && !isDuplicateColumnErr(err) {
 			return fmt.Errorf("adding %s column: %w", alter.column, err)
@@ -147,11 +149,12 @@ func (s *Store) CreateTask(t *Task) error {
 	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO tasks (id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO tasks (id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		t.ID, t.Intent, string(t.State), string(t.Phase),
 		string(loopJSON), string(assumptionsJSON), string(attemptsJSON), string(dependsOnJSON),
 		priority, string(hardConstraintsJSON), string(rewindContextsJSON),
+		t.PlanOutput, t.PID,
 		t.CreatedAt.Format(time.RFC3339Nano), t.UpdatedAt.Format(time.RFC3339Nano),
 	)
 	if err != nil {
@@ -163,7 +166,7 @@ func (s *Store) CreateTask(t *Task) error {
 // GetTask retrieves a task by ID. Returns sql.ErrNoRows if not found.
 func (s *Store) GetTask(id string) (*Task, error) {
 	row := s.db.QueryRow(
-		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, created_at, updated_at
+		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at
 		 FROM tasks WHERE id = ?`, id,
 	)
 	return s.scanTask(row)
@@ -202,11 +205,12 @@ func (s *Store) UpdateTask(t *Task) error {
 	}
 
 	result, err := s.db.Exec(
-		`UPDATE tasks SET intent=?, state=?, phase=?, loop_count=?, assumptions=?, attempts=?, depends_on=?, priority=?, hard_constraints=?, rewind_contexts=?, updated_at=?
+		`UPDATE tasks SET intent=?, state=?, phase=?, loop_count=?, assumptions=?, attempts=?, depends_on=?, priority=?, hard_constraints=?, rewind_contexts=?, plan_output=?, pid=?, updated_at=?
 		 WHERE id=?`,
 		t.Intent, string(t.State), string(t.Phase),
 		string(loopJSON), string(assumptionsJSON), string(attemptsJSON), string(dependsOnJSON),
 		priority, string(hardConstraintsJSON), string(rewindContextsJSON),
+		t.PlanOutput, t.PID,
 		t.UpdatedAt.Format(time.RFC3339Nano), t.ID,
 	)
 	if err != nil {
@@ -231,12 +235,12 @@ func (s *Store) ListTasks(filterState TaskState) ([]*Task, error) {
 
 	if filterState == "" {
 		rows, err = s.db.Query(
-			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, created_at, updated_at
+			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at
 			 FROM tasks ORDER BY created_at ASC`,
 		)
 	} else {
 		rows, err = s.db.Query(
-			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, created_at, updated_at
+			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at
 			 FROM tasks WHERE state = ? ORDER BY created_at ASC`,
 			string(filterState),
 		)
@@ -256,6 +260,36 @@ func (s *Store) ListTasks(filterState TaskState) ([]*Task, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating tasks: %w", err)
+	}
+	return tasks, nil
+}
+
+// ListResumable returns every task in a non-terminal, resumable state
+// (see Task.IsResumable), sorted most-recently-updated first. Used by
+// `vairdict resume` with no args and by `vairdict status` to surface
+// unfinished work ahead of completed runs.
+func (s *Store) ListResumable() ([]*Task, error) {
+	rows, err := s.db.Query(
+		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at
+		 FROM tasks
+		 WHERE state IN ('planning','plan_review','coding','code_review','quality','quality_review')
+		 ORDER BY updated_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying resumable tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tasks []*Task
+	for rows.Next() {
+		t, err := s.scanTaskRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating resumable tasks: %w", err)
 	}
 	return tasks, nil
 }
@@ -284,6 +318,8 @@ func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 		priority            string
 		hardConstraintsJSON string
 		rewindContextsJSON  string
+		planOutput          string
+		pid                 int
 		createdAt           string
 		updatedAt           string
 	)
@@ -291,11 +327,14 @@ func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 	err := sc.Scan(&t.ID, &t.Intent, &state, &phase,
 		&loopJSON, &assumptionsJSON, &attemptsJSON, &dependsOnJSON, &priority,
 		&hardConstraintsJSON, &rewindContextsJSON,
+		&planOutput, &pid,
 		&createdAt, &updatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("scanning task: %w", err)
 	}
 	t.Priority = priority
+	t.PlanOutput = planOutput
+	t.PID = pid
 
 	t.State = TaskState(state)
 	t.Phase = Phase(phase)

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -286,9 +286,36 @@ type Task struct {
 	// Priority is one of "high", "normal", "low". Drives dispatch order
 	// in the scheduler when multiple tasks are ready at once. Empty or
 	// missing is treated as normal.
-	Priority  string    `json:"priority,omitempty"`
+	Priority string `json:"priority,omitempty"`
+	// PlanOutput is the rendered plan text (requirements + implementation
+	// plan) produced by the plan phase. Persisted so `vairdict resume`
+	// can continue a later phase without regenerating a different plan
+	// than the one the code on the worktree branch was built from.
+	PlanOutput string `json:"plan_output,omitempty"`
+	// PID is the OS process id of the currently attached runner, or 0
+	// when no process is attached. Written when `vairdict run` (or
+	// `resume`) begins orchestration and cleared on a clean exit. Used
+	// by `vairdict status` to render a RUNNING indicator via a kill(pid, 0)
+	// liveness check; stale PIDs (process died without cleanup) show as
+	// not running and the task is resumable.
+	PID       int       `json:"pid,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// IsResumable reports whether the task is in a non-terminal state and
+// can be picked up by `vairdict resume`. Terminal states (done,
+// escalated, blocked) return false; StatePending also returns false
+// because a pending task has never started and should be launched via
+// `vairdict run`, not resumed.
+func (t *Task) IsResumable() bool {
+	switch t.State {
+	case StatePlanning, StatePlanReview,
+		StateCoding, StateCodeReview,
+		StateQuality, StateQualityReview:
+		return true
+	}
+	return false
 }
 
 // ErrInvalidTransition is returned when an invalid state transition is attempted.

--- a/internal/ui/cli.go
+++ b/internal/ui/cli.go
@@ -16,10 +16,10 @@ var allPhases = []state.Phase{state.PhasePlan, state.PhaseCode, state.PhaseQuali
 type phaseStatus int
 
 const (
-	phasePending  phaseStatus = iota
-	phaseActive               // currently running
-	phasePassed               // completed successfully
-	phaseFailed               // completed with failure
+	phasePending phaseStatus = iota
+	phaseActive              // currently running
+	phasePassed              // completed successfully
+	phaseFailed              // completed with failure
 )
 
 // cliRenderer prints sectioned, colored, emoji-decorated output for human
@@ -34,18 +34,18 @@ type cliRenderer struct {
 	useASCI bool
 
 	// Task-list state: tracks each phase's status for checklist display.
-	phases    map[state.Phase]phaseStatus
-	scores    map[state.Phase]float64
-	activeStep string // current sub-step within the active phase
+	phases     map[state.Phase]phaseStatus
+	scores     map[state.Phase]float64
+	activeStep string                   // current sub-step within the active phase
 	doneSteps  map[state.Phase][]string // completed sub-steps per phase
 }
 
 func newCLIRenderer(out io.Writer, colors ColorScheme, ascii bool) *cliRenderer {
 	r := &cliRenderer{
-		w:       bufio.NewWriter(out),
-		pal:     paletteFor(colors),
-		colors:  colors,
-		useASCI: ascii,
+		w:         bufio.NewWriter(out),
+		pal:       paletteFor(colors),
+		colors:    colors,
+		useASCI:   ascii,
 		phases:    make(map[state.Phase]phaseStatus),
 		scores:    make(map[state.Phase]float64),
 		doneSteps: make(map[state.Phase][]string),

--- a/internal/workspace/attach_test.go
+++ b/internal/workspace/attach_test.go
@@ -1,0 +1,109 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeRunner records every command and replays canned responses keyed
+// by the full command line. Anything not in the map succeeds with "".
+type fakeRunner struct {
+	replies map[string]fakeReply
+	calls   []string
+}
+
+type fakeReply struct {
+	out []byte
+	err error
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{replies: map[string]fakeReply{}}
+}
+
+func (f *fakeRunner) on(cmdline string, out string, err error) {
+	f.replies[cmdline] = fakeReply{out: []byte(out), err: err}
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, name string, args ...string) ([]byte, error) {
+	line := name + " " + strings.Join(args, " ")
+	f.calls = append(f.calls, line)
+	if r, ok := f.replies[line]; ok {
+		return r.out, r.err
+	}
+	return nil, nil
+}
+
+func TestAttach_BranchMissing(t *testing.T) {
+	// When neither the worktree nor the branch exists, Attach must
+	// refuse — there is no committed code to restore and resume can't
+	// continue.
+	runner := newFakeRunner()
+	runner.on("git worktree list --porcelain", "", nil)
+	runner.on("git rev-parse --verify vairdict/t-missing", "", errors.New("unknown revision"))
+
+	mgr := New(t.TempDir(), "worktrees", runner)
+	if _, err := mgr.Attach(context.Background(), "t-missing"); err == nil {
+		t.Fatal("Attach should fail when branch does not exist")
+	} else if !strings.Contains(err.Error(), "branch vairdict/t-missing not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAttach_ReAttachesExistingBranch(t *testing.T) {
+	// Branch exists, worktree directory does not — Attach should run
+	// `git worktree add <path> <branch>` to restore the worktree at the
+	// deterministic path and reuse the existing branch.
+	runner := newFakeRunner()
+	runner.on("git worktree list --porcelain", "", nil) // no active worktrees
+	runner.on("git rev-parse --verify vairdict/t-recover", "abc123\n", nil)
+
+	repoRoot := t.TempDir()
+	mgr := New(repoRoot, "worktrees", runner)
+
+	ws, err := mgr.Attach(context.Background(), "t-recover")
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if ws.Branch != "vairdict/t-recover" {
+		t.Errorf("branch = %q, want vairdict/t-recover", ws.Branch)
+	}
+	// Must have invoked `git worktree add <path> <branch>` — i.e. no
+	// -b flag, because we are attaching to an existing branch, not
+	// creating one.
+	foundAdd := false
+	for _, c := range runner.calls {
+		if strings.HasPrefix(c, "git worktree add ") && strings.Contains(c, "vairdict/t-recover") && !strings.Contains(c, "-b") {
+			foundAdd = true
+			break
+		}
+	}
+	if !foundAdd {
+		t.Errorf("expected `git worktree add <path> vairdict/t-recover` (no -b); got calls: %v", runner.calls)
+	}
+}
+
+func TestAttach_BranchExistsButWorktreeAddFails(t *testing.T) {
+	// Surface the underlying git error rather than returning a generic
+	// "cannot resume" — the operator needs the real reason.
+	runner := newFakeRunner()
+	runner.on("git worktree list --porcelain", "", nil)
+	runner.on("git rev-parse --verify vairdict/t-broken", "abc123\n", nil)
+	// Any call to `worktree add` fails. Match on prefix via injection
+	// using a sentinel key that will never match and a fallback:
+	// simpler to just wire the exact call we expect.
+	repoRoot := t.TempDir()
+	mgr := New(repoRoot, "worktrees", runner)
+
+	wantPath := fmt.Sprintf("%s/worktrees/t-broken", repoRoot)
+	runner.on(fmt.Sprintf("git worktree add %s vairdict/t-broken", wantPath), "", errors.New("boom"))
+
+	if _, err := mgr.Attach(context.Background(), "t-broken"); err == nil {
+		t.Fatal("Attach should propagate worktree add errors")
+	} else if !strings.Contains(err.Error(), "re-attaching worktree") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -73,6 +73,52 @@ type Workspace struct {
 	taskID string
 }
 
+// Attach returns a Workspace for an existing task, reusing the on-disk
+// worktree if it is still registered with git, or re-attaching the
+// deterministic `vairdict/<taskID>` branch to a fresh worktree
+// directory if the previous one was cleaned up (crash, prune, laptop
+// close). Used by `vairdict resume` so a run can pick up exactly where
+// it was interrupted without regenerating the plan or losing the code
+// the coder already committed.
+//
+// If neither the worktree nor the branch exists, Attach returns an
+// error — resume cannot recover from a missing branch because the code
+// the task produced is lost.
+func (m *Manager) Attach(ctx context.Context, taskID string) (*Workspace, error) {
+	branch := "vairdict/" + taskID
+	worktreePath := filepath.Join(m.repoRoot, m.baseDir, taskID)
+
+	// Case 1: worktree is still registered with git and the directory
+	// exists — just reuse it.
+	if _, err := os.Stat(worktreePath); err == nil {
+		active := m.listActiveWorktrees(ctx)
+		if active[worktreePath] {
+			slog.Info("workspace reattached (existing worktree)", "task", taskID, "path", worktreePath, "branch", branch)
+			return &Workspace{Path: worktreePath, Branch: branch, mgr: m, taskID: taskID}, nil
+		}
+		// Directory exists but git doesn't know about it (partially
+		// cleaned up). Remove it so `git worktree add` below succeeds.
+		_ = os.RemoveAll(worktreePath)
+	}
+
+	// Case 2: branch exists but the worktree is gone. Recreate the
+	// worktree pointed at the existing branch so the committed code is
+	// restored at worktreePath.
+	if _, err := m.runner.Run(ctx, m.repoRoot, "git", "rev-parse", "--verify", branch); err != nil {
+		return nil, fmt.Errorf("branch %s not found — cannot resume: %w", branch, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
+		return nil, fmt.Errorf("creating worktree base dir: %w", err)
+	}
+	if _, err := m.runner.Run(ctx, m.repoRoot, "git", "worktree", "add", worktreePath, branch); err != nil {
+		return nil, fmt.Errorf("re-attaching worktree for branch %s: %w", branch, err)
+	}
+
+	slog.Info("workspace reattached (recreated worktree)", "task", taskID, "path", worktreePath, "branch", branch)
+	return &Workspace{Path: worktreePath, Branch: branch, mgr: m, taskID: taskID}, nil
+}
+
 // Create creates a new git worktree for the given task. The worktree is
 // based on the current HEAD of the main branch. Returns a Workspace that
 // must be cleaned up with Cleanup() when the task is done.


### PR DESCRIPTION
Closes #90.

## Summary

Adds the ability to resume an interrupted run from its last persisted state, tail the per-task log in human-readable form, and detach a run (or resume) to the background so it survives the terminal closing.

## What changed

- **state**: persist `plan_output` + `pid` columns; `ListResumable()` and `IsResumable()` surface non-terminal tasks.
- **workspace**: `Attach()` reuses the existing worktree or recreates one pointed at the deterministic `vairdict/<id>` branch.
- **run orchestration**: refactored to accept a `resumeState` so plan and code phases are skipped cleanly when resuming later phases; plan output is persisted after the plan phase for later resumes.
- **`vairdict resume [id]`**: bare form lists resumable tasks (sorted most-recently-updated first); with an id, normalizes review states, reattaches the workspace, and hands a pre-populated resume state to the orchestrator. Terminal states (done/escalated/blocked) print status and exit.
- **`vairdict logs <id>`**: pretty-prints `~/.vairdict/logs/<id>.log` as `HH:MM:SS [phase/state] msg key=val`. JSON stays on disk for future tooling. Supports `-n, --lines N` (default 200) and `-f, --follow`.
- **`vairdict status`**: adds a `RUN` column (via `kill(pid, 0)` liveness) and sorts by `updated_at DESC` so recent / running tasks bubble up. Detail view shows pid + log path when alive, or a stale-pid hint.
- **`--background` / `-b`**: on `run` and `resume`, re-execs with `setsid`, redirects stdout/stderr to the per-task log file, and prints a banner with the `status` / `logs` / `resume` commands.
- **Interrupt handler**: first ctrl-c cancels the context and prints `resume with: vairdict resume <id>`; second ctrl-c force-exits.

## Design decisions worth flagging

- **DB over files** for the persisted plan text. The state DB is already local SQLite, so keeping `plan_output` there (vs. a per-task artifact dir) avoids schema drift and keeps everything one place.
- **JSON-on-disk, pretty on read.** slog is already structured everywhere; downgrading the disk format to text would be lossy for future analytics / web UI. The `logs` command does the formatting.
- **Single-process foreground, separate-process `--background`.** Same model Claude Code uses — rich TUI stays intact. `stop` and `detach` (move running task to background, abort background task) are scoped to #91 (cmd/interactive), not here.
- **Resume semantics.** Terminal states no-op; review states are requeued to their phase's active state (idempotent); quality-phase resume skips the coder entirely so committed code is not overwritten.

## Test plan

- [x] `state`: PlanOutput + PID round-trip, IsResumable table, ListResumable ordering
- [x] `workspace`: Attach reuses existing, recreates from branch, errors when neither
- [x] `orchestration`: resume from code skips plan + branch, resume from quality skips code + commit, fresh run persists plan output
- [x] `logs`: JSON line formats with phase/state; non-JSON passes through; `--lines N` tails correctly
- [x] `background`: arg passthrough for run and resume, `VAIRDICT_FOREGROUND` gate
- [ ] Manual smoke: run → ctrl-c → `vairdict resume <id>` (relies on live agents, not exercised in unit tests)
- [ ] Manual smoke: `vairdict run "..." -b` → `vairdict status` shows RUN `*`, `vairdict logs <id> -f` streams

## Not in this PR (tracked for #91)

- `vairdict stop <id>` — convenience kill for background tasks
- `vairdict detach <id>` — move a running foreground task to background without ctrl-c

https://claude.ai/code/session_01D1NWLM6U8c7BD42VnQ1yvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1NWLM6U8c7BD42VnQ1yvZ)_