### PR TITLE
feat(judges): swap judge model independently of completer (#129)

### DIFF
--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -27,11 +27,14 @@ import (
 
 // completer is the narrow interface that the plan / quality judges and the
 // plan phase's Planner all share. Both claude.Client and claudecli.Client
-// satisfy it structurally.
+// satisfy it structurally. Model() is exposed so judges can stamp the
+// verdict with the model that produced it without each call site
+// having to plumb the resolved model through separately.
 type completer interface {
 	CompleteWithSystem(ctx context.Context, system, prompt string, target any) error
 	CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
 	CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, handlers map[string]claude.ToolHandler, target any) error
+	Model() string
 }
 
 // completerRole names a completer slot in the orchestration pipeline.
@@ -75,6 +78,29 @@ func backendForRole(cfg *config.Config, role completerRole) string {
 	}
 }
 
+// modelForRole returns the model name the given role should pin. The
+// planner shares the global agents.model — its output is consumed by
+// a judge anyway, so swapping its model independently is out of scope
+// for this knob. Each judge applies the
+// {plan,code,quality}_judge_model → judge_model → model fallback so a
+// user can grade plans with a stricter model than the one that
+// produced them. Empty string means "let the underlying client pick
+// its default".
+func modelForRole(cfg *config.Config, role completerRole) string {
+	switch role {
+	case rolePlanner:
+		return cfg.Agents.Model
+	case rolePlanJudge:
+		return cfg.Agents.PlanJudgeModelResolved()
+	case roleCodeJudge:
+		return cfg.Agents.CodeJudgeModelResolved()
+	case roleQualityJudge:
+		return cfg.Agents.QualityJudgeModelResolved()
+	default:
+		return ""
+	}
+}
+
 // chooseBackend returns the resolved backend for the given config setting.
 // `cliAvailable` is injected (via claudecli.IsAvailable in production) so
 // the resolver is deterministic and unit-testable without touching PATH.
