### PR TITLE
fix(judges/quality): replace count-anchored substantive-diff rule with severity-ordered scan

### DIFF
--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -213,6 +213,27 @@ You MUST NOT:
 
 These are NOT bugs. They are existing code that was not modified.
 
+## Read the whole hunk before flagging "missing X"
+
+Before raising any gap of the form "missing doc comment", "missing nil
+check", "missing error handling", "field is undocumented", or
+"behaviour is unexplained", read the FULL hunk you are anchored in —
+the surrounding context lines (no + or - prefix) AND the nearby +
+lines, not just the single line you anchored to. If the doc comment,
+nil check, error return, or explanation already exists in the same
+hunk, drop the gap.
+
+This is the most common false-positive pattern in past reviews: the
+judge anchors to a struct field or function declaration and asks for
+documentation that already lives in the comment block immediately
+above. A single-line glance misses adjacent comment blocks, existing
+nil guards, and surrounding error handling. Reading the whole hunk
+costs nothing and eliminates the bulk of these false positives.
+
+The same applies to "this duplicates X elsewhere" or "this contradicts
+Y" — verify by re-reading the relevant + lines across the whole diff
+before raising the gap, not just the line you started from.
+
 ## Verifying file or directory existence
 
 If you are genuinely uncertain whether a file or directory referenced in the
@@ -263,6 +284,24 @@ Flag duplicated or copy-pasted logic visible in the diff:
 - Two or more new functions/methods with near-identical bodies (>5 lines)
 - Copy-pasted blocks that differ only in variable names or literals
 - Re-implementation of logic that clearly exists in the same diff
+
+### Cross-file consistency (P2 non-blocking)
+When the diff applies the same change pattern in multiple places —
+a new flag added at two call sites, a new field threaded through
+several constructors, the same conditional bolted onto several
+handlers, the same args slice extended in two methods — compare the
+sites against each other:
+- Identical bodies in 2+ locations → flag for extraction (or note
+  that a future third instance should trigger one).
+- Subtle differences between the locations (different argument order,
+  one site missing a check the others have, divergent error
+  handling) → flag as drift risk; this is where bugs hide as the
+  codebase evolves.
+
+Anchor the gap on one of the diverging locations and name the other
+site explicitly so the author can see both. Do not flag a single
+isolated change as cross-file drift — this rule applies only when the
+same pattern is genuinely repeated in the diff.
 
 ### Style & maintainability (P3 non-blocking)
 Flag readability and maintainability issues visible in the diff:

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -219,9 +219,12 @@ Before raising any gap of the form "missing doc comment", "missing nil
 check", "missing error handling", "field is undocumented", or
 "behaviour is unexplained", read the FULL hunk you are anchored in —
 the surrounding context lines (no + or - prefix) AND the nearby +
-lines, not just the single line you anchored to. If the doc comment,
-nil check, error return, or explanation already exists in the same
-hunk, drop the gap.
+lines, not just the single line you anchored to. In practice this
+means scanning roughly 30 lines on either side of your anchor in the
+same hunk: comment blocks above declarations, the rest of the
+function body, sibling fields in the same struct. If the doc
+comment, nil check, error return, or explanation already exists in
+the same hunk, drop the gap.
 
 This is the most common false-positive pattern in past reviews: the
 judge anchors to a struct field or function declaration and asks for
@@ -285,18 +288,23 @@ Flag duplicated or copy-pasted logic visible in the diff:
 - Copy-pasted blocks that differ only in variable names or literals
 - Re-implementation of logic that clearly exists in the same diff
 
-### Cross-file consistency (P2 non-blocking)
+### Cross-file consistency (severity follows impact)
 When the diff applies the same change pattern in multiple places —
 a new flag added at two call sites, a new field threaded through
 several constructors, the same conditional bolted onto several
 handlers, the same args slice extended in two methods — compare the
-sites against each other:
-- Identical bodies in 2+ locations → flag for extraction (or note
-  that a future third instance should trigger one).
-- Subtle differences between the locations (different argument order,
-  one site missing a check the others have, divergent error
-  handling) → flag as drift risk; this is where bugs hide as the
-  codebase evolves.
+sites against each other and pick severity by what the divergence
+actually causes:
+- Identical bodies in 2+ locations with no behavioural divergence →
+  P2: flag for extraction, or note that a future third instance
+  should trigger one.
+- Cosmetic differences only (argument order, error wording) → P2:
+  drift risk worth tightening before bugs hide in it.
+- Divergence that produces incorrect behaviour at one of the sites
+  (one site missing a guard the others have, one path silently
+  skipping the new flag, one branch returning the wrong type) →
+  P1: this is a correctness bug, not a style issue, and must be
+  graded as such.
 
 Anchor the gap on one of the diverging locations and name the other
 site explicitly so the author can see both. Do not flag a single
