### PR TITLE
feat(config): per-phase backend selection + pre-flight validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,27 @@ Do not start work on an issue that is still "Blocked" in `plans/PROGRESS.md`.
 Do not exceed the scope defined in the issue.
 Do not open a PR without a passing verdict (M3+).
 
+## Working Without VAIrdict (manual / Claude Code sessions)
+
+When a task or issue is being worked on directly (not through
+`vairdict run`), follow this order — no exceptions:
+
+1. **Plan first.** Read the full issue, identify the files / packages
+   you'll touch, sketch the approach, and present the plan back to the
+   user. Do not start editing until the user confirms.
+2. **Tests next.** Tests are part of the task's definition of done —
+   not an afterthought. Write the tests for the new behavior before
+   the implementation code (or alongside it for plumbing-only changes
+   where pure-tests-first is impractical, but never after).
+3. **Then implementation.** Make the tests pass. Keep changes scoped
+   to what the plan agreed on.
+4. **Verify at the end.** Run the relevant test suite (`make test` or
+   the targeted package) and confirm the new tests pass before
+   reporting the task as done.
+
+The "tests pass" check is non-negotiable — a task is not done until
+its tests are written AND green.
+
 ## What NOT to do
 
 - Do not commit directly to main — all code changes go through PRs

--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -3,7 +3,8 @@
 // in internal/agents/claudecode which uses tools and edits the filesystem).
 //
 // Three values are accepted in vairdict.yaml under agents.planner /
-// agents.judge:
+// agents.judge (and the per-phase overrides agents.plan_judge,
+// agents.code_judge, agents.quality_judge):
 //
 //	claude      — smart default: try claude-cli, fall back to claude-api
 //	claude-cli  — strict local subprocess (errors if `claude` not on PATH)
@@ -17,6 +18,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/exec"
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/agents/claudecli"
@@ -32,6 +34,18 @@ type completer interface {
 	CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, handlers map[string]claude.ToolHandler, target any) error
 }
 
+// completerRole names a completer slot in the orchestration pipeline.
+// Each role reads its backend from a different field in agents.* (with
+// per-phase judges falling back to agents.judge).
+type completerRole string
+
+const (
+	rolePlanner      completerRole = "planner"
+	rolePlanJudge    completerRole = "plan_judge"
+	roleCodeJudge    completerRole = "code_judge"
+	roleQualityJudge completerRole = "quality_judge"
+)
+
 // backendKind is the resolved backend identifier returned alongside the
 // completer instance so it can be surfaced in CLI output and logs. Note
 // this is the *resolved* kind — `claude` (smart) is never returned here;
@@ -43,6 +57,24 @@ const (
 	backendClaudeAPI backendKind = "claude-api" // HTTP API
 )
 
+// backendForRole reads the configured backend string for the given role
+// from cfg.Agents, applying the per-phase fallback to Judge for the
+// three judge slots.
+func backendForRole(cfg *config.Config, role completerRole) string {
+	switch role {
+	case rolePlanner:
+		return cfg.Agents.Planner
+	case rolePlanJudge:
+		return cfg.Agents.PlanJudgeBackend()
+	case roleCodeJudge:
+		return cfg.Agents.CodeJudgeBackend()
+	case roleQualityJudge:
+		return cfg.Agents.QualityJudgeBackend()
+	default:
+		return ""
+	}
+}
+
 // chooseBackend returns the resolved backend for the given config setting.
 // `cliAvailable` is injected (via claudecli.IsAvailable in production) so
 // the resolver is deterministic and unit-testable without touching PATH.
