### PR TITLE
feat(cmd): interactive run — status, note, pause, continue (#91)

### DIFF
--- a/cmd/vairdict/interactive_test.go
+++ b/cmd/vairdict/interactive_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vairdict/vairdict/internal/interactive"
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// TestOrchestration_DrainsNotesIntoTask verifies that when deps.interactive
+// is wired in, notes queued on the shared State land on the task before
+// each phase runs (and therefore reach the plan/code prompt builders).
+func TestOrchestration_DrainsNotesIntoTask(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	iState := interactive.New()
+	iState.AddNote("please write tests")
+
+	deps := b.deps()
+	deps.interactive = iState
+
+	task := state.NewTask("t-notes", "build with notes")
+	r := &fakeRenderer{}
+
+	if err := runOrchestration(context.Background(), deps, task, r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The plan phase ran — it should have received task.Notes with the
+	// user's queued note. We capture task.Notes at the time the fake
+	// plan runner was called via a snapshot on the bundle.
+	if b.plan.capturedNotes == nil {
+		t.Fatal("plan runner should have seen task.Notes populated")
+	}
+	if len(b.plan.capturedNotes) != 1 || b.plan.capturedNotes[0] != "please write tests" {
+		t.Errorf("plan runner got notes %v, want [\"please write tests\"]", b.plan.capturedNotes)
+	}
+
+	// Notes must be drained — a second call to DrainNotes comes back
+	// empty so the same note isn't reinjected into subsequent phases.
+	if got := iState.DrainNotes(); got != nil {
+		t.Errorf("notes should be drained on first phase entry, still have %v", got)
+	}
+}
+
+// TestOrchestration_PauseGateBlocksUntilResume verifies the pause
+// semantics from the AC: pause gates the next phase entry, does not
+// interrupt an in-flight agent call. We pause before the run starts,
+// wait long enough that orchestration would have completed if not
+// blocked, then resume and confirm it does finish.
+func TestOrchestration_PauseGateBlocksUntilResume(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	iState := interactive.New()
+	iState.SetPaused(true)
+
+	deps := b.deps()
+	deps.interactive = iState
+
+	task := state.NewTask("t-pause", "build paused")
+	r := &fakeRenderer{}
+
+	done := make(chan error, 1)
+	go func() { done <- runOrchestration(context.Background(), deps, task, r) }()
+
+	// While paused, the plan runner must not be called.
+	time.Sleep(100 * time.Millisecond)
+	if b.plan.called {
+		t.Fatal("plan runner should not have been called while paused")
+	}
+
+	// Resume — orchestration must unblock and finish.
+	iState.SetPaused(false)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("orchestration did not finish within 1s after resume")
+	}
+	if !b.plan.called {
+		t.Error("plan runner should have run after resume")
+	}
+}
+
+// TestOrchestration_PauseCancelledContextReturnsError verifies that
+// ctrl-c while paused actually aborts the run rather than hanging
+// forever on the condition variable.
+func TestOrchestration_PauseCancelledContextReturnsError(t *testing.T) {
+	t.Parallel()
+	b := newOrchBundle()
+	iState := interactive.New()
+	iState.SetPaused(true)
+
+	deps := b.deps()
+	deps.interactive = iState
+
+	task := state.NewTask("t-pause-cancel", "cancel while paused")
+	r := &fakeRenderer{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runOrchestration(ctx, deps, task, r) }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected context error, got nil")
+		}
+		if !strings.Contains(err.Error(), "context") {
+			t.Errorf("expected context error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("orchestration did not unblock on cancel")
+	}
+	if b.plan.called {
+		t.Error("plan runner should not have been called after cancel while paused")
+	}
+}

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vairdict/vairdict/internal/deps"
 	"github.com/vairdict/vairdict/internal/escalation"
 	"github.com/vairdict/vairdict/internal/github"
+	"github.com/vairdict/vairdict/internal/interactive"
 	codejudge "github.com/vairdict/vairdict/internal/judges/code"
 	planjudge "github.com/vairdict/vairdict/internal/judges/plan"
 	qualityjudge "github.com/vairdict/vairdict/internal/judges/quality"
@@ -46,6 +47,7 @@ var (
 	dependsOnFlag  []string
 	priorityFlag   string
 	backgroundFlag bool
+	noTTYFlag      bool
 )
 
 var runCmd = &cobra.Command{
@@ -160,6 +162,7 @@ func init() {
 	runCmd.Flags().StringSliceVar(&dependsOnFlag, "depends-on", nil, "task ID(s) this run depends on. The new task will wait (or start blocked) until each listed task is StateDone in the store.")
 	runCmd.Flags().StringVar(&priorityFlag, "priority", "", "task priority: high|normal|low (default: normal). Higher-priority tasks are dispatched first when multiple are ready.")
 	runCmd.Flags().BoolVarP(&backgroundFlag, "background", "b", false, "run detached so the task survives terminal exit. Prints the task id, then returns. Use 'vairdict status <id>' and 'vairdict logs <id> -f' to follow progress.")
+	runCmd.Flags().BoolVar(&noTTYFlag, "no-tty", false, "disable the interactive input loop (status/note/pause/continue). Auto-enabled when stdin is not a TTY (e.g. piped or under CI).")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -230,6 +233,29 @@ type runDeps struct {
 	onEscalation func(ctx context.Context, task *state.Task, result escalation.Result) error
 	issueNumber  int
 	autoMerge    bool
+	// interactive, when non-nil, gates phase/loop entry on the user's
+	// pause flag and drains queued notes into task.Notes before each
+	// phase call. Nil in tests and in --no-tty / piped-stdin runs.
+	interactive *interactive.State
+}
+
+// gateBeforePhase runs the interactive pause-and-drain step that every
+// phase entry shares. Split out of the orchestration body so tests can
+// leave deps.interactive nil without branching noise at every call
+// site. Returns ctx.Err() on cancellation during a pause.
+func (d runDeps) gateBeforePhase(ctx context.Context, task *state.Task, phase state.Phase, loop, maxLoop int) error {
+	if d.interactive == nil {
+		return nil
+	}
+	d.interactive.UpdatePhase(phase, loop, maxLoop)
+	if err := d.interactive.WaitWhilePaused(ctx); err != nil {
+		return err
+	}
+	notes := d.interactive.DrainNotes()
+	if len(notes) > 0 {
+		task.Notes = append(task.Notes, notes...)
+	}
+	return nil
 }
 
 // --- Default (production) phase runner implementations ---
@@ -418,6 +444,17 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 
 	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient, issueNumber)
 
+	// Interactive input loop: if stdin is a TTY and --no-tty is not
+	// set, spawn a goroutine that reads commands from the user and
+	// lets them steer the run (status / note / pause / continue).
+	// Orchestration and the input loop share an interactive.State.
+	if shouldRunInteractive() {
+		iState := interactive.New()
+		deps.interactive = iState
+		r.Note("interactive", "type 'status' / 'note <text>' / 'pause' / 'continue' — or 'help'")
+		go interactive.RunLoop(ctx, iState, os.Stdin, os.Stdout)
+	}
+
 	// Claim the run with this PID so `vairdict status` shows it as
 	// running. Cleared on normal exit; a crash leaves a stale PID, which
 	// the liveness check (kill -0) treats as not-running.
@@ -429,6 +466,24 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 	defer clearPID(store, task)
 
 	return runOrchestration(ctx, deps, task, r)
+}
+
+// shouldRunInteractive reports whether the interactive input loop
+// should start. Off when --no-tty is set or stdin isn't a terminal
+// (piped, CI, test harness) — the AC requires non-interactive mode to
+// behave exactly as before. Also off when the process was re-execed by
+// --background, whose stdin points at /dev/null in the child and would
+// otherwise spin EOF forever.
+func shouldRunInteractive() bool {
+	if noTTYFlag {
+		return false
+	}
+	if shouldRunForeground() {
+		// Running as the detached child of --background — no user on
+		// this process's stdin, don't attach an input loop.
+		return false
+	}
+	return ui.IsTerminal(os.Stdin)
 }
 
 // taskResult records the outcome of a single concurrent task.
@@ -669,6 +724,9 @@ func runOrchestrationWithResume(ctx context.Context, deps runDeps, task *state.T
 	for cycle := 0; cycle < maxOuterCycles; cycle++ {
 		// --- Plan phase (first cycle, or after rewind to plan) ---
 		if planResult == nil {
+			if err := deps.gateBeforePhase(ctx, task, state.PhasePlan, 0, 0); err != nil {
+				return err
+			}
 			pr, err := deps.plan.Run(ctx, task)
 			if err != nil {
 				r.Error(err)
@@ -721,6 +779,9 @@ func runOrchestrationWithResume(ctx context.Context, deps runDeps, task *state.T
 				codeFeedback = v.Summary
 			}
 		} else {
+			if err := deps.gateBeforePhase(ctx, task, state.PhaseCode, 0, 0); err != nil {
+				return err
+			}
 			codeResult, err := deps.code.Run(ctx, task, planResult.Plan)
 			if err != nil {
 				r.Error(err)
@@ -747,6 +808,9 @@ func runOrchestrationWithResume(ctx context.Context, deps runDeps, task *state.T
 		}
 
 		// --- Quality phase (gates the PR) ---
+		if err := deps.gateBeforePhase(ctx, task, state.PhaseQuality, 0, 0); err != nil {
+			return err
+		}
 		qResult, err := deps.quality.Run(ctx, task, planResult.Plan, codeFeedback)
 		if err != nil {
 			r.Error(err)

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -497,20 +497,24 @@ func TestBuildQualityHardConstraints_NilVerdict(t *testing.T) {
 // the last entry once exhausted.
 
 type fakePlanRunner struct {
-	result     *planphase.PhaseResult
-	gaps       []state.Gap
-	results    []*planphase.PhaseResult
-	gapsByCall [][]state.Gap
-	err        error
-	called     bool
-	calls      int
-	lastTask   *state.Task
+	result        *planphase.PhaseResult
+	gaps          []state.Gap
+	results       []*planphase.PhaseResult
+	gapsByCall    [][]state.Gap
+	err           error
+	called        bool
+	calls         int
+	lastTask      *state.Task
+	capturedNotes []string // snapshot of task.Notes at Run() entry; used by #91 tests
 }
 
 func (f *fakePlanRunner) Run(_ context.Context, task *state.Task) (*planphase.PhaseResult, error) {
 	f.called = true
 	f.calls++
 	f.lastTask = task
+	if len(task.Notes) > 0 {
+		f.capturedNotes = append([]string(nil), task.Notes...)
+	}
 	result, gaps := f.pick()
 	if result != nil {
 		// Mimic the production plan phase's state transitions so the

--- a/internal/interactive/loop.go
+++ b/internal/interactive/loop.go
@@ -1,0 +1,142 @@
+package interactive
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// RunLoop is the foreground input reader. It parses lines from `in`
+// and dispatches to the four commands in the #91 AC:
+//
+//	status             — print current phase/loop/score/elapsed/paused
+//	note <text>        — queue guidance for the next agent prompt
+//	pause              — gate next phase/loop entry
+//	continue           — resume after pause
+//
+// Returns when the context is cancelled (caller finishes orchestration)
+// or stdin is closed. Unknown commands print a short help line — the
+// loop never returns on a bad command.
+//
+// The loop is intentionally simple (`bufio.Scanner`, no readline,
+// no TUI framework). The issue explicitly calls for this: a run
+// already has a rich renderer emitting to stdout, and a fancier input
+// UI would fight it on every repaint.
+func RunLoop(ctx context.Context, s *State, in io.Reader, out io.Writer) {
+	scanner := bufio.NewScanner(in)
+	// Break out of scanner.Scan() when the context is cancelled so a
+	// finishing run shuts the input goroutine down cleanly. Scanner
+	// doesn't support context, so we close the underlying reader via
+	// the caller; here we just re-check after each line.
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		handleCommand(line, s, out)
+	}
+}
+
+// handleCommand parses and dispatches a single input line. Split out of
+// RunLoop so unit tests can drive it without spinning the scanner.
+func handleCommand(line string, s *State, out io.Writer) {
+	cmd, rest := splitCmd(line)
+	switch cmd {
+	case "status":
+		renderStatus(s.Status(), out)
+	case "note":
+		if rest == "" {
+			_, _ = fmt.Fprintln(out, "usage: note <text to append to next agent prompt>")
+			return
+		}
+		s.AddNote(rest)
+		slog.Info("user note queued", "note", rest)
+		_, _ = fmt.Fprintf(out, "note queued (%d pending): %s\n", s.Status().QueuedNotes, rest)
+	case "pause":
+		if s.IsPaused() {
+			_, _ = fmt.Fprintln(out, "already paused")
+			return
+		}
+		s.SetPaused(true)
+		slog.Info("run paused by user")
+		_, _ = fmt.Fprintln(out, "paused — orchestration will stop at the next phase/loop boundary. type 'continue' to resume.")
+	case "continue", "resume":
+		if !s.IsPaused() {
+			_, _ = fmt.Fprintln(out, "not paused")
+			return
+		}
+		s.SetPaused(false)
+		slog.Info("run resumed by user")
+		_, _ = fmt.Fprintln(out, "resuming…")
+	case "help", "?":
+		renderHelp(out)
+	default:
+		_, _ = fmt.Fprintf(out, "unknown command %q — type 'help' for the list.\n", cmd)
+	}
+}
+
+// splitCmd splits "note hello there" into ("note", "hello there").
+// Preserves internal whitespace in the argument so multi-word notes
+// reach the agent intact.
+func splitCmd(line string) (cmd, rest string) {
+	i := strings.IndexByte(line, ' ')
+	if i < 0 {
+		return line, ""
+	}
+	return line[:i], strings.TrimSpace(line[i+1:])
+}
+
+// renderStatus prints a one-line snapshot. Intentionally terse so a
+// user polling `status` between phases sees a compact diff.
+func renderStatus(sn Snapshot, out io.Writer) {
+	phase := string(sn.Phase)
+	if phase == "" {
+		phase = "pending"
+	}
+	pausedLabel := ""
+	if sn.Paused {
+		pausedLabel = " [PAUSED]"
+	}
+	scoreLabel := "-"
+	if sn.LastScore > 0 {
+		scoreLabel = fmt.Sprintf("%.0f", sn.LastScore)
+	}
+	loopLabel := fmt.Sprintf("%d/%d", sn.Loop, sn.MaxLoop)
+	if sn.MaxLoop == 0 {
+		loopLabel = fmt.Sprintf("%d", sn.Loop)
+	}
+	_, _ = fmt.Fprintf(out, "phase=%s loop=%s score=%s elapsed=%s notes=%d%s\n",
+		phase, loopLabel, scoreLabel, formatElapsed(sn.Elapsed), sn.QueuedNotes, pausedLabel)
+}
+
+// formatElapsed prints a short HH:MM:SS-ish string. Kept out of
+// time.Duration's default format to avoid "3m5.123456s" noise.
+func formatElapsed(d time.Duration) string {
+	d = d.Round(time.Second)
+	h := int(d / time.Hour)
+	m := int((d % time.Hour) / time.Minute)
+	sec := int((d % time.Minute) / time.Second)
+	if h > 0 {
+		return fmt.Sprintf("%dh%02dm%02ds", h, m, sec)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm%02ds", m, sec)
+	}
+	return fmt.Sprintf("%ds", sec)
+}
+
+func renderHelp(out io.Writer) {
+	_, _ = fmt.Fprintln(out, "interactive run commands:")
+	_, _ = fmt.Fprintln(out, "  status            — show current phase, loop, score, elapsed time")
+	_, _ = fmt.Fprintln(out, "  note <text>       — queue a note for the next agent prompt")
+	_, _ = fmt.Fprintln(out, "  pause             — pause before the next phase/loop (does not kill an in-flight agent)")
+	_, _ = fmt.Fprintln(out, "  continue          — resume after pause")
+	_, _ = fmt.Fprintln(out, "  help              — show this list")
+}

--- a/internal/interactive/loop_test.go
+++ b/internal/interactive/loop_test.go
@@ -1,0 +1,117 @@
+package interactive
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleCommand_Status(t *testing.T) {
+	s := New()
+	s.UpdatePhase("code", 2, 5)
+	s.UpdateScore(73)
+
+	var out bytes.Buffer
+	handleCommand("status", s, &out)
+
+	got := out.String()
+	for _, want := range []string{"phase=code", "loop=2/5", "score=73", "notes=0"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("status output missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestHandleCommand_Note(t *testing.T) {
+	s := New()
+	var out bytes.Buffer
+	handleCommand("note remember to add tests", s, &out)
+
+	if s.Status().QueuedNotes != 1 {
+		t.Errorf("note count = %d, want 1", s.Status().QueuedNotes)
+	}
+	drained := s.DrainNotes()
+	if len(drained) != 1 || drained[0] != "remember to add tests" {
+		t.Errorf("drained = %v, want [\"remember to add tests\"]", drained)
+	}
+	if !strings.Contains(out.String(), "note queued") {
+		t.Errorf("missing echo line: %q", out.String())
+	}
+}
+
+func TestHandleCommand_NoteRequiresArg(t *testing.T) {
+	s := New()
+	var out bytes.Buffer
+	handleCommand("note", s, &out)
+
+	if s.Status().QueuedNotes != 0 {
+		t.Error("bare 'note' should not queue anything")
+	}
+	if !strings.Contains(out.String(), "usage:") {
+		t.Errorf("missing usage line: %q", out.String())
+	}
+}
+
+func TestHandleCommand_PauseAndContinue(t *testing.T) {
+	s := New()
+	var out bytes.Buffer
+
+	handleCommand("pause", s, &out)
+	if !s.IsPaused() {
+		t.Fatal("pause command should set paused=true")
+	}
+
+	// Second pause should be a no-op with a 'already paused' line.
+	out.Reset()
+	handleCommand("pause", s, &out)
+	if !strings.Contains(out.String(), "already paused") {
+		t.Errorf("double pause should warn, got: %q", out.String())
+	}
+
+	out.Reset()
+	handleCommand("continue", s, &out)
+	if s.IsPaused() {
+		t.Fatal("continue command should clear paused")
+	}
+
+	out.Reset()
+	handleCommand("continue", s, &out)
+	if !strings.Contains(out.String(), "not paused") {
+		t.Errorf("continue when not paused should warn, got: %q", out.String())
+	}
+}
+
+func TestHandleCommand_Unknown(t *testing.T) {
+	s := New()
+	var out bytes.Buffer
+	handleCommand("foo bar", s, &out)
+	if !strings.Contains(out.String(), "unknown command") {
+		t.Errorf("unknown command should be reported: %q", out.String())
+	}
+}
+
+func TestRunLoop_ExitsOnEOF(t *testing.T) {
+	// When the input stream closes, RunLoop must return — otherwise
+	// piped stdin or a closed terminal would hang the run forever.
+	s := New()
+	in := strings.NewReader("status\nnote hello\n")
+	var out bytes.Buffer
+
+	done := make(chan struct{})
+	go func() {
+		RunLoop(context.Background(), s, in, &out)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Both commands should have been processed before EOF.
+		if s.Status().QueuedNotes != 1 {
+			t.Errorf("expected 1 queued note after loop, got %d", s.Status().QueuedNotes)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("RunLoop did not return on EOF")
+	}
+}

--- a/internal/interactive/state.go
+++ b/internal/interactive/state.go
@@ -1,0 +1,183 @@
+// Package interactive implements the in-flight steering interface for
+// `vairdict run`. A foreground readline loop lets the user query status,
+// queue notes for the next agent prompt, and pause/continue the outer
+// orchestration without opening a second terminal.
+//
+// Two goroutines share this package: the orchestration goroutine reads
+// pause state and drains note queues at phase boundaries; the input
+// goroutine mutates them in response to user commands. All shared
+// state lives behind a mutex + condition variable in State.
+package interactive
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// State is the mutex-guarded shared memory between the orchestration
+// goroutine and the foreground input loop. Constructed once per run
+// and handed to both goroutines.
+//
+// Invariants:
+//   - All public methods are safe for concurrent use.
+//   - WaitWhilePaused must be called from the orchestration goroutine,
+//     not the input goroutine (blocks on the pause condition).
+//   - DrainNotes is destructive: a note is observed exactly once by the
+//     orchestration side, matching the issue AC ("queued notes are
+//     consumed once and logged").
+type State struct {
+	mu sync.Mutex
+	// cond signals when `paused` flips false so WaitWhilePaused can
+	// wake. Using a condition variable over a channel lets the pause
+	// state be toggled any number of times cheaply.
+	cond *sync.Cond
+
+	paused bool
+	notes  []string
+
+	phase     state.Phase
+	loop      int
+	maxLoop   int
+	lastScore float64
+	startTime time.Time
+}
+
+// New constructs an empty state with the wall-clock start time captured
+// for status elapsed-time reporting.
+func New() *State {
+	s := &State{
+		startTime: time.Now(),
+	}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// Snapshot is a point-in-time read of the state, safe to print from
+// the input goroutine without holding the state mutex past the call.
+type Snapshot struct {
+	Phase       state.Phase
+	Loop        int
+	MaxLoop     int
+	LastScore   float64
+	Elapsed     time.Duration
+	Paused      bool
+	QueuedNotes int
+}
+
+// Status returns a Snapshot for `status` command rendering.
+func (s *State) Status() Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Snapshot{
+		Phase:       s.phase,
+		Loop:        s.loop,
+		MaxLoop:     s.maxLoop,
+		LastScore:   s.lastScore,
+		Elapsed:     time.Since(s.startTime),
+		Paused:      s.paused,
+		QueuedNotes: len(s.notes),
+	}
+}
+
+// AddNote queues guidance text from the user for the next agent call.
+// Empty strings are ignored so a blank `note` command is a no-op rather
+// than polluting the next prompt.
+func (s *State) AddNote(text string) {
+	if text == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notes = append(s.notes, text)
+}
+
+// DrainNotes returns every queued note and clears the queue. Called by
+// the orchestration goroutine at phase boundaries; the AC requires
+// notes to be consumed once, so each call is destructive.
+func (s *State) DrainNotes() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.notes) == 0 {
+		return nil
+	}
+	out := s.notes
+	s.notes = nil
+	return out
+}
+
+// SetPaused sets the paused flag and broadcasts a wakeup so any
+// WaitWhilePaused caller that was blocked wakes up when `paused` goes
+// false. No-op on idempotent sets — callers may safely pause-when-
+// paused or continue-when-running.
+func (s *State) SetPaused(paused bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.paused == paused {
+		return
+	}
+	s.paused = paused
+	s.cond.Broadcast()
+}
+
+// IsPaused reports whether pause is currently set. Used by tests and
+// the status renderer.
+func (s *State) IsPaused() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.paused
+}
+
+// WaitWhilePaused blocks until the paused flag is false or ctx is
+// cancelled. Returns ctx.Err() on cancellation, nil when it resumed
+// cleanly. Safe to call when not paused — the condition is checked
+// before blocking so the common case is lock-drop-drop.
+//
+// Phase-boundary gating (`pause` before next loop entry) is the single
+// caller today; the function is exposed on the State so other gates
+// can reuse it without duplicating the cond-var dance.
+func (s *State) WaitWhilePaused(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for s.paused {
+		// Release the mutex while waiting and reacquire on wakeup —
+		// ctx cancellation is surfaced via a goroutine that broadcasts
+		// when the context fires, otherwise the wait would block
+		// forever if the user cancels mid-pause.
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				s.cond.Broadcast()
+			case <-done:
+			}
+		}()
+		s.cond.Wait()
+		close(done)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// UpdatePhase records the phase the orchestration is about to enter
+// along with its loop budget. Called before each plan/code/quality
+// phase so `status` reflects live progress.
+func (s *State) UpdatePhase(phase state.Phase, loop, maxLoop int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.phase = phase
+	s.loop = loop
+	s.maxLoop = maxLoop
+}
+
+// UpdateScore records the last verdict score observed at the current
+// phase so `status` can show the trend within a phase.
+func (s *State) UpdateScore(score float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastScore = score
+}

--- a/internal/interactive/state_test.go
+++ b/internal/interactive/state_test.go
@@ -1,0 +1,139 @@
+package interactive
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+func TestAddAndDrainNotes(t *testing.T) {
+	s := New()
+
+	if got := s.DrainNotes(); got != nil {
+		t.Errorf("DrainNotes on empty state returned %v, want nil", got)
+	}
+
+	s.AddNote("first")
+	s.AddNote("") // ignored
+	s.AddNote("second")
+
+	if n := s.Status().QueuedNotes; n != 2 {
+		t.Errorf("QueuedNotes = %d, want 2 (empty string should be ignored)", n)
+	}
+
+	drained := s.DrainNotes()
+	if len(drained) != 2 || drained[0] != "first" || drained[1] != "second" {
+		t.Errorf("DrainNotes returned %v, want [first second]", drained)
+	}
+
+	// Drain is destructive — a second call should come back empty.
+	if got := s.DrainNotes(); got != nil {
+		t.Errorf("second DrainNotes returned %v, want nil (consumed once)", got)
+	}
+}
+
+func TestSetPausedIdempotent(t *testing.T) {
+	s := New()
+	if s.IsPaused() {
+		t.Fatal("new State should not be paused")
+	}
+	s.SetPaused(true)
+	s.SetPaused(true) // second call is a no-op
+	if !s.IsPaused() {
+		t.Error("after SetPaused(true), IsPaused should be true")
+	}
+	s.SetPaused(false)
+	if s.IsPaused() {
+		t.Error("after SetPaused(false), IsPaused should be false")
+	}
+}
+
+func TestWaitWhilePaused_NotPausedReturnsImmediately(t *testing.T) {
+	s := New()
+	// Not paused — WaitWhilePaused must return immediately with nil.
+	done := make(chan error, 1)
+	go func() { done <- s.WaitWhilePaused(context.Background()) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("WaitWhilePaused blocked on an unpaused state")
+	}
+}
+
+func TestWaitWhilePaused_WakesOnResume(t *testing.T) {
+	s := New()
+	s.SetPaused(true)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var gotErr error
+	go func() {
+		defer wg.Done()
+		gotErr = s.WaitWhilePaused(context.Background())
+	}()
+
+	// Give the goroutine time to enter the wait.
+	time.Sleep(50 * time.Millisecond)
+	s.SetPaused(false)
+	wg.Wait()
+
+	if gotErr != nil {
+		t.Errorf("WaitWhilePaused returned %v on resume, want nil", gotErr)
+	}
+}
+
+func TestWaitWhilePaused_CancelledContextUnblocks(t *testing.T) {
+	// A cancelled context must wake WaitWhilePaused even if the user
+	// never hits continue — otherwise ctrl-c can't abort a paused run.
+	s := New()
+	s.SetPaused(true)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- s.WaitWhilePaused(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected ctx.Err, got nil")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("WaitWhilePaused did not wake on context cancel")
+	}
+}
+
+func TestStatusSnapshot(t *testing.T) {
+	s := New()
+	s.UpdatePhase(state.PhaseCode, 2, 5)
+	s.UpdateScore(87)
+	s.AddNote("hi")
+
+	sn := s.Status()
+	if sn.Phase != state.PhaseCode {
+		t.Errorf("Phase = %s, want code", sn.Phase)
+	}
+	if sn.Loop != 2 || sn.MaxLoop != 5 {
+		t.Errorf("Loop/MaxLoop = %d/%d, want 2/5", sn.Loop, sn.MaxLoop)
+	}
+	if sn.LastScore != 87 {
+		t.Errorf("LastScore = %v, want 87", sn.LastScore)
+	}
+	if sn.QueuedNotes != 1 {
+		t.Errorf("QueuedNotes = %d, want 1", sn.QueuedNotes)
+	}
+	if sn.Paused {
+		t.Error("Paused = true, want false")
+	}
+	if sn.Elapsed <= 0 {
+		t.Errorf("Elapsed should be > 0, got %v", sn.Elapsed)
+	}
+}

--- a/internal/phases/code/phase.go
+++ b/internal/phases/code/phase.go
@@ -73,9 +73,17 @@ func (p *CodePhase) Run(ctx context.Context, task *state.Task, plan string) (*Ph
 			"max_loops", p.cfg.MaxLoops,
 		)
 
-		// Build the coder prompt.
+		// Build the coder prompt. task.Notes are user guidance queued
+		// from the interactive run loop (#91) — consume them on the
+		// first loop and clear so subsequent requeues don't repeat the
+		// same note.
 		prompt := buildCoderPrompt(task.Intent, plan, lastFeedback, task.Assumptions,
-			state.RewindContextsFor(task.RewindContexts, state.PhaseCode))
+			state.RewindContextsFor(task.RewindContexts, state.PhaseCode),
+			task.Notes)
+		if len(task.Notes) > 0 {
+			slog.Info("consumed user notes into code prompt", "task_id", task.ID, "count", len(task.Notes))
+			task.Notes = nil
+		}
 
 		// Run the coder agent.
 		p.notify(loop+1, p.cfg.MaxLoops, "coding", 0, false, nil)
@@ -167,7 +175,7 @@ func (p *CodePhase) Run(ctx context.Context, task *state.Task, plan string) (*Ph
 // Your plan must explicitly address Z." framing from issue #86 — that
 // constraint is what stops successive rewinds from converging on the
 // same code.
-func buildCoderPrompt(intent string, plan string, feedback string, assumptions []state.Assumption, rewindContexts []state.RewindContext) string {
+func buildCoderPrompt(intent string, plan string, feedback string, assumptions []state.Assumption, rewindContexts []state.RewindContext, notes []string) string {
 	var b strings.Builder
 
 	b.WriteString("## Task Intent\n")
@@ -177,6 +185,14 @@ func buildCoderPrompt(intent string, plan string, feedback string, assumptions [
 	b.WriteString("## Approved Plan\n")
 	b.WriteString(plan)
 	b.WriteString("\n")
+
+	if len(notes) > 0 {
+		b.WriteString("\n## Notes from User\n")
+		b.WriteString("The user queued the following guidance between phases. Incorporate every note into your implementation:\n")
+		for _, n := range notes {
+			fmt.Fprintf(&b, "- %s\n", n)
+		}
+	}
 
 	if len(rewindContexts) > 0 {
 		b.WriteString("\n## Rewind Context (previous outer cycles)\n")

--- a/internal/phases/code/phase_test.go
+++ b/internal/phases/code/phase_test.go
@@ -14,7 +14,7 @@ import (
 func TestBuildCoderPrompt_IncludesBaseline(t *testing.T) {
 	// #84: the coder must see the non-negotiable standards so it doesn't
 	// write code that would be flagged during quality.
-	prompt := buildCoderPrompt("do stuff", "step 1", "", nil, nil)
+	prompt := buildCoderPrompt("do stuff", "step 1", "", nil, nil, nil)
 	if !strings.Contains(prompt, standards.Block) {
 		t.Error("coder prompt must include the baseline standards block")
 	}
@@ -228,7 +228,7 @@ func TestRun_AttemptsStored(t *testing.T) {
 func TestBuildCoderPrompt(t *testing.T) {
 	prompt := buildCoderPrompt("intent", "plan", "fix tests", []state.Assumption{
 		{Severity: state.SeverityP2, Description: "assumed X"},
-	}, nil)
+	}, nil, nil)
 
 	if !containsStr(prompt, "intent") {
 		t.Error("prompt should contain intent")
@@ -262,7 +262,7 @@ func TestBuildCoderPrompt_WithRewindContext(t *testing.T) {
 			Failure:       []string{"[P0] TestRetryLimit failed"},
 		},
 	}
-	prompt := buildCoderPrompt("intent", "plan", "", nil, contexts)
+	prompt := buildCoderPrompt("intent", "plan", "", nil, contexts, nil)
 
 	if !strings.Contains(prompt, "Rewind Context") {
 		t.Error("expected rewind context section header")

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -108,9 +108,17 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 			return nil, fmt.Errorf("running plan phase: unexpected state %s", task.State)
 		}
 
-		// Build the planner prompt.
+		// Build the planner prompt. task.Notes are user guidance queued
+		// from the interactive run loop (#91) — consume them on the
+		// first loop and clear so subsequent requeues don't repeat the
+		// same note.
 		prompt := buildPlannerPrompt(task.Intent, lastFeedback, task.Assumptions, task.HardConstraints,
-			state.RewindContextsFor(task.RewindContexts, state.PhasePlan))
+			state.RewindContextsFor(task.RewindContexts, state.PhasePlan),
+			task.Notes)
+		if len(task.Notes) > 0 {
+			slog.Info("consumed user notes into plan prompt", "task_id", task.ID, "count", len(task.Notes))
+			task.Notes = nil
+		}
 
 		// Call the planner agent.
 		p.notify(loop+1, p.cfg.MaxLoops, "generating plan", 0, false, nil)
@@ -234,12 +242,20 @@ func (p *PlanPhase) processGaps(task *state.Task, gaps []state.Gap) {
 // Your plan must explicitly address Z." framing from issue #86 —
 // without that constraint, successive rewinds tend to converge on the
 // same plan and the outer loop spins instead of terminating.
-func buildPlannerPrompt(intent string, feedback string, assumptions []state.Assumption, hardConstraints []string, rewindContexts []state.RewindContext) string {
+func buildPlannerPrompt(intent string, feedback string, assumptions []state.Assumption, hardConstraints []string, rewindContexts []state.RewindContext, notes []string) string {
 	var b strings.Builder
 
 	b.WriteString("## Task Intent\n")
 	b.WriteString(intent)
 	b.WriteString("\n")
+
+	if len(notes) > 0 {
+		b.WriteString("\n## Notes from User\n")
+		b.WriteString("The user queued the following guidance between phases. Fold every note into your plan:\n")
+		for _, n := range notes {
+			fmt.Fprintf(&b, "- %s\n", n)
+		}
+	}
 
 	if len(rewindContexts) > 0 {
 		b.WriteString("\n## Rewind Context (previous outer cycles)\n")

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -508,7 +508,7 @@ func TestPlanPhase_ContextCancellation(t *testing.T) {
 }
 
 func TestBuildPlannerPrompt_NoFeedback(t *testing.T) {
-	prompt := buildPlannerPrompt("build an API", "", nil, nil, nil)
+	prompt := buildPlannerPrompt("build an API", "", nil, nil, nil, nil)
 
 	if !strings.Contains(prompt, "## Task Intent") {
 		t.Error("expected intent header")
@@ -528,7 +528,7 @@ func TestBuildPlannerPrompt_NoFeedback(t *testing.T) {
 }
 
 func TestBuildPlannerPrompt_WithFeedback(t *testing.T) {
-	prompt := buildPlannerPrompt("build an API", "missing auth", nil, nil, nil)
+	prompt := buildPlannerPrompt("build an API", "missing auth", nil, nil, nil, nil)
 
 	if !strings.Contains(prompt, "Previous Attempt Feedback") {
 		t.Error("expected feedback section")
@@ -542,7 +542,7 @@ func TestBuildPlannerPrompt_WithAssumptions(t *testing.T) {
 	assumptions := []state.Assumption{
 		{Description: "using PostgreSQL", Severity: state.SeverityP2, Phase: state.PhasePlan},
 	}
-	prompt := buildPlannerPrompt("build an API", "some feedback", assumptions, nil, nil)
+	prompt := buildPlannerPrompt("build an API", "some feedback", assumptions, nil, nil, nil)
 
 	if !strings.Contains(prompt, "Assumptions from Previous Loops") {
 		t.Error("expected assumptions section")
@@ -560,7 +560,7 @@ func TestBuildPlannerPrompt_WithHardConstraints(t *testing.T) {
 		"[quality judge, P0] /admin/users is not protected by auth middleware",
 		"[quality judge, P1] /admin/logs bypasses the same middleware",
 	}
-	prompt := buildPlannerPrompt("build an API", "", nil, constraints, nil)
+	prompt := buildPlannerPrompt("build an API", "", nil, constraints, nil, nil)
 
 	if !strings.Contains(prompt, "Hard Constraints") {
 		t.Error("expected hard constraints section")
@@ -588,7 +588,7 @@ func TestBuildPlannerPrompt_WithRewindContext(t *testing.T) {
 			Failure:       []string{"[P0] brute-force possible"},
 		},
 	}
-	prompt := buildPlannerPrompt("build an API", "", nil, nil, contexts)
+	prompt := buildPlannerPrompt("build an API", "", nil, nil, contexts, nil)
 
 	if !strings.Contains(prompt, "Rewind Context") {
 		t.Error("expected rewind context section header")
@@ -621,7 +621,7 @@ func TestBuildPlannerPrompt_MultipleRewindsAccumulate(t *testing.T) {
 		{Cycle: 1, Target: state.PhasePlan, RootCause: "cause A", TriedApproach: "plan A"},
 		{Cycle: 2, Target: state.PhasePlan, RootCause: "cause B", TriedApproach: "plan B"},
 	}
-	prompt := buildPlannerPrompt("build an API", "", nil, nil, contexts)
+	prompt := buildPlannerPrompt("build an API", "", nil, nil, contexts, nil)
 
 	if !strings.Contains(prompt, "Cycle 1") || !strings.Contains(prompt, "Cycle 2") {
 		t.Error("expected headings for every cycle so history accumulates")

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -298,7 +298,13 @@ type Task struct {
 	// by `vairdict status` to render a RUNNING indicator via a kill(pid, 0)
 	// liveness check; stale PIDs (process died without cleanup) show as
 	// not running and the task is resumable.
-	PID       int       `json:"pid,omitempty"`
+	PID int `json:"pid,omitempty"`
+	// Notes are transient, per-phase user guidance drained from the
+	// interactive run loop (#91). Never persisted (the `json:"-"` tag
+	// keeps them out of the DB column) — consumed exactly once by the
+	// next plan or code prompt, then cleared. A fresh `vairdict run`
+	// or `resume` starts with no pending notes.
+	Notes     []string  `json:"-"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -10,11 +10,10 @@ Update this file when opening, completing, or blocking an issue.
 ---
 
 ## Ready to Start
-- #90 cmd/resume: resume interrupted run from last checkpoint
-- #91 cmd/interactive: status, notes, pause/continue during execution
 - #82 perf: load test 5 concurrent tasks
 
 ## In Progress
+- #91 cmd/interactive: status, notes, pause/continue during execution
 
 ## Blocked
 
@@ -71,6 +70,7 @@ Update this file when opening, completing, or blocking an issue.
 - #111 cmd: @vairdict explain — answer questions about PR changes inline
 - #112 cmd: @vairdict fix — push code changes from PR comments
 - #113 cmd: @vairdict run — trigger full plan/code/quality loop from PR comment
+- #90 cmd/resume: resume interrupted run from last checkpoint
 
 ---
 
@@ -166,6 +166,6 @@ reviewed by the agent judge, only then created in GitHub.
 | M2        | done        | 6/6         |
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
-| M5        | in progress | 14/17       |
+| M5        | in progress | 15/17       |
 | M6        | not started | 0/7         |
 | M7+       | not started | —           |


### PR DESCRIPTION
Closes #91.

## Summary

Adds a foreground input loop to `vairdict run` so the user can steer a long task without opening a second terminal. Four commands, deliberately simple (`bufio.Scanner` + `switch`, no TUI framework per the issue).

```
status            phase/loop/score/elapsed/notes/paused snapshot
note <text>       queue guidance for the next agent prompt
pause             gate next phase/loop entry (does not kill an in-flight call)
continue          resume after pause
help              list the above
```

## What changed

- **`internal/interactive/` (new package)** — mutex+cond-var `State` shared between the orchestration goroutine and the input loop. `DrainNotes` is destructive (AC: "consumed once and logged"). `WaitWhilePaused` wakes on ctx cancel so ctrl-c during a pause aborts cleanly rather than hanging on the cond var.
- **`state.Task`** — transient `Notes []string` with `json:"-"` so it never hits the DB. Drained from `interactive.State` before each phase; the phase consumes on its first inner loop and clears, so requeues don't repeat the note.
- **`internal/phases/plan` + `internal/phases/code`** — `buildPlannerPrompt` / `buildCoderPrompt` take a `notes []string` and render a `## Notes from User` section when non-empty. Consumption is logged at Info level.
- **`runOrchestration`** — `gateBeforePhase()` hook runs before each plan/code/quality phase: `UpdatePhase` → `WaitWhilePaused` → `DrainNotes`. No-op when `deps.interactive` is nil, so tests and the `--no-tty` path have zero overhead.
- **`vairdict run`** — new `--no-tty` flag. Interactive loop auto-skips when stdin isn't a TTY, `--no-tty` is set, or we're running as the detached child of `--background` (`VAIRDICT_FOREGROUND=1`).

## Design notes

- **Pause semantics** match the AC exactly: pause gates the **next** phase/loop entry, it doesn't interrupt an in-flight agent call. Agents run to completion, then the gate blocks before the next one.
- **Notes lifecycle**: queued on user command → drained into `task.Notes` at next phase boundary → consumed into the prompt on that phase's first inner loop → cleared. So a `note` typed mid-code-phase lands on the next (plan or code) call.
- **Visuals**: the existing spinner-based TUI keeps emitting to stdout. The input loop reads from stdin and writes to stdout on user command. Per the issue, we accept the minor visual interplay rather than pull in a TUI framework.
- **Non-interactive fallback** is the default when stdin isn't a TTY — CI, manifests, pipes, and the `--background` child all behave exactly as before.

## Test plan

- [x] `interactive.State`: AddNote/DrainNotes idempotence, SetPaused idempotence, WaitWhilePaused returns immediately when not paused / wakes on resume / wakes on ctx cancel.
- [x] `interactive.RunLoop`: status output, note queues correctly, pause/continue toggles, unknown command reported, RunLoop returns on EOF (so piped stdin and closed terminals don't hang).
- [x] Orchestration (`cmd/vairdict/interactive_test.go`): notes land on `task.Notes` before plan phase, pause gate blocks until resume, cancelled context unblocks paused wait.
- [x] Existing phase tests updated for the new `notes` parameter on `buildPlannerPrompt` / `buildCoderPrompt`.
- [ ] Manual smoke: `vairdict run "..."` → type `status`, `note foo`, `pause`, `continue` — relies on live agents, not exercised in unit tests.

## Not in this PR (tracked for follow-ups)

- `vairdict stop <id>` and `vairdict detach <id>` — discussed during #90 scoping; belong in a separate issue since the AC here is `status / note / pause / continue` only.

https://claude.ai/code/session_01D1NWLM6U8c7BD42VnQ1yvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1NWLM6U8c7BD42VnQ1yvZ)_