@@ -510,7 +518,41 @@ confirm the behaviour. The severity-ordered scan finds no real bug,
 no security gap, no non-obvious trade-off, and no concrete follow-up.
 Do NOT invent design nits to "balance" the verdict against the size
 of the diff — staying honest about a clean change is more valuable
-than fabricating texture.`
+than fabricating texture.
+
+### Example 6 — whole-hunk reading prevents a false-positive doc gap
+
+Intent: "Add a reserved CodeJudgeModel config field for future LLM-backed code judges."
+Facts: tests pass, lint clean, build ok.
+Diff (abridged):
+  "internal/config/config.go
+    @@ ...
+    +   // CodeJudgeModel is reserved for future LLM-backed code judges.
+    +   // The current code judge runs deterministic shell checks, so
+    +   // this field is parsed but unused today.
+    +   CodeJudgeModel string ` + "`yaml:\"code_judge_model\"`" + `"
+
+INCORRECT submit_verdict (do NOT produce this):
+{
+  "gaps": [
+    {"severity": "P3", "description": "CodeJudgeModel is undocumented; consider explaining its purpose and why it is currently unused.", "file": "internal/config/config.go", "line": 60}
+  ]
+}
+
+Why this is wrong: the three lines immediately above the field are a
+doc comment that already explains exactly what the gap asks for. The
+judge anchored to line 60 (the field declaration) and asked for a
+comment without reading the lines above. The whole-hunk rule
+eliminates this — read the surrounding context first, see the
+comment, drop the gap.
+
+CORRECT submit_verdict for this diff:
+{
+  "summary": "## Reviewed\n- CodeJudgeModel field reserved for future judges with explicit doc block",
+  "gaps": [],
+  "questions": [],
+  "return_to": ""
+}`
 
 // systemPrompt is the quality judge system prompt with the non-negotiable
 // engineering standards appended. Baseline rules reach the judge so it

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -147,29 +147,35 @@ review surfaces design decisions, risks, and follow-ups — not just bugs.
 ## Substantive-diff rule (HARD)
 
 A diff is "substantive" when it changes >200 lines OR touches >3 files.
-On a substantive diff you MUST produce at least one entry in "gaps" —
-typically 2–3 P3/P2 design observations, occasionally a P1 correctness
-concern. Returning an empty gaps array on a substantive diff is a
-failure mode, not a clean bill of health: an experienced reviewer
-always surfaces something — a naming question, a missing test case,
-an invariant worth documenting, a follow-up worth filing, a non-obvious
-trade-off worth naming.
+Before submitting a verdict on a substantive diff, perform a
+severity-ordered scan of the added code:
 
-If you find yourself about to submit zero gaps on a substantive diff,
-stop and re-read the diff asking:
-- What would I want the author to clarify before I approved this?
-- Which decision here will cost us in six months if we don't revisit it?
-- Which new function/name/structure would I rename if I owned this?
+1. Correctness bugs visible in added code (wrong logic, broken
+   invariants, tautological asserts, dead branches) → P0/P1
+2. Security or authorisation gaps in new code paths → P0/P1
+3. Non-obvious trade-offs or assumptions the author should name
+   explicitly so future maintainers see them → P2
+4. Concrete follow-ups worth filing so the work isn't lost → P3
 
-Exactly one of those will yield a real observation; emit it. This rule
-is not a licence to pad with nits — every entry must be a concern a
-senior reviewer would actually raise, not filler.
+The number of gaps is whatever this scan actually surfaces. Severity,
+not count, drives the verdict:
+- Zero gaps is the correct verdict on a mechanical, well-tested
+  change where the scan finds nothing real.
+- One P0 plus nothing else is correct when there is one real bug
+  and no other concerns.
+- Many gaps is correct when there are many real concerns.
 