@@ -51,7 +83,14 @@ const (
 //	"claude-cli" → claude-cli (caller errors later if PATH lookup fails)
 //	"claude-api" → claude-api (caller errors later if no API key)
 //	"auto"       → deprecated alias for "claude" — accepted with no warn
+//
+// roleName is included in the error message for unknown values so the
+// user can see which slot needs fixing.
 func chooseBackend(setting string, cliAvailable bool) (backendKind, error) {
+	return chooseBackendForRole("agents.judge", setting, cliAvailable)
+}
+
+func chooseBackendForRole(roleName, setting string, cliAvailable bool) (backendKind, error) {
 	switch setting {
 	case "", "claude", "auto":
 		if cliAvailable {
@@ -63,15 +102,16 @@ func chooseBackend(setting string, cliAvailable bool) (backendKind, error) {
 	case "claude-api":
 		return backendClaudeAPI, nil
 	default:
-		return "", fmt.Errorf("unknown agents.judge backend %q (want claude|claude-cli|claude-api)", setting)
+		return "", fmt.Errorf("unknown %s backend %q (want claude|claude-cli|claude-api)", roleName, setting)
 	}
 }
 
-// resolveCompleter picks a backend per chooseBackend and constructs the
-// matching client. The returned backendKind is informational (rendered as
-// a `completer:` note in CLI mode).
-func resolveCompleter(cfg *config.Config) (completer, backendKind, error) {
-	kind, err := chooseBackend(cfg.Agents.Judge, claudecli.IsAvailable())
+// resolveCompleter picks a backend for the given role per chooseBackend
+// and constructs the matching client. The returned backendKind is
+// informational (rendered as a `completer:` note in CLI mode).
+func resolveCompleter(cfg *config.Config, role completerRole) (completer, backendKind, error) {
+	setting := backendForRole(cfg, role)
+	kind, err := chooseBackendForRole("agents."+string(role), setting, claudecli.IsAvailable())
 	if err != nil {
 		return nil, "", err
 	}
@@ -96,5 +136,98 @@ func resolveCompleter(cfg *config.Config) (completer, backendKind, error) {
 		return c, kind, nil
 	default:
 		return nil, "", fmt.Errorf("unreachable backend kind: %s", kind)
+	}
+}
+
+// backendProbes injects the side-effects validateBackends needs (PATH
+// lookups, API key probe). Production wires these to exec.LookPath and
+// config.ResolveAPIKey; tests set deterministic stubs.
+type backendProbes struct {
+	cliAvailable  func(name string) bool
+	apiKeyPresent func() bool
+}
+
+// defaultBackendProbes returns probes that hit the real environment.
+// Kept as a constructor so callers don't have to re-import os/exec or
+// the config package just to do a pre-flight check.
+func defaultBackendProbes() backendProbes {
+	return backendProbes{
+		cliAvailable: func(name string) bool {
+			_, err := exec.LookPath(name)
+			return err == nil
+		},
+		apiKeyPresent: func() bool {
+			return config.ResolveAPIKey() != ""
+		},
+	}
+}
+
+// validateBackends walks every resolved completer role plus the coder
+// and verifies that the chosen backend is actually usable: CLI binary
+// on PATH for *-cli / family CLIs, API key configured for *-api.
+//
+// Smart defaults ("", "claude", "auto") never trigger errors — they
+// fall through to whichever family is available at runtime. Validation
+// only fires for explicit pinned backends so users who want VAIrdict
+// to "just work" with whichever family they happen to have aren't
+// blocked by missing alternatives.
+//
+// The function is pure: no network, no slog, no global state — just
+// probes injected via the parameter so tests can drive it.
+func validateBackends(cfg *config.Config, probes backendProbes) error {
+	checks := []struct {
+		name    string
+		setting string
+	}{
+		{"agents.planner", cfg.Agents.Planner},
+		{"agents.plan_judge", cfg.Agents.PlanJudgeBackend()},
+		{"agents.code_judge", cfg.Agents.CodeJudgeBackend()},
+		{"agents.quality_judge", cfg.Agents.QualityJudgeBackend()},
+	}
+	for _, c := range checks {
+		if err := validateCompleterBackend(c.name, c.setting, probes); err != nil {
+			return err
+		}
+	}
+	return validateCoderBackend(cfg.Agents.Coder, probes)
+}
+
+// validateCompleterBackend covers the planner / judge slots which all
+// share the same {claude, claude-cli, claude-api, auto} taxonomy.
+func validateCompleterBackend(roleName, setting string, probes backendProbes) error {
+	switch setting {
+	case "", "claude", "auto":
+		// Smart default — let runtime fall through to whichever family
+		// is available. AC explicitly requires no error here.
+		return nil
+	case "claude-cli":
+		if !probes.cliAvailable("claude") {
+			return fmt.Errorf("%s: claude-cli requires the `claude` binary on PATH", roleName)
+		}
+		return nil
+	case "claude-api":
+		if !probes.apiKeyPresent() {
+			return fmt.Errorf("%s: claude-api requires ANTHROPIC_API_KEY (env var or ~/.config/vairdict/config.yaml)", roleName)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s: unknown backend %q (want claude|claude-cli|claude-api)", roleName, setting)
+	}
+}
+
+// validateCoderBackend covers agents.coder, which today only supports
+// claude-code (the family CLI runner used by internal/agents/claudecode).
+// Listed separately because the taxonomy is different from the completer
+// slots — claude-code is the only legal value, and it requires the
+// `claude` binary to be on PATH.
+func validateCoderBackend(setting string, probes backendProbes) error {
+	switch setting {
+	case "", "claude-code":
+		if !probes.cliAvailable("claude") {
+			return fmt.Errorf("agents.coder: claude-code requires the `claude` binary on PATH")
+		}
+		return nil
+	default:
+		return fmt.Errorf("agents.coder: unknown backend %q (want claude-code)", setting)
 	}
 }

--- a/cmd/vairdict/completer_test.go
+++ b/cmd/vairdict/completer_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/config"
+)
 
 func TestChooseBackend(t *testing.T) {
 	cases := []struct {
@@ -40,5 +45,198 @@ func TestChooseBackend(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestBackendForRole(t *testing.T) {
+	// Flat-only — every judge role inherits agents.judge.
+	flat := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code",
+		Judge:   "claude-cli",
+	}}
+	if got := backendForRole(flat, rolePlanner); got != "claude" {
+		t.Errorf("rolePlanner = %q, want claude", got)
+	}
+	if got := backendForRole(flat, rolePlanJudge); got != "claude-cli" {
+		t.Errorf("rolePlanJudge (flat) = %q, want claude-cli", got)
+	}
+	if got := backendForRole(flat, roleCodeJudge); got != "claude-cli" {
+		t.Errorf("roleCodeJudge (flat) = %q, want claude-cli", got)
+	}
+	if got := backendForRole(flat, roleQualityJudge); got != "claude-cli" {
+		t.Errorf("roleQualityJudge (flat) = %q, want claude-cli", got)
+	}
+
+	// Mixed — one phase override, others inherit.
+	mixed := &config.Config{Agents: config.AgentsConfig{
+		Planner:      "claude",
+		Judge:        "claude-cli",
+		QualityJudge: "claude-api",
+	}}
+	if got := backendForRole(mixed, rolePlanJudge); got != "claude-cli" {
+		t.Errorf("rolePlanJudge (mixed) = %q, want claude-cli", got)
+	}
+	if got := backendForRole(mixed, roleQualityJudge); got != "claude-api" {
+		t.Errorf("roleQualityJudge (mixed) = %q, want claude-api", got)
+	}
+}
+
+// TestValidateBackends_FlatOnlyLegacy: a config that only sets the flat
+// fields must validate identically to pre-issue-128 behavior. With CLI
+// available and Judge=claude (smart), no error.
+func TestValidateBackends_FlatOnlyLegacy(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code",
+		Judge:   "claude",
+	}}
+	probes := backendProbes{
+		cliAvailable:  func(string) bool { return true },
+		apiKeyPresent: func() bool { return false },
+	}
+	if err := validateBackends(cfg, probes); err != nil {
+		t.Errorf("flat legacy config should validate, got: %v", err)
+	}
+}
+
+// TestValidateBackends_PerPhaseOnly: explicit pinned backends per phase
+// validate when their requirements are met.
+func TestValidateBackends_PerPhaseOnly(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner:      "claude-api",
+		Coder:        "claude-code",
+		Judge:        "claude-api",
+		PlanJudge:    "claude-cli",
+		CodeJudge:    "claude-api",
+		QualityJudge: "claude-cli",
+	}}
+	probes := backendProbes{
+		cliAvailable:  func(string) bool { return true },
+		apiKeyPresent: func() bool { return true },
+	}
+	if err := validateBackends(cfg, probes); err != nil {
+		t.Errorf("per-phase config with all reqs met should validate, got: %v", err)
+	}
+}
+
+// TestValidateBackends_MissingBinary: claude-cli pinned but `claude` not
+// on PATH → must error and name both the role and the missing binary.
+func TestValidateBackends_MissingBinary(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code",
+		Judge:   "claude",
+		// PlanJudge is the explicit pinned slot that should fail validation.
+		PlanJudge: "claude-cli",
+	}}
+	probes := backendProbes{
+		cliAvailable:  func(string) bool { return false }, // no claude
+		apiKeyPresent: func() bool { return true },
+	}
+	err := validateBackends(cfg, probes)
+	if err == nil {
+		t.Fatal("expected error for missing claude binary")
+	}
+	if !strings.Contains(err.Error(), "plan_judge") {
+		t.Errorf("error should name the role (plan_judge), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should name the missing binary, got: %v", err)
+	}
+}
+
+// TestValidateBackends_MissingAPIKey: claude-api pinned but no key →
+// must error.
+func TestValidateBackends_MissingAPIKey(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code",
+		Judge:   "claude",
+		// CodeJudge is the explicit pinned slot that should fail validation.
+		CodeJudge: "claude-api",
+	}}
+	probes := backendProbes{
+		cliAvailable:  func(string) bool { return true },
+		apiKeyPresent: func() bool { return false },
+	}
+	err := validateBackends(cfg, probes)
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+	if !strings.Contains(err.Error(), "code_judge") {
+		t.Errorf("error should name the role (code_judge), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("error should name the missing requirement, got: %v", err)
+	}
+}
+
+// TestValidateBackends_UnknownBackend: an unknown name on any role must
+// error and name the role and the bad value.
+func TestValidateBackends_UnknownBackend(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code",
+		Judge:   "claude",
+		// Quality judge has a typo — should fail.
+		QualityJudge: "openai",
+	}}
+	probes := backendProbes{
+		cliAvailable:  func(string) bool { return true },
+		apiKeyPresent: func() bool { return true },
+	}
+	err := validateBackends(cfg, probes)
+	if err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+	if !strings.Contains(err.Error(), "quality_judge") {
+		t.Errorf("error should name the role (quality_judge), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "openai") {
+		t.Errorf("error should echo the bad value, got: %v", err)
+	}
+}
+
+// TestValidateBackends_AutoDoesNotErrorWhenFamilyUnavailable: per AC,
+// smart defaults ("claude" / "auto" / empty) MUST NOT error even when
+// no family is available — they fall through at runtime.
+func TestValidateBackends_AutoDoesNotErrorWhenFamilyUnavailable(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code",
+		Judge:   "auto",
+	}}
+	// Neither the CLI nor an API key — but every completer slot uses
+	// the smart default, so validation must still pass. Coder still
+	// needs the binary, so we pretend that's available.
+	probes := backendProbes{
+		cliAvailable:  func(name string) bool { return name == "claude" },
+		apiKeyPresent: func() bool { return false },
+	}
+	if err := validateBackends(cfg, probes); err != nil {
+		t.Errorf("smart-default config should not error, got: %v", err)
+	}
+}
+
+// TestValidateBackends_CoderNeedsBinary: claude-code is the family CLI
+// runner — it requires `claude` on PATH. Validating with no binary
+// must error and name agents.coder.
+func TestValidateBackends_CoderNeedsBinary(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude-api",
+		Coder:   "claude-code",
+		Judge:   "claude-api",
+	}}
+	probes := backendProbes{
+		cliAvailable:  func(string) bool { return false }, // no claude on PATH
+		apiKeyPresent: func() bool { return true },
+	}
+	err := validateBackends(cfg, probes)
+	if err == nil {
+		t.Fatal("expected error when claude is missing for the coder")
+	}
+	if !strings.Contains(err.Error(), "agents.coder") {
+		t.Errorf("error should name the coder role, got: %v", err)
 	}
 }