@@ -108,7 +134,11 @@ func chooseBackendForRole(roleName, setting string, cliAvailable bool) (backendK
 
 // resolveCompleter picks a backend for the given role per chooseBackend
 // and constructs the matching client. The returned backendKind is
-// informational (rendered as a `completer:` note in CLI mode).
+// informational (rendered as a `completer:` note in CLI mode). The
+// model is resolved via modelForRole so a user can swap the judge
+// model independently of the producer model — the override flows into
+// the underlying client (claude.WithModel / claudecli.WithModel) so
+// the actual API call uses it.
 func resolveCompleter(cfg *config.Config, role completerRole) (completer, backendKind, error) {
 	setting := backendForRole(cfg, role)
 	kind, err := chooseBackendForRole("agents."+string(role), setting, claudecli.IsAvailable())
@@ -116,20 +146,30 @@ func resolveCompleter(cfg *config.Config, role completerRole) (completer, backen
 		return nil, "", err
 	}
 
+	model := modelForRole(cfg, role)
+
 	switch kind {
 	case backendClaudeCLI:
 		// --dangerously-skip-permissions lets the subprocess call tools
 		// without interactive prompts, matching the claudecode runner.
-		return claudecli.New(
+		opts := []claudecli.Option{
 			claudecli.WithExtraArgs("--dangerously-skip-permissions"),
-		), kind, nil
+		}
+		if model != "" {
+			opts = append(opts, claudecli.WithModel(model))
+		}
+		return claudecli.New(opts...), kind, nil
 	case backendClaudeAPI:
 		// Judges must be deterministic — temperature=0 removes sampling
 		// variance so the same (prompt, diff) pair produces the same verdict
 		// structure across runs. The planner shares this client, which is
 		// fine: its output is consumed by a judge anyway, so determinism
 		// flows through the whole pipeline.
-		c, err := claude.NewClient(cfg, claude.WithTemperature(0))
+		opts := []claude.Option{claude.WithTemperature(0)}
+		if model != "" {
+			opts = append(opts, claude.WithModel(model))
+		}
+		c, err := claude.NewClient(cfg, opts...)
 		if err != nil {
 			return nil, "", fmt.Errorf("creating claude client: %w", err)
 		}

--- a/cmd/vairdict/completer_test.go
+++ b/cmd/vairdict/completer_test.go
@@ -82,6 +82,118 @@ func TestBackendForRole(t *testing.T) {
 	}
 }
 
+// TestModelForRole: the planner shares agents.model unchanged so swapping
+// the judge model never accidentally rewrites the producer; each judge
+// applies the {plan,code,quality}_judge_model → judge_model → model
+// fallback chain so a single agents.judge_model swaps every judge slot.
+func TestModelForRole(t *testing.T) {
+	// Legacy config: only Model is set. Every role resolves to it.
+	flat := &config.Config{Agents: config.AgentsConfig{
+		Model: "claude-sonnet-4-20250514",
+	}}
+	cases := []struct {
+		role completerRole
+		want string
+	}{
+		{rolePlanner, "claude-sonnet-4-20250514"},
+		{rolePlanJudge, "claude-sonnet-4-20250514"},
+		{roleCodeJudge, "claude-sonnet-4-20250514"},
+		{roleQualityJudge, "claude-sonnet-4-20250514"},
+	}
+	for _, tc := range cases {
+		if got := modelForRole(flat, tc.role); got != tc.want {
+			t.Errorf("flat modelForRole(%s) = %q, want %q", tc.role, got, tc.want)
+		}
+	}
+
+	// judge_model set: judges swap, planner stays on Model. This is the
+	// canonical use case from the issue — judge with a stricter model
+	// while the cheap producer keeps the original.
+	swap := &config.Config{Agents: config.AgentsConfig{
+		Model:      "claude-haiku-4-5",
+		JudgeModel: "claude-opus-4-7",
+	}}
+	if got := modelForRole(swap, rolePlanner); got != "claude-haiku-4-5" {
+		t.Errorf("swap planner = %q, want claude-haiku-4-5 (Model preserved)", got)
+	}
+	if got := modelForRole(swap, rolePlanJudge); got != "claude-opus-4-7" {
+		t.Errorf("swap plan judge = %q, want claude-opus-4-7 (judge_model)", got)
+	}
+	if got := modelForRole(swap, roleQualityJudge); got != "claude-opus-4-7" {
+		t.Errorf("swap quality judge = %q, want claude-opus-4-7 (judge_model)", got)
+	}
+
+	// Per-phase override wins over the global judge_model.
+	mixed := &config.Config{Agents: config.AgentsConfig{
+		Model:             "claude-haiku-4-5",
+		JudgeModel:        "claude-sonnet-4-6",
+		QualityJudgeModel: "claude-opus-4-7",
+	}}
+	if got := modelForRole(mixed, rolePlanJudge); got != "claude-sonnet-4-6" {
+		t.Errorf("mixed plan judge = %q, want claude-sonnet-4-6 (judge_model)", got)
+	}
+	if got := modelForRole(mixed, roleQualityJudge); got != "claude-opus-4-7" {
+		t.Errorf("mixed quality judge = %q, want claude-opus-4-7 (per-phase)", got)
+	}
+}
+
+// TestResolveCompleter_JudgeModelOverride: when judge_model is set, the
+// API client returned for the judge slots is pinned to that model while
+// the planner stays on agents.model. Hits the AC: WithModel reaches the
+// API call, completer calls do not get the judge model.
+func TestResolveCompleter_JudgeModelOverride(t *testing.T) {
+	// API key must be present for claude-api to construct.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-judgemodel")
+
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner:    "claude-api",
+		Judge:      "claude-api",
+		Model:      "claude-haiku-4-5",
+		JudgeModel: "claude-opus-4-7",
+	}}
+
+	planner, _, err := resolveCompleter(cfg, rolePlanner)
+	if err != nil {
+		t.Fatalf("resolveCompleter(planner): %v", err)
+	}
+	if got := planner.Model(); got != "claude-haiku-4-5" {
+		t.Errorf("planner client model = %q, want claude-haiku-4-5 (Model untouched)", got)
+	}
+
+	for _, role := range []completerRole{rolePlanJudge, roleQualityJudge, roleCodeJudge} {
+		c, _, err := resolveCompleter(cfg, role)
+		if err != nil {
+			t.Fatalf("resolveCompleter(%s): %v", role, err)
+		}
+		if got := c.Model(); got != "claude-opus-4-7" {
+			t.Errorf("%s client model = %q, want claude-opus-4-7 (judge_model)", role, got)
+		}
+	}
+}
+
+// TestResolveCompleter_NoJudgeModelInheritsModel: with judge_model unset,
+// every judge falls back to agents.model so existing configs keep
+// working unchanged. AC: configs that only set agents.model keep
+// working — purely additive.
+func TestResolveCompleter_NoJudgeModelInheritsModel(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-fallback")
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude-api",
+		Judge:   "claude-api",
+		Model:   "claude-sonnet-4-20250514",
+	}}
+
+	for _, role := range []completerRole{rolePlanner, rolePlanJudge, roleQualityJudge} {
+		c, _, err := resolveCompleter(cfg, role)
+		if err != nil {
+			t.Fatalf("resolveCompleter(%s): %v", role, err)
+		}
+		if got := c.Model(); got != "claude-sonnet-4-20250514" {
+			t.Errorf("%s client model = %q, want claude-sonnet (Model fallback)", role, got)
+		}
+	}
+}
+
 // TestValidateBackends_FlatOnlyLegacy: a config that only sets the flat
 // fields must validate identically to pre-issue-128 behavior. With CLI
 // available and Judge=claude (smart), no error.