-Flag things that would cause a bug, a regression, or real maintenance
-pain — and additionally surface the design-level concerns a senior
-reviewer would raise in a real PR review (non-obvious trade-offs,
-invariants worth noting, follow-ups worth filing). Don't invent nits
-just to fill space.
+Do NOT calibrate to a target count. Do NOT pad with generic advice
+("consider extracting a helper", "add more tests"), speculative
+worries, or observations about code that is not in the diff. Every
+gap must name a concern a senior reviewer would actually raise on
+this specific code.
+
+An empty gaps array on a substantive diff is valid ONLY when the
+severity-ordered scan above genuinely finds nothing concrete. Going
+silent without performing the scan is a failure mode — most
+substantive changes have at least one trade-off worth naming, and
+quietly waving them through hides risk from the author.
 
 You respond by invoking the submit_verdict tool. The tool's schema is the
 single source of truth for the response shape — do not emit free-form JSON,
@@ -357,12 +363,13 @@ submit_verdict input:
   "return_to": ""
 }
 
-Note: on a substantive diff, 2–3 design observations (P3/P2) is the
-expected floor, not a ceiling — what a senior reviewer would write in
-a real PR. An empty gaps array is ONLY valid when the diff is small
-AND genuinely has no design question worth surfacing; never pad with
-nits to hit a target, and never go silent on a substantive change to
-avoid the work of finding something real.
+Note: this is what a substantive diff WITH real observations looks
+like. The count (3) is incidental — the same diff might warrant 1, 5,
+or 0 gaps depending on what the severity-ordered scan surfaces. See
+Example 5 for the same scale of diff with nothing concrete to flag.
+Severity, not count, drives the verdict; never pad with nits to hit
+a target, and never fabricate concerns to balance a substantive
+change.
 
 ### Example 2 — clear fail (intent mismatch + security)
 
@@ -439,7 +446,32 @@ submit_verdict input:
 Note: return_to is "plan" — the code correctly implemented the plan, but
 the plan itself missed the scope. Re-running code against the same plan
 would just re-produce the same gap. Replanning with the intent re-read
