### PR TITLE
feat(github): auto-resolve prior bot review threads before posting

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -379,7 +379,8 @@ func (c *Client) deletePreviousVerdicts(ctx context.Context, prNumber int) {
 // authenticated user's login. The viewer login is used to filter threads
 // down to ones authored by the current actor (the VAIrdict bot in CI;
 // a human running `vairdict review` locally) so we never resolve another
-// reviewer's threads.
+// reviewer's threads. comments.totalCount lets us distinguish a solo
+// bot comment from a thread someone has replied to.
 const reviewThreadsQuery = `query ($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
   viewer { login }
   repository(owner: $owner, name: $repo) {
@@ -389,7 +390,7 @@ const reviewThreadsQuery = `query ($owner: String!, $repo: String!, $pr: Int!, $
         nodes {
           id
           isResolved
-          comments(first: 1) { nodes { author { login } } }
+          comments(first: 1) { totalCount nodes { author { login } } }
         }
       }
     }
@@ -418,7 +419,8 @@ type reviewThreadsResponse struct {
 						ID         string `json:"id"`
 						IsResolved bool   `json:"isResolved"`
 						Comments   struct {
-							Nodes []struct {
+							TotalCount int `json:"totalCount"`
+							Nodes      []struct {
 								Author struct {
 									Login string `json:"login"`
 								} `json:"author"`
@@ -491,6 +493,12 @@ func (c *Client) listUnresolvedSelfThreadIDs(ctx context.Context, prNumber int) 
 				continue
 			}
 			if !strings.EqualFold(node.Comments.Nodes[0].Author.Login, viewer) {
+				continue
+			}
+			// Preserve threads someone has replied to. totalCount > 1
+			// means the bot's original comment has at least one reply
+			// — auto-resolving would hide ongoing discussion.
+			if node.Comments.TotalCount > 1 {
 				continue
 			}
 			ids = append(ids, node.ID)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -375,6 +375,170 @@ func (c *Client) deletePreviousVerdicts(ctx context.Context, prNumber int) {
 	}
 }
 
+// reviewThreadsQuery fetches review threads on a PR along with the
+// authenticated user's login. The viewer login is used to filter threads
+// down to ones authored by the current actor (the VAIrdict bot in CI;
+// a human running `vairdict review` locally) so we never resolve another
+// reviewer's threads.
+const reviewThreadsQuery = `query ($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+  viewer { login }
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) { nodes { author { login } } }
+        }
+      }
+    }
+  }
+}`
+
+const resolveReviewThreadMutation = `mutation ($id: ID!) {
+  resolveReviewThread(input: {threadId: $id}) { thread { id } }
+}`
+
+// reviewThreadsResponse mirrors the GraphQL shape we care about. Extra
+// fields are tolerated.
+type reviewThreadsResponse struct {
+	Data struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+					Nodes []struct {
+						ID         string `json:"id"`
+						IsResolved bool   `json:"isResolved"`
+						Comments   struct {
+							Nodes []struct {
+								Author struct {
+									Login string `json:"login"`
+								} `json:"author"`
+							} `json:"nodes"`
+						} `json:"comments"`
+					} `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// resolveOwnerRepo returns "owner/name" for the current repo via gh.
+// Used by the GraphQL helpers because gh's REST {owner}/{repo}
+// placeholder substitution doesn't extend to the graphql endpoint.
+func (c *Client) resolveOwnerRepo(ctx context.Context) (string, string, error) {
+	out, err := c.runner.Run(ctx, "gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+	if err != nil {
+		return "", "", fmt.Errorf("resolving repo: %w", err)
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected nameWithOwner output: %q", string(out))
+	}
+	return parts[0], parts[1], nil
+}
+
+// listUnresolvedSelfThreadIDs walks every review thread on prNumber and
+// returns the GraphQL node IDs of those that are (a) not yet resolved
+// and (b) authored by the currently authenticated gh user. Pagination
+// is followed transparently. Filtering on "viewer" — rather than a
+// hardcoded bot login — keeps the helper symmetric for human use of
+// `vairdict review` and for the bot in CI.
+func (c *Client) listUnresolvedSelfThreadIDs(ctx context.Context, prNumber int) ([]string, error) {
+	owner, repo, err := c.resolveOwnerRepo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	cursor := ""
+	for {
+		args := []string{
+			"api", "graphql",
+			"-f", "owner=" + owner,
+			"-f", "repo=" + repo,
+			"-F", fmt.Sprintf("pr=%d", prNumber),
+			"-f", "query=" + reviewThreadsQuery,
+		}
+		if cursor != "" {
+			args = append(args, "-f", "cursor="+cursor)
+		}
+		out, err := c.runner.Run(ctx, "gh", args...)
+		if err != nil {
+			return nil, fmt.Errorf("listing review threads on PR #%d: %w", prNumber, err)
+		}
+
+		var resp reviewThreadsResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			return nil, fmt.Errorf("decoding review threads response: %w", err)
+		}
+
+		viewer := resp.Data.Viewer.Login
+		threads := resp.Data.Repository.PullRequest.ReviewThreads
+		for _, node := range threads.Nodes {
+			if node.IsResolved {
+				continue
+			}
+			if len(node.Comments.Nodes) == 0 {
+				continue
+			}
+			if !strings.EqualFold(node.Comments.Nodes[0].Author.Login, viewer) {
+				continue
+			}
+			ids = append(ids, node.ID)
+		}
+
+		if !threads.PageInfo.HasNextPage || threads.PageInfo.EndCursor == "" {
+			break
+		}
+		cursor = threads.PageInfo.EndCursor
+	}
+	return ids, nil
+}
+
+// resolveReviewThread marks the GraphQL review thread with the given
+// node ID as resolved. Idempotent at the API level — calling it twice
+// is a no-op.
+func (c *Client) resolveReviewThread(ctx context.Context, threadID string) error {
+	_, err := c.runner.Run(ctx, "gh", "api", "graphql",
+		"-f", "id="+threadID,
+		"-f", "query="+resolveReviewThreadMutation,
+	)
+	if err != nil {
+		return fmt.Errorf("resolving review thread %s: %w", threadID, err)
+	}
+	return nil
+}
+
+// resolveSelfReviewThreads resolves every unresolved review thread on
+// prNumber that the current actor authored. Mirrors the best-effort
+// posture of deletePreviousVerdicts — failures are logged at debug,
+// never bubbled up: the new review must still be posted even if
+// thread cleanup fails (e.g. fine-grained PAT without write:discussion,
+// API hiccup, etc.).
+func (c *Client) resolveSelfReviewThreads(ctx context.Context, prNumber int) {
+	ids, err := c.listUnresolvedSelfThreadIDs(ctx, prNumber)
+	if err != nil {
+		slog.Debug("failed to list prior review threads for cleanup", "pr", prNumber, "error", err)
+		return
+	}
+	for _, id := range ids {
+		if err := c.resolveReviewThread(ctx, id); err != nil {
+			slog.Debug("failed to resolve prior review thread", "id", id, "error", err)
+			continue
+		}
+		slog.Debug("resolved prior review thread", "id", id)
+	}
+}
+
 // InlineComment represents a single inline review comment on a PR diff.
 type InlineComment struct {
 	Path     string `json:"path"`
@@ -399,6 +563,11 @@ func (c *Client) PostVerdict(ctx context.Context, prNumber int, verdict *state.V
 // the same review as the verdict summary — a single cohesive review.
 func (c *Client) PostVerdictWithDiff(ctx context.Context, prNumber int, verdict *state.Verdict, phase state.Phase, loop int, diff string) error {
 	c.deletePreviousVerdicts(ctx, prNumber)
+	// Cleans up inline review threads from any previous review the
+	// current actor posted on this PR. Without this, every push leaves
+	// the prior round's nits visible alongside the new ones — see
+	// https://github.com/vairdict/vairdict/pull/138 for the symptom.
+	c.resolveSelfReviewThreads(ctx, prNumber)
 
 	// Build inline comments from gaps with file:line info.
 	var inlineResult *InlineReviewResult

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1211,3 +1211,338 @@ func containsStr(s, substr string) bool {
 	}
 	return false
 }
+
+// --- Issue: dedupe bot review threads across pushes ---
+
+// twoPageThreadResponse returns two pages of unresolved + viewer-authored
+// threads + a couple noise threads (resolved, other-author) so the test
+// asserts both filtering and pagination.
+const firstPageThreadResponse = `{
+  "data": {
+    "viewer": {"login": "vairdict[bot]"},
+    "repository": {"pullRequest": {"reviewThreads": {
+      "pageInfo": {"hasNextPage": true, "endCursor": "CURSOR1"},
+      "nodes": [
+        {"id": "T1", "isResolved": false, "comments": {"nodes": [{"author": {"login": "vairdict[bot]"}}]}},
+        {"id": "T2-resolved", "isResolved": true, "comments": {"nodes": [{"author": {"login": "vairdict[bot]"}}]}},
+        {"id": "T3-otheruser", "isResolved": false, "comments": {"nodes": [{"author": {"login": "someone-else"}}]}}
+      ]
+    }}}
+  }
+}`
+
+const secondPageThreadResponse = `{
+  "data": {
+    "viewer": {"login": "vairdict[bot]"},
+    "repository": {"pullRequest": {"reviewThreads": {
+      "pageInfo": {"hasNextPage": false, "endCursor": null},
+      "nodes": [
+        {"id": "T4", "isResolved": false, "comments": {"nodes": [{"author": {"login": "vairdict[bot]"}}]}}
+      ]
+    }}}
+  }
+}`
+
+func TestListUnresolvedSelfThreadIDs_FiltersAndPaginates(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh repo": {Output: []byte("vairdict/vairdict\n")},
+		},
+		Sequence: map[string][]fakeResponse{
+			"gh api graphql": {
+				{Output: []byte(firstPageThreadResponse)},
+				{Output: []byte(secondPageThreadResponse)},
+			},
+		},
+	}
+	client := New(runner)
+
+	ids, err := client.listUnresolvedSelfThreadIDs(context.Background(), 138)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"T1", "T4"}
+	if len(ids) != len(want) {
+		t.Fatalf("ids = %v, want %v", ids, want)
+	}
+	for i, id := range want {
+		if ids[i] != id {
+			t.Errorf("ids[%d] = %q, want %q", i, ids[i], id)
+		}
+	}
+	// Sanity: the second graphql call should pass the cursor from page 1.
+	graphqlCalls := 0
+	sawCursor := false
+	for _, c := range runner.Calls {
+		if c.Name == "gh" && len(c.Args) >= 2 && c.Args[0] == "api" && c.Args[1] == "graphql" {
+			graphqlCalls++
+			for _, a := range c.Args {
+				if a == "cursor=CURSOR1" {
+					sawCursor = true
+				}
+			}
+		}
+	}
+	if graphqlCalls != 2 {
+		t.Errorf("expected 2 graphql calls (paginated), got %d", graphqlCalls)
+	}
+	if !sawCursor {
+		t.Errorf("expected page 2 to pass cursor=CURSOR1, args were: %+v", runner.Calls)
+	}
+}
+
+func TestListUnresolvedSelfThreadIDs_Empty(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh repo": {Output: []byte("vairdict/vairdict\n")},
+			"gh api graphql": {Output: []byte(`{
+  "data": {
+    "viewer": {"login": "vairdict[bot]"},
+    "repository": {"pullRequest": {"reviewThreads": {
+      "pageInfo": {"hasNextPage": false, "endCursor": null},
+      "nodes": []
+    }}}
+  }
+}`)},
+		},
+	}
+	client := New(runner)
+
+	ids, err := client.listUnresolvedSelfThreadIDs(context.Background(), 138)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected empty slice, got %v", ids)
+	}
+}
+
+func TestListUnresolvedSelfThreadIDs_RepoLookupError(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh repo": {Err: errors.New("not in a git repo")},
+		},
+	}
+	client := New(runner)
+
+	_, err := client.listUnresolvedSelfThreadIDs(context.Background(), 138)
+	if err == nil {
+		t.Fatal("expected error when gh repo view fails")
+	}
+}
+
+func TestListUnresolvedSelfThreadIDs_GraphqlError(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh repo":        {Output: []byte("vairdict/vairdict\n")},
+			"gh api graphql": {Err: errors.New("graphql 500")},
+		},
+	}
+	client := New(runner)
+
+	_, err := client.listUnresolvedSelfThreadIDs(context.Background(), 138)
+	if err == nil {
+		t.Fatal("expected error when graphql query fails")
+	}
+}
+
+func TestResolveReviewThread_SendsMutation(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh api graphql": {Output: []byte(`{"data":{"resolveReviewThread":{"thread":{"id":"T1"}}}}`)},
+		},
+	}
+	client := New(runner)
+
+	err := client.resolveReviewThread(context.Background(), "T1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Must have called gh api graphql with the thread id parameter.
+	found := false
+	for _, c := range runner.Calls {
+		if c.Name != "gh" || len(c.Args) < 2 || c.Args[0] != "api" || c.Args[1] != "graphql" {
+			continue
+		}
+		for _, a := range c.Args {
+			if a == "id=T1" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected mutation arg id=T1, calls: %+v", runner.Calls)
+	}
+}
+
+func TestResolveReviewThread_PropagatesError(t *testing.T) {
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh api graphql": {Err: errors.New("forbidden")},
+		},
+	}
+	client := New(runner)
+
+	err := client.resolveReviewThread(context.Background(), "T1")
+	if err == nil {
+		t.Fatal("expected error from gh api graphql failure")
+	}
+}
+
+func TestResolveSelfReviewThreads_ResolvesEachListedID(t *testing.T) {
+	// Single graphql list response with two viewer-authored threads,
+	// followed by two graphql mutation responses. Sequence drives the
+	// list-then-resolve order on the same key.
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh repo": {Output: []byte("vairdict/vairdict\n")},
+		},
+		Sequence: map[string][]fakeResponse{
+			"gh api graphql": {
+				{Output: []byte(`{
+  "data": {
+    "viewer": {"login": "vairdict[bot]"},
+    "repository": {"pullRequest": {"reviewThreads": {
+      "pageInfo": {"hasNextPage": false, "endCursor": null},
+      "nodes": [
+        {"id": "T1", "isResolved": false, "comments": {"nodes": [{"author": {"login": "vairdict[bot]"}}]}},
+        {"id": "T2", "isResolved": false, "comments": {"nodes": [{"author": {"login": "vairdict[bot]"}}]}}
+      ]
+    }}}
+  }
+}`)},
+				{Output: []byte(`{"data":{"resolveReviewThread":{"thread":{"id":"T1"}}}}`)},
+				{Output: []byte(`{"data":{"resolveReviewThread":{"thread":{"id":"T2"}}}}`)},
+			},
+		},
+	}
+	client := New(runner)
+
+	client.resolveSelfReviewThreads(context.Background(), 138)
+
+	// Should have called: 1 list + 2 resolve = 3 graphql calls.
+	graphqlCalls := 0
+	resolveIDs := []string{}
+	for _, c := range runner.Calls {
+		if c.Name == "gh" && len(c.Args) >= 2 && c.Args[0] == "api" && c.Args[1] == "graphql" {
+			graphqlCalls++
+			for _, a := range c.Args {
+				if strings.HasPrefix(a, "id=") {
+					resolveIDs = append(resolveIDs, strings.TrimPrefix(a, "id="))
+				}
+			}
+		}
+	}
+	if graphqlCalls != 3 {
+		t.Errorf("expected 1 list + 2 resolve = 3 graphql calls, got %d", graphqlCalls)
+	}
+	if len(resolveIDs) != 2 || resolveIDs[0] != "T1" || resolveIDs[1] != "T2" {
+		t.Errorf("expected resolve(T1) then resolve(T2), got %v", resolveIDs)
+	}
+}
+
+func TestResolveSelfReviewThreads_ListErrorIsSwallowed(t *testing.T) {
+	// Best-effort: a list error must NOT block subsequent posting flow.
+	// We assert by simply checking the call returns without panicking
+	// and no resolve mutation runs.
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh repo": {Err: errors.New("not in a git repo")},
+		},
+	}
+	client := New(runner)
+
+	// Should not panic, should not return.
+	client.resolveSelfReviewThreads(context.Background(), 138)
+
+	for _, c := range runner.Calls {
+		if c.Name == "gh" && len(c.Args) >= 2 && c.Args[0] == "api" && c.Args[1] == "graphql" {
+			t.Errorf("unexpected graphql call after list error: %+v", c)
+		}
+	}
+}
+
+func TestPostVerdictWithDiff_ResolvesPriorThreadsBeforePosting(t *testing.T) {
+	// End-to-end check: the post path resolves stale viewer-authored
+	// threads BEFORE posting a new review so users only see the latest
+	// review's findings.
+	diff := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1,3 +1,4 @@
+ a
+ b
++c
+ d
+`
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"git rev-parse": {Output: []byte(".git")},
+			"git remote":    {Output: []byte("https://github.com/vairdict/vairdict")},
+			"gh auth":       {Output: []byte("ok")},
+			"gh pr review":  {Output: []byte("ok")},
+			"gh pr comment": {Output: []byte("ok")},
+			"gh repo":       {Output: []byte("vairdict/vairdict\n")},
+		},
+		Sequence: map[string][]fakeResponse{
+			// First graphql call = list. Returns one stale unresolved thread.
+			// Second graphql call = the resolveReviewThread mutation for T-stale.
+			"gh api graphql": {
+				{Output: []byte(`{
+  "data": {
+    "viewer": {"login": "vairdict[bot]"},
+    "repository": {"pullRequest": {"reviewThreads": {
+      "pageInfo": {"hasNextPage": false, "endCursor": null},
+      "nodes": [
+        {"id": "T-stale", "isResolved": false, "comments": {"nodes": [{"author": {"login": "vairdict[bot]"}}]}}
+      ]
+    }}}
+  }
+}`)},
+				{Output: []byte(`{"data":{"resolveReviewThread":{"thread":{"id":"T-stale"}}}}`)},
+			},
+		},
+	}
+	client := New(runner)
+
+	verdict := &state.Verdict{
+		Score: 80,
+		Pass:  true,
+		Gaps: []state.Gap{
+			{Severity: state.SeverityP2, Description: "tiny nit", Blocking: false, File: "foo.go", Line: 3},
+		},
+	}
+
+	if err := client.PostVerdictWithDiff(context.Background(), 7, verdict, state.PhaseQuality, 1, diff); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find the index of the resolveReviewThread call (id=T-stale) and the
+	// review-post call (gh api .../reviews). Resolve must happen before post.
+	resolveIdx, postIdx := -1, -1
+	for i, c := range runner.Calls {
+		if c.Name == "gh" && len(c.Args) >= 2 && c.Args[0] == "api" && c.Args[1] == "graphql" {
+			for _, a := range c.Args {
+				if a == "id=T-stale" {
+					resolveIdx = i
+				}
+			}
+		}
+		if c.Name == "gh" && len(c.Args) >= 2 && c.Args[0] == "api" {
+			for _, a := range c.Args {
+				if strings.Contains(a, "/reviews") {
+					postIdx = i
+				}
+			}
+		}
+	}
+	if resolveIdx < 0 {
+		t.Fatalf("expected a resolveReviewThread mutation; calls: %+v", runner.Calls)
+	}
+	if postIdx < 0 {
+		t.Fatalf("expected a review POST call; calls: %+v", runner.Calls)
+	}
+	if resolveIdx >= postIdx {
+		t.Errorf("resolveReviewThread (idx %d) must run BEFORE review POST (idx %d)", resolveIdx, postIdx)
+	}
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1243,6 +1243,38 @@ const secondPageThreadResponse = `{
   }
 }`
 
+func TestListUnresolvedSelfThreadIDs_SkipsThreadsWithReplies(t *testing.T) {
+	// A thread the bot started but a human replied to should NOT be
+	// auto-resolved — that would hide ongoing discussion. Detected via
+	// comments.totalCount > 1 on the GraphQL response.
+	runner := &FakeRunner{
+		Responses: map[string]fakeResponse{
+			"gh repo": {Output: []byte("vairdict/vairdict\n")},
+			"gh api graphql": {Output: []byte(`{
+  "data": {
+    "viewer": {"login": "vairdict[bot]"},
+    "repository": {"pullRequest": {"reviewThreads": {
+      "pageInfo": {"hasNextPage": false, "endCursor": null},
+      "nodes": [
+        {"id": "T-replied", "isResolved": false, "comments": {"totalCount": 2, "nodes": [{"author": {"login": "vairdict[bot]"}}]}},
+        {"id": "T-solo",    "isResolved": false, "comments": {"totalCount": 1, "nodes": [{"author": {"login": "vairdict[bot]"}}]}}
+      ]
+    }}}
+  }
+}`)},
+		},
+	}
+	client := New(runner)
+
+	ids, err := client.listUnresolvedSelfThreadIDs(context.Background(), 138)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "T-solo" {
+		t.Errorf("ids = %v, want [T-solo] (T-replied has a human reply and must be preserved)", ids)
+	}
+}
+
 func TestListUnresolvedSelfThreadIDs_FiltersAndPaginates(t *testing.T) {
 	runner := &FakeRunner{
 		Responses: map[string]fakeResponse{

--- a/internal/github/fake.go
+++ b/internal/github/fake.go
@@ -4,8 +4,16 @@ import "context"
 
 // FakeRunner records commands and returns configurable responses.
 type FakeRunner struct {
+	// Responses maps a command key to a single canned response. Reused
+	// across every matching call.
 	Responses map[string]fakeResponse
-	Calls     []FakeCall
+	// Sequence is consumed in order: each matching call pops the head
+	// of the slice. Useful for paginated APIs or list-then-resolve
+	// flows where the same command shape is called multiple times
+	// with different arguments. Sequence wins over Responses when both
+	// match the same key.
+	Sequence map[string][]fakeResponse
+	Calls    []FakeCall
 }
 
 type fakeResponse struct {
@@ -23,23 +31,41 @@ type FakeCall struct {
 func (f *FakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	f.Calls = append(f.Calls, FakeCall{Name: name, Args: args})
 
-	// Build lookup keys from most specific to least.
-	key := name
+	keys := []string{name}
 	if len(args) > 0 {
-		key = name + " " + args[0]
+		keys = append([]string{name + " " + args[0]}, keys...)
 	}
 	if len(args) > 1 {
-		specific := name + " " + args[0] + " " + args[1]
-		if resp, ok := f.Responses[specific]; ok {
+		keys = append([]string{name + " " + args[0] + " " + args[1]}, keys...)
+	}
+
+	// Sequence wins over Responses so tests can drive multi-call
+	// flows (pagination, list-then-resolve) without bespoke runners.
+	for _, k := range keys {
+		if resp, ok := popSeq(f.Sequence, k); ok {
 			return resp.Output, resp.Err
 		}
 	}
-	if resp, ok := f.Responses[key]; ok {
-		return resp.Output, resp.Err
+	for _, k := range keys {
+		if resp, ok := f.Responses[k]; ok {
+			return resp.Output, resp.Err
+		}
 	}
-	if resp, ok := f.Responses[name]; ok {
-		return resp.Output, resp.Err
-	}
-
 	return nil, nil
+}
+
+// popSeq pulls the head of the queue at key, mutating the map. Returns
+// (zero, false) when the key is missing or its queue is empty so the
+// caller can fall through to the single-shot Responses map.
+func popSeq(m map[string][]fakeResponse, key string) (fakeResponse, bool) {
+	if m == nil {
+		return fakeResponse{}, false
+	}
+	seq := m[key]
+	if len(seq) == 0 {
+		return fakeResponse{}, false
+	}
+	resp := seq[0]
+	m[key] = seq[1:]
+	return resp, true
 }


### PR DESCRIPTION
## Summary
- Auto-resolves prior bot review threads on a PR before posting a new review, so each push starts from a clean slate and only the latest review's findings are visible.
- Adds two GraphQL helpers (`listUnresolvedSelfThreadIDs`, `resolveReviewThread`) plus a best-effort wrapper (`resolveSelfReviewThreads`) wired into `PostVerdictWithDiff`. Failures are logged at debug and never block posting, mirroring the existing `deletePreviousVerdicts` pattern.
- Filtering on the gh "viewer" login keeps the helper symmetric: in CI the bot only resolves its own threads; locally a human running `vairdict review` only resolves theirs — never another reviewer's.

## Why
Every push the bot reviewed left the prior round's inline nits visible alongside the new ones (see #138 for the symptom — 6 unresolved threads after just 2 pushes). The bot was effectively stacking findings across runs even when each individual review was fine.

## Test plan
- [x] 9 new unit tests in `internal/github/client_test.go` covering: filter-resolved-and-other-authors, pagination across cursor, empty, repo-lookup error, graphql query error, mutation send, mutation error, list+resolve sequence, end-to-end ordering inside `PostVerdictWithDiff` (resolve runs before post).
- [x] `FakeRunner` extended with a `Sequence` map for multi-call flows on the same command key; existing tests unchanged.
- [x] `go test ./...` green (excluding the pre-existing sandbox-related `workspace`/`conflicts` git-signing failures unrelated to this change).
- [x] `go vet`, `gofmt`, `go build` all clean.

https://claude.ai/code/session_01D3JS6fSmmW7BaWrQtSpkFL

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3JS6fSmmW7BaWrQtSpkFL)_