--- a/internal/agents/claude/client.go
+++ b/internal/agents/claude/client.go
@@ -228,6 +228,11 @@ func (c *Client) Complete(ctx context.Context, prompt string, target any) error 
 	return c.CompleteWithSystem(ctx, "", prompt, target)
 }
 
+// Model returns the model name the client sends with each request.
+// Used by judges to stamp the verdict with the model that produced
+// it so PR comments and logs can show which model graded the change.
+func (c *Client) Model() string { return c.model }
+
 // CompleteWithSystem sends a prompt with a system message to the Anthropic
 // Messages API and unmarshals the JSON response into the target struct.
 func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, target any) error {

--- a/internal/agents/claude/fake.go
+++ b/internal/agents/claude/fake.go
@@ -18,7 +18,15 @@ type FakeClient struct {
 
 	// Calls records each prompt sent to Complete for assertions.
 	Calls []FakeCall
+
+	// ModelName is the value Model() reports. Tests that need to
+	// assert verdicts are stamped with the right model set this.
+	ModelName string
 }
+
+// Model returns the configured ModelName so FakeClient satisfies the
+// same {Complete*, Model} interface real clients do.
+func (f *FakeClient) Model() string { return f.ModelName }
 
 // FakeCall records a single invocation of Complete, CompleteWithSystem, or
 // CompleteWithTool. ToolName is empty for non-tool calls.

--- a/internal/agents/claudecli/client.go
+++ b/internal/agents/claudecli/client.go
@@ -79,6 +79,7 @@ type Client struct {
 	timeout    time.Duration
 	cmdFactory CommandFactory
 	extraArgs  []string
+	model      string
 }
 
 // Option configures a Client.
@@ -103,6 +104,14 @@ func WithExtraArgs(args ...string) Option {
 	return func(c *Client) { c.extraArgs = append(c.extraArgs, args...) }
 }
 
+// WithModel pins the Claude CLI subprocess to a specific model via the
+// `--model` flag. Empty string is a no-op (the CLI picks its default).
+// Use this when the judge model must be different from whatever the
+// `claude` install would otherwise select.
+func WithModel(model string) Option {
+	return func(c *Client) { c.model = model }
+}
+
 // New constructs a Client with the given options.
 func New(opts ...Option) *Client {
 	c := &Client{
@@ -122,6 +131,11 @@ func IsAvailable() bool {
 	_, err := exec.LookPath("claude")
 	return err == nil
 }
+
+// Model returns the model the client is pinned to via WithModel, or
+// empty string when the client uses the CLI's default. Callers that
+// stamp verdicts with the model that produced them read this.
+func (c *Client) Model() string { return c.model }
 
 // Complete is a convenience wrapper for CompleteWithSystem with an empty
 // system prompt. It exists so Client satisfies any narrow Completer-style
@@ -214,6 +228,9 @@ func (c *Client) completeWithOpts(ctx context.Context, system, prompt string, no
 	if system != "" {
 		args = append(args, "--append-system-prompt", system)
 	}
+	if c.model != "" {
+		args = append(args, "--model", c.model)
+	}
 	args = append(args, c.extraArgs...)
 	args = append(args, prompt)
 
@@ -290,6 +307,9 @@ func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, 
 	args := []string{"-p", "--output-format", "json"}
 	if system != "" {
 		args = append(args, "--append-system-prompt", system)
+	}
+	if c.model != "" {
+		args = append(args, "--model", c.model)
 	}
 	args = append(args, c.extraArgs...)
 	args = append(args, prompt)

--- a/internal/agents/claudecli/client_test.go
+++ b/internal/agents/claudecli/client_test.go
@@ -218,6 +218,53 @@ func TestCompleteWithSystem_ArgsIncludeSystemAndExtras(t *testing.T) {
 	}
 }
 
+func TestCompleteWithSystem_WithModelAddsFlag(t *testing.T) {
+	// AC: WithModel must reach the actual subprocess invocation. Pinning
+	// the judge model in config has to flow into the claude --model flag
+	// or it doesn't actually do anything.
+	var captured []string
+	envelope := `{"type":"result","is_error":false,"result":"{}"}`
+	c := New(
+		WithModel("claude-opus-4-7"),
+		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			captured = append([]string{name}, args...)
+			return stdoutCmd(ctx, envelope)
+		}),
+	)
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "", "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Model() != "claude-opus-4-7" {
+		t.Errorf("client Model() = %q, want claude-opus-4-7", c.Model())
+	}
+	joined := strings.Join(captured, " ")
+	if !strings.Contains(joined, "--model claude-opus-4-7") {
+		t.Errorf("captured args missing --model claude-opus-4-7: %v", captured)
+	}
+}
+
+func TestCompleteWithSystem_NoModelSkipsFlag(t *testing.T) {
+	// Without WithModel the CLI's default applies — no --model flag.
+	var captured []string
+	envelope := `{"type":"result","is_error":false,"result":"{}"}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		captured = append([]string{name}, args...)
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "", "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, a := range captured {
+		if a == "--model" {
+			t.Errorf("client without WithModel must not add --model flag: %v", captured)
+		}
+	}
+}
+
 func TestCompleteWithSystem_NoSystemPromptSkipsFlag(t *testing.T) {
 	var captured []string
 	envelope := `{"type":"result","is_error":false,"result":"{}"}`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,21 @@ type AgentsConfig struct {
 	PlanJudge    string `yaml:"plan_judge,omitempty"`
 	CodeJudge    string `yaml:"code_judge,omitempty"`
 	QualityJudge string `yaml:"quality_judge,omitempty"`
+
+	// JudgeModel pins a model for every judge slot, overriding Model.
+	// Per-phase fields below override JudgeModel for that slot only.
+	// All judge_*_model fields fall back to JudgeModel, then to Model,
+	// so configs that only set Model keep working unchanged.
+	//
+	// CodeJudgeModel is reserved for parity with the per-phase judge
+	// backend fields; the current code judge runs deterministic shell
+	// checks (lint/test/build) and does not call an LLM, so the value
+	// is accepted but unused until a future LLM-backed code judge
+	// lands.
+	JudgeModel        string `yaml:"judge_model,omitempty"`
+	PlanJudgeModel    string `yaml:"plan_judge_model,omitempty"`
+	CodeJudgeModel    string `yaml:"code_judge_model,omitempty"`
+	QualityJudgeModel string `yaml:"quality_judge_model,omitempty"`
 }
 
 // PlanJudgeBackend returns the backend setting for the plan judge,
@@ -75,6 +90,39 @@ func (a AgentsConfig) QualityJudgeBackend() string {
 		return a.QualityJudge
 	}
 	return a.Judge
+}
+
+// PlanJudgeModelResolved returns the model the plan judge should use,
+// applying the fallback chain plan_judge_model → judge_model → model.
+// Empty string means "let the underlying client pick its default".
+func (a AgentsConfig) PlanJudgeModelResolved() string {
+	return firstNonEmpty(a.PlanJudgeModel, a.JudgeModel, a.Model)
+}
+
+// CodeJudgeModelResolved mirrors PlanJudgeModelResolved for the code
+// judge slot. The current code judge does not call an LLM so the value
+// is unused at runtime; the resolver exists so configs are accepted
+// uniformly and the field can be wired the day an LLM-backed code
+// judge lands.
+func (a AgentsConfig) CodeJudgeModelResolved() string {
+	return firstNonEmpty(a.CodeJudgeModel, a.JudgeModel, a.Model)
+}
+
+// QualityJudgeModelResolved returns the model the quality judge should
+// use, applying the fallback chain quality_judge_model → judge_model
+// → model. Empty string means "let the underlying client pick its
+// default".
+func (a AgentsConfig) QualityJudgeModelResolved() string {
+	return firstNonEmpty(a.QualityJudgeModel, a.JudgeModel, a.Model)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 type EnvironmentConfig struct {
@@ -366,6 +414,18 @@ func Merge(base *Config, overrides Config) *Config {
 	}
 	if overrides.Agents.QualityJudge != "" {
 		merged.Agents.QualityJudge = overrides.Agents.QualityJudge
+	}
+	if overrides.Agents.JudgeModel != "" {
+		merged.Agents.JudgeModel = overrides.Agents.JudgeModel
+	}
+	if overrides.Agents.PlanJudgeModel != "" {
+		merged.Agents.PlanJudgeModel = overrides.Agents.PlanJudgeModel
+	}
+	if overrides.Agents.CodeJudgeModel != "" {
+		merged.Agents.CodeJudgeModel = overrides.Agents.CodeJudgeModel
+	}
+	if overrides.Agents.QualityJudgeModel != "" {
+		merged.Agents.QualityJudgeModel = overrides.Agents.QualityJudgeModel
 	}
 
 	// Environment

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -420,6 +420,101 @@ func TestMerge_PerPhaseJudges(t *testing.T) {
 	}
 }
 
+func TestAgentsConfig_JudgeModelFallback(t *testing.T) {
+	// Existing-config shape: only Model is set. Every judge resolves to
+	// it. Guards AC: configs that only set agents.model keep working.
+	flat := AgentsConfig{Model: "claude-sonnet-4-20250514"}
+	if got := flat.PlanJudgeModelResolved(); got != "claude-sonnet-4-20250514" {
+		t.Errorf("flat plan judge model = %q, want claude-sonnet (Model fallback)", got)
+	}
+	if got := flat.CodeJudgeModelResolved(); got != "claude-sonnet-4-20250514" {
+		t.Errorf("flat code judge model = %q, want claude-sonnet (Model fallback)", got)
+	}
+	if got := flat.QualityJudgeModelResolved(); got != "claude-sonnet-4-20250514" {
+		t.Errorf("flat quality judge model = %q, want claude-sonnet (Model fallback)", got)
+	}
+
+	// JudgeModel pins all judges; Model stays as the producer model so
+	// `agents.judge_model` is the one knob that swaps every judge.
+	withGlobalJudge := AgentsConfig{
+		Model:      "claude-haiku-4-5",
+		JudgeModel: "claude-opus-4-7",
+	}
+	if got := withGlobalJudge.PlanJudgeModelResolved(); got != "claude-opus-4-7" {
+		t.Errorf("plan judge model with judge_model = %q, want claude-opus", got)
+	}
+	if got := withGlobalJudge.QualityJudgeModelResolved(); got != "claude-opus-4-7" {
+		t.Errorf("quality judge model with judge_model = %q, want claude-opus", got)
+	}
+
+	// Per-phase wins over global judge_model wins over model — the AC
+	// fallback chain. quality_judge_model overrides; plan inherits the
+	// global judge_model; the producer model (Model) never leaks into a
+	// judge slot when judge_model is set.
+	mixed := AgentsConfig{
+		Model:             "claude-haiku-4-5",
+		JudgeModel:        "claude-sonnet-4-6",
+		QualityJudgeModel: "claude-opus-4-7",
+	}
+	if got := mixed.PlanJudgeModelResolved(); got != "claude-sonnet-4-6" {
+		t.Errorf("plan judge model = %q, want claude-sonnet-4-6 (judge_model fallback)", got)
+	}
+	if got := mixed.QualityJudgeModelResolved(); got != "claude-opus-4-7" {
+		t.Errorf("quality judge model = %q, want claude-opus-4-7 (per-phase override)", got)
+	}
+}
+
+func TestParseConfig_JudgeModelFields(t *testing.T) {
+	data := []byte(`
+project:
+  name: judgemodel
+agents:
+  model: claude-sonnet-4-20250514
+  judge_model: claude-opus-4-7
+  plan_judge_model: claude-sonnet-4-6
+  quality_judge_model: claude-opus-4-7
+`)
+	cfg, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agents.JudgeModel != "claude-opus-4-7" {
+		t.Errorf("judge_model = %q, want claude-opus-4-7", cfg.Agents.JudgeModel)
+	}
+	if cfg.Agents.PlanJudgeModel != "claude-sonnet-4-6" {
+		t.Errorf("plan_judge_model = %q, want claude-sonnet-4-6", cfg.Agents.PlanJudgeModel)
+	}
+	if cfg.Agents.QualityJudgeModel != "claude-opus-4-7" {
+		t.Errorf("quality_judge_model = %q, want claude-opus-4-7", cfg.Agents.QualityJudgeModel)
+	}
+}
+
+func TestMerge_JudgeModelOverlay(t *testing.T) {
+	// Overlay (e.g. vairdict.ci.yaml) introduces a stricter judge model
+	// while leaving the producer model alone — the canonical use case
+	// from the issue: "swap the judge model in CI without touching the
+	// completer's model".
+	base := Defaults()
+	base.Project.Name = "base"
+	base.Agents.Model = "claude-haiku-4-5"
+
+	overrides := Config{
+		Agents: AgentsConfig{
+			JudgeModel: "claude-opus-4-7",
+		},
+	}
+	merged := Merge(&base, overrides)
+	if merged.Agents.Model != "claude-haiku-4-5" {
+		t.Errorf("model = %q, want claude-haiku-4-5 (producer preserved)", merged.Agents.Model)
+	}
+	if merged.Agents.JudgeModel != "claude-opus-4-7" {
+		t.Errorf("judge_model = %q, want claude-opus-4-7", merged.Agents.JudgeModel)
+	}
+	if got := merged.Agents.PlanJudgeModelResolved(); got != "claude-opus-4-7" {
+		t.Errorf("plan judge model = %q, want claude-opus-4-7", got)
+	}
+}
+
 func TestMerge_DoesNotMutateBase(t *testing.T) {
 	base := Defaults()
 	base.Project.Name = "original"

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -619,7 +619,7 @@ func (c *Client) PostVerdictWithDiff(ctx context.Context, prNumber int, verdict 
 			slog.Warn("review with inline comments failed, falling back to plain comment",
 				"pr", prNumber, "inline_comments", len(inlineComments), "error", err)
 		} else {
-			slog.Info("verdict posted", "pr", prNumber, "pass", verdict.Pass, "score", verdict.Score, "mode", "review", "inline_comments", len(inlineComments))
+			slog.Info("verdict posted", "pr", prNumber, "pass", verdict.Pass, "score", verdict.Score, "model", verdict.Model, "mode", "review", "inline_comments", len(inlineComments))
 			return nil
 		}
 	}
@@ -629,7 +629,7 @@ func (c *Client) PostVerdictWithDiff(ctx context.Context, prNumber int, verdict 
 	if verdict.Pass {
 		err := c.ApprovePR(ctx, prNumber, comment)
 		if err == nil {
-			slog.Info("verdict posted", "pr", prNumber, "pass", true, "score", verdict.Score, "mode", "approval")
+			slog.Info("verdict posted", "pr", prNumber, "pass", true, "score", verdict.Score, "model", verdict.Model, "mode", "approval")
 			return nil
 		}
 		// Approval denied (self-authored PR, Actions token, etc).
@@ -640,7 +640,7 @@ func (c *Client) PostVerdictWithDiff(ctx context.Context, prNumber int, verdict 
 	if err := c.AddComment(ctx, prNumber, comment); err != nil {
 		return fmt.Errorf("posting verdict comment: %w", err)
 	}
-	slog.Info("verdict posted", "pr", prNumber, "pass", verdict.Pass, "score", verdict.Score, "mode", "comment")
+	slog.Info("verdict posted", "pr", prNumber, "pass", verdict.Pass, "score", verdict.Score, "model", verdict.Model, "mode", "comment")
 	return nil
 }
 
@@ -897,8 +897,14 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int, i
 		fmt.Fprintf(&b, "<h2><img src=\"%s\" alt=\"VAIrdict\" height=\"24\"> VAIrdict Verdict: ❌ FAIL</h2>\n\n", LogoURL)
 	}
 
-	// Summary line.
-	fmt.Fprintf(&b, "**Score:** %.0f%% | **Phase:** %s | **Loop:** %d\n\n", verdict.Score, phase, loop)
+	// Summary line. The model field is appended when the judge stamped
+	// it (every LLM-backed judge does); deterministic judges that don't
+	// call an LLM leave it empty and the field is omitted from the line.
+	fmt.Fprintf(&b, "**Score:** %.0f%% | **Phase:** %s | **Loop:** %d", verdict.Score, phase, loop)
+	if verdict.Model != "" {
+		fmt.Fprintf(&b, " | **Model:** `%s`", verdict.Model)
+	}
+	b.WriteString("\n\n")
 
 	// Judge narrative (Reviewed / Notes sections). Without this, a passing
 	// verdict with no gaps renders as just the score line, hiding everything

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -489,6 +489,42 @@ func TestFormatVerdictComment_NoGaps(t *testing.T) {
 	}
 }
 
+func TestFormatVerdictComment_RendersModel(t *testing.T) {
+	// AC: verdict output records which model produced the verdict so PR
+	// comments can show it. When Model is set, the score line surfaces it
+	// alongside score/phase/loop.
+	verdict := &state.Verdict{
+		Score: 95,
+		Pass:  true,
+		Model: "claude-opus-4-7",
+	}
+
+	comment := FormatVerdictComment(verdict, state.PhaseQuality, 1, nil)
+
+	if !contains(comment, "claude-opus-4-7") {
+		t.Errorf("comment must mention the model that produced the verdict, got:\n%s", comment)
+	}
+	if !contains(comment, "**Model:**") {
+		t.Errorf("comment must label the model, got:\n%s", comment)
+	}
+}
+
+func TestFormatVerdictComment_NoModelOmitted(t *testing.T) {
+	// Code judge runs deterministic shell checks (lint/test/build) and
+	// leaves Model empty. The score line must omit the model field
+	// rather than render an empty `Model: \`\`` artifact.
+	verdict := &state.Verdict{
+		Score: 100,
+		Pass:  true,
+	}
+
+	comment := FormatVerdictComment(verdict, state.PhaseCode, 1, nil)
+
+	if contains(comment, "**Model:**") {
+		t.Errorf("comment must omit Model label when verdict has no model, got:\n%s", comment)
+	}
+}
+
 func TestFormatVerdictComment_FailWithNoGaps_NoSuchMessage(t *testing.T) {
 	// "No issues found" is a PASS-only affirmation. A failing verdict
 	// (even one without structured gaps) must never render it.

--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -17,9 +17,12 @@ import (
 )
 
 // Completer is the interface for sending prompts to an LLM. Plan judge uses
-// tool-use exclusively so responses conform to a strict schema.
+// tool-use exclusively so responses conform to a strict schema. Model()
+// reports the model the client routes calls to so the verdict can be
+// stamped with the model that produced it.
 type Completer interface {
 	CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
+	Model() string
 }
 
 // PlanJudge evaluates a plan against an intent and returns a typed Verdict.
@@ -191,6 +194,7 @@ func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string, ackno
 
 	verdict.Score = verdictschema.ComputeScoreWithAcknowledged(verdict.Gaps, acknowledged)
 	verdict.Pass = verdict.Score >= j.cfg.CoverageThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
+	verdict.Model = j.client.Model()
 
 	return &verdict, nil
 }

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -418,6 +418,24 @@ func TestJudge_AcknowledgedAssumptionsInPrompt(t *testing.T) {
 	}
 }
 