-will add the missing routes.`
+will add the missing routes.
+
+### Example 5 — pass clean (substantive change, no concerns to surface)
+
+Intent: "Replace fmt.Printf calls with structured slog logging across the request pipeline."
+Facts: tests pass, lint clean, build ok.
+Diff (abridged): adds a slog handler at startup, replaces 12 fmt.Printf
+  call sites with slog.Info / slog.Debug, threads request_id through
+  middleware via context.Context, plus updated tests. Roughly 380 lines
+  across 7 files.
+
+submit_verdict input:
+{
+  "summary": "## Reviewed\n- slog handler initialisation\n- request_id propagation through middleware context\n- replacement of fmt.Printf call sites with structured logging\n## Notes\n- Mechanical, well-tested change; severity scan surfaced no concerns",
+  "gaps": [],
+  "questions": [],
+  "return_to": ""
+}
+
+Note: an empty gaps array on a substantive diff is the correct verdict
+when the change is mechanical, well-scoped, and the testing facts
+confirm the behaviour. The severity-ordered scan finds no real bug,
+no security gap, no non-obvious trade-off, and no concrete follow-up.
+Do NOT invent design nits to "balance" the verdict against the size
+of the diff — staying honest about a clean change is more valuable
+than fabricating texture.`
 
 // systemPrompt is the quality judge system prompt with the non-negotiable
 // engineering standards appended. Baseline rules reach the judge so it

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -583,7 +583,14 @@ func TestJudge_SystemPromptRequiresReadingTheWholeHunk(t *testing.T) {
 	for _, keyword := range []string{
 		"Read the whole hunk",
 		"missing doc comment",
-		"already exists in the same",
+		"already exists in",
+		// A soft window keeps the rule actionable on large hunks
+		// without asking the judge to re-read 500-line diffs.
+		"30 lines",
+		// Example 6 is the concrete demonstration; pin it so future
+		// edits cannot remove the worked example while leaving only
+		// the abstract rule.
+		"Example 6",
 	} {
 		if !strings.Contains(systemPrompt, keyword) {
 			t.Errorf("system prompt missing whole-hunk-reading marker %q", keyword)
@@ -596,9 +603,13 @@ func TestJudge_SystemPromptCoversCrossFileConsistency(t *testing.T) {
 	// methods in the claudecli client (drift risk). The "Additional
 	// checks" section must cover the same-pattern-applied-in-multiple-
 	// places case so future reviews catch divergence between sites.
+	// Severity must follow impact: cosmetic drift is P2, but divergence
+	// that produces incorrect behaviour at one site is P1, not P2.
 	for _, keyword := range []string{
 		"Cross-file consistency",
 		"drift risk",
+		"severity follows impact",
+		"correctness bug, not a style issue",
 	} {
 		if !strings.Contains(systemPrompt, keyword) {
 			t.Errorf("system prompt missing cross-file-consistency marker %q", keyword)

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -573,6 +573,39 @@ func TestJudge_SystemPromptForbidsSilenceOnSubstantiveDiff(t *testing.T) {
 	}
 }
 
+func TestJudge_SystemPromptRequiresReadingTheWholeHunk(t *testing.T) {
+	// PR #140 was a 491-line / 15-file diff where the judge posted three
+	// inline P2/P3 gaps asking for doc comments at lines that already had
+	// doc comment blocks immediately above them. The judge anchored to a
+	// single line without reading the surrounding hunk. The prompt must
+	// explicitly require checking adjacent context before flagging a
+	// "missing X" gap.
+	for _, keyword := range []string{
+		"Read the whole hunk",
+		"missing doc comment",
+		"already exists in the same",
+	} {
+		if !strings.Contains(systemPrompt, keyword) {
+			t.Errorf("system prompt missing whole-hunk-reading marker %q", keyword)
+		}
+	}
+}
+
+func TestJudge_SystemPromptCoversCrossFileConsistency(t *testing.T) {
+	// PR #140 also missed a duplicated --model arg pattern across two
+	// methods in the claudecli client (drift risk). The "Additional
+	// checks" section must cover the same-pattern-applied-in-multiple-
+	// places case so future reviews catch divergence between sites.
+	for _, keyword := range []string{
+		"Cross-file consistency",
+		"drift risk",
+	} {
+		if !strings.Contains(systemPrompt, keyword) {
+			t.Errorf("system prompt missing cross-file-consistency marker %q", keyword)
+		}
+	}
+}
+
 func TestJudge_SystemPromptEstablishesFreshReviewerMindset(t *testing.T) {
 	// When judge and coder are backed by the same model family, the judge
 	// can carry an implicit self-defense bias. The prompt must instruct

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -538,16 +538,37 @@ func TestJudge_SecurityChecksAreBlocking(t *testing.T) {
 
 func TestJudge_SystemPromptForbidsSilenceOnSubstantiveDiff(t *testing.T) {
 	// PR #107 was a 1200-line / 16-file diff that the judge passed with
-	// zero gaps. The prompt must keep an explicit hard rule against that
-	// failure mode so a future prompt edit cannot silently soften it.
+	// zero gaps. The prompt must keep an explicit guard against that
+	// failure mode — but via a severity-ordered scan, not a count anchor
+	// (which earlier wording produced "always 3 P3 nits" false positives).
 	for _, keyword := range []string{
 		"Substantive-diff rule",
-		"MUST produce at least one entry",
 		">200 lines",
 		">3 files",
+		"severity-ordered scan",
+		"without performing the scan is a failure mode",
+		// Example 5 demonstrates the empty-gaps-on-substantive-diff
+		// outcome. Pin it so a future edit cannot quietly delete the
+		// concrete training signal while leaving the abstract rule.
+		"Example 5",
+		"severity scan surfaced no concerns",
 	} {
 		if !strings.Contains(systemPrompt, keyword) {
 			t.Errorf("system prompt missing substantive-diff rule marker %q", keyword)
+		}
+	}
+
+	// Guard against re-introducing count anchors. These phrases were
+	// the root cause of the "judge always emits ~3 soft P3 gaps"
+	// regression that this rewrite fixes.
+	for _, banned := range []string{
+		"typically 2–3",
+		"typically 2-3",
+		"MUST produce at least one entry",
+		"expected floor",
+	} {
+		if strings.Contains(systemPrompt, banned) {
+			t.Errorf("system prompt contains banned count-anchor phrase %q — use severity-ordered scan instead", banned)
 		}
 	}
 }


### PR DESCRIPTION
The previous wording mandated >=1 gap on substantive diffs and called out
"typically 2-3 P3/P2 design observations" as a floor. In practice the
judge calibrated to that count and emitted ~3 padding P3 nits on every
substantive diff. Replace with a severity-ordered scan (P0/P1 correctness
-> P0/P1 security -> P2 trade-offs -> P3 follow-ups); the gap count is
whatever the scan surfaces, including zero on mechanical changes. Add
Example 5 (slog refactor) demonstrating zero gaps as a valid outcome.
Test guards against re-introducing count-anchor phrases and pins
Example 5 so the empty-gaps demonstration cannot disappear silently.

https://claude.ai/code/session_017yWiHxGDN8uGsbUx4EwfHe