--- a/cmd/vairdict/handle_comment.go
+++ b/cmd/vairdict/handle_comment.go
@@ -743,7 +743,9 @@ func runExplainQuestion(ctx context.Context, diff, question string) (string, err
 	if err != nil {
 		return "", fmt.Errorf("loading config: %w", err)
 	}
-	client, _, err := resolveCompleter(cfg)
+	// @vairdict explain is a free-form Q&A about a PR — closest to the
+	// quality judge's role since it's reasoning over a finished diff.
+	client, _, err := resolveCompleter(cfg, roleQualityJudge)
 	if err != nil {
 		return "", fmt.Errorf("resolving completer: %w", err)
 	}

--- a/cmd/vairdict/manifest_run.go
+++ b/cmd/vairdict/manifest_run.go
@@ -42,7 +42,11 @@ func runManifest(manifest *Manifest, mode ui.Mode, colors ui.ColorScheme, ascii 
 	}
 	defer func() { _ = store.Close() }()
 
-	client, _, err := resolveCompleter(cfg)
+	if err := validateBackends(cfg, defaultBackendProbes()); err != nil {
+		return fmt.Errorf("backend validation: %w", err)
+	}
+
+	comps, err := resolveAllCompleters(cfg)
 	if err != nil {
 		return err
 	}
@@ -129,7 +133,7 @@ func runManifest(manifest *Manifest, mode ui.Mode, colors ui.ColorScheme, ascii 
 				defer func() { <-sem }()
 
 				t := tasks[id]
-				res := runSingleTask(ctx, cfg, client, store, repoRoot, t.Intent, issueByID[id], t.Priority)
+				res := runSingleTask(ctx, cfg, comps, store, repoRoot, t.Intent, issueByID[id], t.Priority)
 				// runSingleTask generated its own task ID for the run; we
 				// want the manifest ID to be the authoritative record
 				// surfaced to the user. The per-goroutine subtask ID is

--- a/cmd/vairdict/resume.go
+++ b/cmd/vairdict/resume.go
@@ -168,7 +168,11 @@ func resumeTask(taskID string, store *state.Store, mode ui.Mode, colors ui.Color
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	client, backend, err := resolveCompleter(cfg)
+	if err := validateBackends(cfg, defaultBackendProbes()); err != nil {
+		return fmt.Errorf("backend validation: %w", err)
+	}
+
+	comps, err := resolveAllCompleters(cfg)
 	if err != nil {
 		return err
 	}
@@ -196,7 +200,7 @@ func resumeTask(taskID string, store *state.Store, mode ui.Mode, colors ui.Color
 	defer func() { _ = r.Close() }()
 
 	r.RunStart(task.ID, task.Intent, logPath)
-	r.Note("completer", string(backend))
+	r.Note("completer", completerNote(comps))
 	r.Note("resume", fmt.Sprintf("from [%s/%s]", task.Phase, task.State))
 
 	slog.Info("task resumed", "id", task.ID, "phase", task.Phase, "state", task.State)
@@ -223,7 +227,7 @@ func resumeTask(taskID string, store *state.Store, mode ui.Mode, colors ui.Color
 
 	ghRunner := &github.ExecRunner{Dir: repoRoot}
 	ghClient := github.New(ghRunner)
-	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient, 0)
+	deps := defaultRunDeps(cfg, comps, store, workDir, r, ghClient, 0)
 
 	// Claim the run with this PID so `vairdict status` shows it as
 	// running while the resumed orchestration is in flight.

--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -108,7 +108,13 @@ func runReview(prNumber int) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	client, _, err := resolveCompleter(cfg)
+	if err := validateBackends(cfg, defaultBackendProbes()); err != nil {
+		return fmt.Errorf("backend validation: %w", err)
+	}
+
+	// vairdict review only runs the quality judge, so we resolve just
+	// that role. Per-phase overrides (agents.quality_judge) take effect.
+	client, _, err := resolveCompleter(cfg, roleQualityJudge)
 	if err != nil {
 		return err
 	}

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -261,14 +261,15 @@ func (d runDeps) gateBeforePhase(ctx context.Context, task *state.Task, phase st
 // --- Default (production) phase runner implementations ---
 
 type defaultPlanRunner struct {
-	cfg    *config.Config
-	client completer
-	store  *state.Store
-	r      ui.Renderer
+	cfg     *config.Config
+	planner completer
+	judge   completer
+	store   *state.Store
+	r       ui.Renderer
 }
 
 func (d *defaultPlanRunner) Run(ctx context.Context, task *state.Task) (*planphase.PhaseResult, error) {
-	return runPlanPhase(ctx, d.cfg, d.client, d.store, task, d.r)
+	return runPlanPhase(ctx, d.cfg, d.planner, d.judge, d.store, task, d.r)
 }
 
 type defaultCodeRunner struct {
@@ -294,11 +295,52 @@ func (d *defaultQualityRunner) Run(ctx context.Context, task *state.Task, plan s
 	return runQualityPhase(ctx, d.cfg, d.client, d.store, task, plan, codeFacts, d.workDir, d.r)
 }
 
-func defaultRunDeps(cfg *config.Config, client completer, store *state.Store, workDir string, r ui.Renderer, ghClient *github.Client, issueNumber int) runDeps {
+// completers bundles the three LLM clients the orchestrator needs, one
+// per role. resolveAllCompleters fills this struct from the config so a
+// single agents.judge value still works (every slot resolves to the
+// same client) while users with per-phase overrides get distinct ones.
+type completers struct {
+	planner      completer
+	planJudge    completer
+	qualityJudge completer
+	// plannerKind / planJudgeKind / qualityJudgeKind are surfaced in
+	// the CLI banner so users can see which backend each role landed on.
+	plannerKind      backendKind
+	planJudgeKind    backendKind
+	qualityJudgeKind backendKind
+}
+
+// resolveAllCompleters builds the planner / plan judge / quality judge
+// clients from the config in one call. Each role goes through
+// resolveCompleter independently so per-phase overrides take effect.
+func resolveAllCompleters(cfg *config.Config) (completers, error) {
+	planner, plannerKind, err := resolveCompleter(cfg, rolePlanner)
+	if err != nil {
+		return completers{}, err
+	}
+	planJudge, planJudgeKind, err := resolveCompleter(cfg, rolePlanJudge)
+	if err != nil {
+		return completers{}, err
+	}
+	qualityJudge, qualityJudgeKind, err := resolveCompleter(cfg, roleQualityJudge)
+	if err != nil {
+		return completers{}, err
+	}
+	return completers{
+		planner:          planner,
+		planJudge:        planJudge,
+		qualityJudge:     qualityJudge,
+		plannerKind:      plannerKind,
+		planJudgeKind:    planJudgeKind,
+		qualityJudgeKind: qualityJudgeKind,
+	}, nil
+}
+
+func defaultRunDeps(cfg *config.Config, comps completers, store *state.Store, workDir string, r ui.Renderer, ghClient *github.Client, issueNumber int) runDeps {
 	return runDeps{
-		plan:      &defaultPlanRunner{cfg: cfg, client: client, store: store, r: r},
+		plan:      &defaultPlanRunner{cfg: cfg, planner: comps.planner, judge: comps.planJudge, store: store, r: r},
 		code:      &defaultCodeRunner{cfg: cfg, store: store, workDir: workDir, r: r},
-		quality:   &defaultQualityRunner{cfg: cfg, client: client, store: store, workDir: workDir, r: r},
+		quality:   &defaultQualityRunner{cfg: cfg, client: comps.qualityJudge, store: store, workDir: workDir, r: r},
 		gh:        ghClient,
 		conflicts: conflicts.New(&workspace.ExecRunner{}),
 		workDir:   workDir,
@@ -342,9 +384,17 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 	}
 	defer func() { _ = store.Close() }()
 
-	// Resolve the completer backend — HTTP claude.Client or local
-	// claude CLI wrapper — based on agents.judge and the environment.
-	client, backend, err := resolveCompleter(cfg)
+	// Pre-flight: catch a missing CLI binary or missing API key now,
+	// before any task state is created, so the user gets one clear
+	// error in the first second instead of a mid-phase failure.
+	if err := validateBackends(cfg, defaultBackendProbes()); err != nil {
+		return fmt.Errorf("backend validation: %w", err)
+	}
+
+	// Resolve the completer backends — one per role so per-phase
+	// overrides take effect. Without overrides every role lands on
+	// the same backend, matching pre-issue-128 behavior.
+	comps, err := resolveAllCompleters(cfg)
 	if err != nil {
 		return err
 	}
@@ -408,7 +458,7 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 	defer func() { _ = r.Close() }()
 
 	r.RunStart(task.ID, intent, logPath)
-	r.Note("completer", string(backend))
+	r.Note("completer", completerNote(comps))
 	if issueNumber > 0 {
 		r.Note("issue", fmt.Sprintf("#%d", issueNumber))
 	}
@@ -442,7 +492,7 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 	ghRunner := &github.ExecRunner{Dir: repoRoot}
 	ghClient := github.New(ghRunner)
 
-	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient, issueNumber)
+	deps := defaultRunDeps(cfg, comps, store, workDir, r, ghClient, issueNumber)
 
 	// Interactive input loop: if stdin is a TTY and --no-tty is not
 	// set, spawn a goroutine that reads commands from the user and
@@ -466,6 +516,18 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 	defer clearPID(store, task)
 
 	return runOrchestration(ctx, deps, task, r)
+}
+
+// completerNote produces the value rendered for the `completer:` line
+// in the CLI banner. When all three roles resolved to the same backend
+// the line is just that one kind ("claude-cli"); when they differ, it
+// shows each role explicitly so the user sees the per-phase split.
+func completerNote(c completers) string {
+	if c.plannerKind == c.planJudgeKind && c.planJudgeKind == c.qualityJudgeKind {
+		return string(c.plannerKind)
+	}
+	return fmt.Sprintf("planner=%s plan_judge=%s quality_judge=%s",
+		c.plannerKind, c.planJudgeKind, c.qualityJudgeKind)
 }
 
 // shouldRunInteractive reports whether the interactive input loop
@@ -520,7 +582,11 @@ func runTasks(intents []string, issues []int, mode ui.Mode, colors ui.ColorSchem
 	}
 	defer func() { _ = store.Close() }()
 
-	client, _, err := resolveCompleter(cfg)
+	if err := validateBackends(cfg, defaultBackendProbes()); err != nil {
+		return fmt.Errorf("backend validation: %w", err)
+	}
+
+	comps, err := resolveAllCompleters(cfg)
 	if err != nil {
 		return err
 	}
@@ -553,7 +619,7 @@ func runTasks(intents []string, issues []int, mode ui.Mode, colors ui.ColorSchem
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			results[idx] = runSingleTask(ctx, cfg, client, store, repoRoot, intent, issueNum, priority)
+			results[idx] = runSingleTask(ctx, cfg, comps, store, repoRoot, intent, issueNum, priority)
 			r := results[idx]
 			status := "pass"
 			if r.Err != nil {
@@ -592,7 +658,7 @@ func runTasks(intents []string, issues []int, mode ui.Mode, colors ui.ColorSchem
 func runSingleTask(
 	ctx context.Context,
 	cfg *config.Config,
-	client completer,
+	comps completers,
 	store *state.Store,
 	repoRoot string,
 	intent string,
@@ -647,7 +713,7 @@ func runSingleTask(
 	ghRunner := &github.ExecRunner{Dir: repoRoot}
 	ghClient := github.New(ghRunner)
 
-	deps := defaultRunDeps(cfg, client, store, workDir, r, ghClient, issueNumber)
+	deps := defaultRunDeps(cfg, comps, store, workDir, r, ghClient, issueNumber)
 	// In concurrent mode, escalation returns an error instead of os.Exit.
 	deps.onEscalation = func(ctx context.Context, task *state.Task, result escalation.Result) error {
 		if err := dispatchEscalation(ctx, task, result, cfg.Escalation, logWriter, ghClient); err != nil {
@@ -1102,11 +1168,11 @@ func lastGapsForPhase(task *state.Task, phase state.Phase) []state.Gap {
 	return nil
 }
 
-func runPlanPhase(ctx context.Context, cfg *config.Config, client completer, store *state.Store, task *state.Task, r ui.Renderer) (*planphase.PhaseResult, error) {
+func runPlanPhase(ctx context.Context, cfg *config.Config, planner, judgeClient completer, store *state.Store, task *state.Task, r ui.Renderer) (*planphase.PhaseResult, error) {
 	r.PhaseStart(state.PhasePlan)
 
-	judge := planjudge.New(client, cfg.Phases.Plan)
-	phase := planphase.New(client, judge, cfg.Phases.Plan)
+	judge := planjudge.New(judgeClient, cfg.Phases.Plan)
+	phase := planphase.New(planner, judge, cfg.Phases.Plan)
 
 	spin := ui.NewSpinner(os.Stdout, "", ui.PaletteForCLI(r), ui.IsASCII(r))
 	phase.OnProgress = phaseProgressHandler(spin, r, state.PhasePlan)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,44 @@ type AgentsConfig struct {
 	Coder   string `yaml:"coder"`
 	Judge   string `yaml:"judge"`
 	Model   string `yaml:"model"`
+
+	// PlanJudge, CodeJudge, and QualityJudge override Judge for that
+	// phase only. Empty means "inherit Judge". Existing configs that
+	// only set Judge keep behaving exactly as before — every judge
+	// resolves to the flat value.
+	PlanJudge    string `yaml:"plan_judge,omitempty"`
+	CodeJudge    string `yaml:"code_judge,omitempty"`
+	QualityJudge string `yaml:"quality_judge,omitempty"`
+}
+
+// PlanJudgeBackend returns the backend setting for the plan judge,
+// honoring the per-phase override when set and falling back to the
+// flat Judge field otherwise.
+func (a AgentsConfig) PlanJudgeBackend() string {
+	if a.PlanJudge != "" {
+		return a.PlanJudge
+	}
+	return a.Judge
+}
+
+// CodeJudgeBackend returns the backend setting for the code judge,
+// honoring the per-phase override when set and falling back to the
+// flat Judge field otherwise.
+func (a AgentsConfig) CodeJudgeBackend() string {
+	if a.CodeJudge != "" {
+		return a.CodeJudge
+	}
+	return a.Judge
+}
+
+// QualityJudgeBackend returns the backend setting for the quality
+// judge, honoring the per-phase override when set and falling back
+// to the flat Judge field otherwise.
+func (a AgentsConfig) QualityJudgeBackend() string {
+	if a.QualityJudge != "" {
+		return a.QualityJudge
+	}
+	return a.Judge
 }
 
 type EnvironmentConfig struct {
@@ -319,6 +357,15 @@ func Merge(base *Config, overrides Config) *Config {
 	}
 	if overrides.Agents.Model != "" {
 		merged.Agents.Model = overrides.Agents.Model
+	}
+	if overrides.Agents.PlanJudge != "" {
+		merged.Agents.PlanJudge = overrides.Agents.PlanJudge
+	}
+	if overrides.Agents.CodeJudge != "" {
+		merged.Agents.CodeJudge = overrides.Agents.CodeJudge
+	}
+	if overrides.Agents.QualityJudge != "" {
+		merged.Agents.QualityJudge = overrides.Agents.QualityJudge
 	}
 
 	// Environment

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -322,6 +322,104 @@ func TestMerge_ParallelZeroNoOverride(t *testing.T) {
 	}
 }
 
+func TestAgentsConfig_PerPhaseFallback(t *testing.T) {
+	// Flat-only config: every per-phase getter falls back to Judge.
+	// This is the legacy shape — we MUST preserve it.
+	flat := AgentsConfig{Planner: "claude", Judge: "claude-cli"}
+	if got := flat.PlanJudgeBackend(); got != "claude-cli" {
+		t.Errorf("flat PlanJudgeBackend = %q, want claude-cli (fallback to Judge)", got)
+	}
+	if got := flat.CodeJudgeBackend(); got != "claude-cli" {
+		t.Errorf("flat CodeJudgeBackend = %q, want claude-cli (fallback to Judge)", got)
+	}
+	if got := flat.QualityJudgeBackend(); got != "claude-cli" {
+		t.Errorf("flat QualityJudgeBackend = %q, want claude-cli (fallback to Judge)", got)
+	}
+
+	// Per-phase only: each override is honored, no Judge to inherit.
+	perPhase := AgentsConfig{
+		PlanJudge:    "claude-api",
+		CodeJudge:    "claude-cli",
+		QualityJudge: "claude",
+	}
+	if got := perPhase.PlanJudgeBackend(); got != "claude-api" {
+		t.Errorf("per-phase PlanJudgeBackend = %q, want claude-api", got)
+	}
+	if got := perPhase.CodeJudgeBackend(); got != "claude-cli" {
+		t.Errorf("per-phase CodeJudgeBackend = %q, want claude-cli", got)
+	}
+	if got := perPhase.QualityJudgeBackend(); got != "claude" {
+		t.Errorf("per-phase QualityJudgeBackend = %q, want claude", got)
+	}
+
+	// Flat with one phase overridden: the override wins for that phase
+	// only; the other phases still inherit from Judge.
+	mixed := AgentsConfig{Judge: "claude-cli", QualityJudge: "claude-api"}
+	if got := mixed.PlanJudgeBackend(); got != "claude-cli" {
+		t.Errorf("mixed PlanJudgeBackend = %q, want claude-cli (inherits Judge)", got)
+	}
+	if got := mixed.CodeJudgeBackend(); got != "claude-cli" {
+		t.Errorf("mixed CodeJudgeBackend = %q, want claude-cli (inherits Judge)", got)
+	}
+	if got := mixed.QualityJudgeBackend(); got != "claude-api" {
+		t.Errorf("mixed QualityJudgeBackend = %q, want claude-api (override)", got)
+	}
+}
+
+func TestParseConfig_PerPhaseJudges(t *testing.T) {
+	data := []byte(`
+project:
+  name: perphase
+agents:
+  judge: claude
+  plan_judge: claude-api
+  code_judge: claude-cli
+  quality_judge: claude-api
+`)
+	cfg, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agents.Judge != "claude" {
+		t.Errorf("agents.judge = %q, want claude", cfg.Agents.Judge)
+	}
+	if cfg.Agents.PlanJudge != "claude-api" {
+		t.Errorf("agents.plan_judge = %q, want claude-api", cfg.Agents.PlanJudge)
+	}
+	if cfg.Agents.CodeJudge != "claude-cli" {
+		t.Errorf("agents.code_judge = %q, want claude-cli", cfg.Agents.CodeJudge)
+	}
+	if cfg.Agents.QualityJudge != "claude-api" {
+		t.Errorf("agents.quality_judge = %q, want claude-api", cfg.Agents.QualityJudge)
+	}
+}
+
+func TestMerge_PerPhaseJudges(t *testing.T) {
+	base := Defaults()
+	base.Project.Name = "base"
+	base.Agents.Judge = "claude"
+
+	overrides := Config{
+		Agents: AgentsConfig{
+			QualityJudge: "claude-api",
+		},
+	}
+	merged := Merge(&base, overrides)
+
+	if merged.Agents.Judge != "claude" {
+		t.Errorf("Judge = %q, want claude (base preserved)", merged.Agents.Judge)
+	}
+	if merged.Agents.QualityJudge != "claude-api" {
+		t.Errorf("QualityJudge = %q, want claude-api (overlay)", merged.Agents.QualityJudge)
+	}
+	if merged.Agents.PlanJudgeBackend() != "claude" {
+		t.Errorf("PlanJudgeBackend = %q, want claude (inherits Judge)", merged.Agents.PlanJudgeBackend())
+	}
+	if merged.Agents.CodeJudgeBackend() != "claude" {
+		t.Errorf("CodeJudgeBackend = %q, want claude (inherits Judge)", merged.Agents.CodeJudgeBackend())
+	}
+}
+
 func TestMerge_DoesNotMutateBase(t *testing.T) {
 	base := Defaults()
 	base.Project.Name = "original"

--- a/internal/config/overlay_test.go
+++ b/internal/config/overlay_test.go
@@ -79,6 +79,39 @@ escalation:
 	}
 }
 
+// TestLoadConfigWithOverlay_PerPhaseOverride covers the M6 schema:
+// base sets the flat agents.judge, overlay sets a single per-phase
+// override. Only that phase should pick up the new backend; the
+// untouched phases must keep inheriting the base Judge.
+func TestLoadConfigWithOverlay_PerPhaseOverride(t *testing.T) {
+	dir := t.TempDir()
+	base := writeFile(t, dir, "vairdict.yaml", baseYAML)
+	overlay := writeFile(t, dir, "vairdict.ci.yaml", `
+agents:
+  quality_judge: claude-api
+`)
+
+	cfg, err := LoadConfigWithOverlay(base, overlay)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agents.Judge != "claude" {
+		t.Errorf("Judge = %q, want claude (base preserved)", cfg.Agents.Judge)
+	}
+	if cfg.Agents.QualityJudge != "claude-api" {
+		t.Errorf("QualityJudge = %q, want claude-api (overlay)", cfg.Agents.QualityJudge)
+	}
+	if cfg.Agents.PlanJudgeBackend() != "claude" {
+		t.Errorf("PlanJudgeBackend = %q, want claude (untouched)", cfg.Agents.PlanJudgeBackend())
+	}
+	if cfg.Agents.CodeJudgeBackend() != "claude" {
+		t.Errorf("CodeJudgeBackend = %q, want claude (untouched)", cfg.Agents.CodeJudgeBackend())
+	}
+	if cfg.Agents.QualityJudgeBackend() != "claude-api" {
+		t.Errorf("QualityJudgeBackend = %q, want claude-api", cfg.Agents.QualityJudgeBackend())
+	}
+}
+
 func TestLoadConfigWithOverlay_OverlayMissing(t *testing.T) {
 	dir := t.TempDir()
 	base := writeFile(t, dir, "vairdict.yaml", baseYAML)


### PR DESCRIPTION
Closes #128.

Adds optional plan_judge / code_judge / quality_judge fields to
agents.* so each phase can pin a different backend (claude-cli vs
claude-api), while keeping the flat agents.judge as the shorthand
default. resolveCompleter now takes a role and reads the right field
per phase. validateBackends runs at vairdict run startup and fails
fast on missing claude binary, missing ANTHROPIC_API_KEY, or unknown
backend names — naming the offending role and the missing
requirement. Smart defaults (claude/auto/empty) are exempt so
auto-resolution still falls through when one family is unavailable.

https://claude.ai/code/session_01D3JS6fSmmW7BaWrQtSpkFL