+func TestJudge_VerdictStampedWithModel(t *testing.T) {
+	// AC: verdict output records which model produced the verdict so PR
+	// comments / logs can show it.
+	fake := &claude.FakeClient{
+		ModelName: "claude-opus-4-7",
+		Response:  state.Verdict{Gaps: []state.Gap{}},
+	}
+	judge := New(fake, defaultCfg())
+
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Model != "claude-opus-4-7" {
+		t.Errorf("verdict.Model = %q, want claude-opus-4-7", verdict.Model)
+	}
+}
+
 func TestJudge_ReflaggedGapHalvedPenalty(t *testing.T) {
 	// When the judge re-flags an already-acknowledged P2 gap, its
 	// penalty should be halved (5 instead of 10).

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -24,9 +24,11 @@ import (
 
 // Completer is the interface for sending prompts to an LLM. Quality judge uses
 // multi-turn tool-use so the model can call auxiliary tools (like check_path)
-// before submitting the final verdict.
+// before submitting the final verdict. Model() reports the model the client
+// routes calls to so the verdict can be stamped with the model that produced it.
 type Completer interface {
 	CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, handlers map[string]claude.ToolHandler, target any) error
+	Model() string
 }
 
 // CommandRunner executes a command and returns its output and error.
@@ -597,11 +599,13 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 	verdict.Score = verdictschema.ComputeScore(verdict.Gaps)
 	verdict.Pass = verdict.Score >= PassThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
 	verdict.ReturnTo = normaliseReturnTo(verdict.ReturnTo, verdict.Pass, verdict.Gaps)
+	verdict.Model = j.client.Model()
 
 	slog.Info("quality judge verdict",
 		"score", verdict.Score,
 		"pass", verdict.Pass,
 		"gaps", len(verdict.Gaps),
+		"model", verdict.Model,
 	)
 
 	return verdict, nil

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -97,6 +97,24 @@ func testConfigWithE2E() config.Config {
 	return cfg
 }
 
+func TestQualityJudge_VerdictStampedWithModel(t *testing.T) {
+	// AC: verdict output records which model produced the verdict so PR
+	// comments / logs can show which judge model graded the change.
+	fake := &claude.FakeClient{
+		ModelName: "claude-opus-4-7",
+		Response:  state.Verdict{Gaps: []state.Gap{}},
+	}
+	judge := New(fake, nil, testConfig())
+
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "diff --git a/x.go b/x.go\n+func H() {}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Model != "claude-opus-4-7" {
+		t.Errorf("verdict.Model = %q, want claude-opus-4-7", verdict.Model)
+	}
+}
+
 func TestJudge_Pass_NoGapsScoresFull(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -154,6 +154,12 @@ type Verdict struct {
 	// it to drive outer-loop rewinds rather than just retrying the same
 	// phase.
 	ReturnTo ReturnTo `json:"return_to,omitempty"`
+	// Model identifies the LLM that produced this verdict. Surfaced in
+	// PR comments and logs so reviewers can see which judge model
+	// graded the change — useful when a config swaps the judge model
+	// independently of the producer model. Empty for verdicts produced
+	// without an LLM (e.g. the code judge's deterministic shell checks).
+	Model string `json:"model,omitempty"`
 }
 
 // Attempt records one execution of a phase.


### PR DESCRIPTION
Adds agents.judge_model plus per-phase plan_judge_model /
code_judge_model / quality_judge_model so a config can grade plans
with a stricter model than the one that produced them. Resolution
chain is per_phase → judge_model → model, so existing configs that
only set agents.model keep working unchanged.

Threads the resolved judge model into both backends — claude.WithModel
on the API client, a new claudecli.WithModel that emits --model on the
CLI subprocess — so the override actually reaches the API call. The
planner stays on agents.model so the producer model is never
accidentally rewritten.

Stamps Verdict.Model with the model that produced it (via Model() on
the completer interfaces) and surfaces it in the PR comment summary
line and the verdict-posted slog so reviewers can see which judge
graded the change.