### PR TITLE
docs: open M6 issues and expand scope to pluggable coder + registry

### DIFF
--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -167,5 +167,5 @@ reviewed by the agent judge, only then created in GitHub.
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
 | M5        | in progress | 15/17       |
-| M6        | not started | 0/7         |
+| M6        | not started | 0/6         |
 | M7+       | not started | —           |

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -167,5 +167,5 @@ reviewed by the agent judge, only then created in GitHub.
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
 | M5        | in progress | 15/17       |
-| M6        | not started | 0/8         |
+| M6        | not started | 0/9         |
 | M7+       | not started | —           |

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -167,5 +167,5 @@ reviewed by the agent judge, only then created in GitHub.
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
 | M5        | in progress | 15/17       |
-| M6        | not started | 0/6         |
+| M6        | not started | 0/8         |
 | M7+       | not started | —           |

--- a/plans/ROADMAP.md
+++ b/plans/ROADMAP.md
@@ -132,18 +132,21 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 > Claude Code is the default. Any CLI agent can replace it.
 
 **Definition of done:**
-- Codex CLI usable as a completer backend
-- Gemini CLI usable as a completer backend
+- Codex CLI usable as a completer **and** coder backend
+- Gemini CLI usable as a completer **and** coder backend
 - Backend selectable per phase in vairdict.yaml
 - Judge model swappable independently of completer model
-- Auto-resolver picks the best available backend like the existing claude resolver
+- Auto-resolver picks the best available backend for both completer
+  and coder roles, like the existing claude resolver
 
 **Issues:**
 - [ ] agents/codex: Codex CLI completer
 - [ ] agents/gemini: Gemini CLI completer
+- [ ] agents/codex: Codex CLI coder (file-editing driver)
+- [ ] agents/gemini: Gemini CLI coder (file-editing driver)
 - [ ] config: per-phase backend selection in vairdict.yaml
 - [ ] judge/pluggable: swap judge model in vairdict.yaml
-- [ ] resolver: extend auto backend resolver to all agents
+- [ ] resolver: extend auto backend resolver to all agents (completer + coder)
 - [ ] docs: agent backend selection guide
 
 ---

--- a/plans/ROADMAP.md
+++ b/plans/ROADMAP.md
@@ -147,6 +147,7 @@ Progress is tracked in [PROGRESS.md](./PROGRESS.md).
 - [ ] config: per-phase backend selection in vairdict.yaml
 - [ ] judge/pluggable: swap judge model in vairdict.yaml
 - [ ] resolver: extend auto backend resolver to all agents (completer + coder)
+- [ ] test/m6: cross-backend integration + e2e tests (gated)
 - [ ] docs: agent backend selection guide
 
 ---


### PR DESCRIPTION
## Summary
- Open the 9 M6 (Pluggable Agents) issues on GitHub: completer + coder backends for Codex/Gemini, registry-based resolver, per-phase config + pre-flight validation, judge-model swap, gated integration suite, docs (#126–#134)
- Sync `plans/PROGRESS.md` and `plans/ROADMAP.md` to the expanded M6 scope (count 0/9, coder backends added, integration test issue added)
- No code changes — docs only

## Test plan
- [x] `plans/PROGRESS.md` count matches ROADMAP issue list (9 bullets)
- [x] All 9 issues labeled `milestone-6` and visible in the milestone view
- [x] Issue cross-references resolve (#126↔#132, #127↔#133, all → #130)

https://claude.ai/code/session_01V2ySWGkKPX7bFEizEKshUH

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2ySWGkKPX7bFEizEKshUH)_