### PR TITLE
perf(agents/claude): prompt caching on system prompt above ~1024 tokens

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,12 @@ runs:
       shell: bash
       env:
         VAIRDICT_VERSION: ${{ inputs.version }}
+        # Authenticate the `releases/latest` probe so we don't share
+        # the 60/hour anonymous rate-limit bucket with every other
+        # runner on the same IP. install.sh reads $GITHUB_TOKEN.
+        # Falls back to github.token (job-default GITHUB_TOKEN);
+        # any caller-set GH_TOKEN env (eg. the App token) still wins.
+        GITHUB_TOKEN: ${{ env.GH_TOKEN || github.token }}
       run: |
         if [ "$VAIRDICT_VERSION" = "latest" ]; then
           curl -fsSL https://raw.githubusercontent.com/vairdict/vairdict/main/scripts/install.sh | INSTALL_DIR="${{ runner.temp }}" sh

--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/agents/claudecli"
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/state"
 )
 
 // completer is the narrow interface that the plan / quality judges and the
@@ -264,6 +265,44 @@ func validateCompleterBackend(roleName, setting string, probes backendProbes) er
 	default:
 		return fmt.Errorf("%s: unknown backend %q (want claude|claude-cli|claude-api)", roleName, setting)
 	}
+}
+
+// seedCLISession copies the persisted CLI session ID for the given role
+// from task.CLISessionIDs onto the matching claudecli.Client (when the
+// resolved completer happens to be a CLI client). No-op for the API
+// client and for tasks that don't carry session state. Used by
+// `vairdict resume` and the inter-loop wiring in run.go to reattach to
+// the same Claude session a previous invocation established.
+func seedCLISession(c completer, task *state.Task, role completerRole) {
+	if task == nil || len(task.CLISessionIDs) == 0 {
+		return
+	}
+	id := task.CLISessionIDs[string(role)]
+	if id == "" {
+		return
+	}
+	if cli, ok := c.(*claudecli.Client); ok {
+		cli.SetSessionID(id)
+	}
+}
+
+// captureCLISession reads the most recent session ID from the
+// underlying claudecli.Client (if any) and writes it back to
+// task.CLISessionIDs so the next phase or `vairdict resume` invocation
+// can reattach. Safe no-op for the API path.
+func captureCLISession(c completer, task *state.Task, role completerRole) {
+	cli, ok := c.(*claudecli.Client)
+	if !ok {
+		return
+	}
+	id := cli.SessionID()
+	if id == "" {
+		return
+	}
+	if task.CLISessionIDs == nil {
+		task.CLISessionIDs = map[string]string{}
+	}
+	task.CLISessionIDs[string(role)] = id
 }
 
 // validateCoderBackend covers agents.coder, which today only supports

--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -49,6 +49,12 @@ const (
 	roleQualityJudge completerRole = "quality_judge"
 )
 
+// planJudgeMaxTokens caps the plan-judge response at a tighter budget
+// than the planner. Verdicts are typically 300-800 tokens; the larger
+// 4096 default just buys headroom that's never used and adds latency.
+// #137.
+const planJudgeMaxTokens = 1024
+
 // backendKind is the resolved backend identifier returned alongside the
 // completer instance so it can be surfaced in CLI output and logs. Note
 // this is the *resolved* kind — `claude` (smart) is never returned here;
@@ -168,6 +174,11 @@ func resolveCompleter(cfg *config.Config, role completerRole) (completer, backen
 		opts := []claude.Option{claude.WithTemperature(0)}
 		if model != "" {
 			opts = append(opts, claude.WithModel(model))
+		}
+		// Plan-judge verdicts are short structured payloads — cap
+		// max_tokens so the judge doesn't pay headroom it never uses.
+		if role == rolePlanJudge {
+			opts = append(opts, claude.WithMaxTokens(planJudgeMaxTokens))
 		}
 		c, err := claude.NewClient(cfg, opts...)
 		if err != nil {

--- a/cmd/vairdict/completer_test.go
+++ b/cmd/vairdict/completer_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
 )
 
@@ -168,6 +169,44 @@ func TestResolveCompleter_JudgeModelOverride(t *testing.T) {
 		if got := c.Model(); got != "claude-opus-4-7" {
 			t.Errorf("%s client model = %q, want claude-opus-4-7 (judge_model)", role, got)
 		}
+	}
+}
+
+// TestResolveCompleter_PlanJudgeCapsMaxTokens: the plan-judge API
+// client must cap max_tokens at 1024 (planJudgeMaxTokens) so verdicts
+// don't pay 4096 headroom they never use. Other roles keep the 4096
+// default. #137.
+func TestResolveCompleter_PlanJudgeCapsMaxTokens(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-maxtokens")
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude-api",
+		Judge:   "claude-api",
+		Model:   "claude-sonnet-4-20250514",
+	}}
+
+	cases := []struct {
+		role completerRole
+		want int
+	}{
+		{rolePlanJudge, planJudgeMaxTokens},
+		{rolePlanner, 4096},
+		{roleQualityJudge, 4096},
+		{roleCodeJudge, 4096},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.role), func(t *testing.T) {
+			c, _, err := resolveCompleter(cfg, tc.role)
+			if err != nil {
+				t.Fatalf("resolveCompleter(%s): %v", tc.role, err)
+			}
+			cc, ok := c.(*claude.Client)
+			if !ok {
+				t.Fatalf("expected *claude.Client for %s, got %T", tc.role, c)
+			}
+			if got := cc.MaxTokens(); got != tc.want {
+				t.Errorf("%s max_tokens = %d, want %d", tc.role, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/vairdict/completer_test.go
+++ b/cmd/vairdict/completer_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
+	"github.com/vairdict/vairdict/internal/agents/claudecli"
 	"github.com/vairdict/vairdict/internal/config"
+	"github.com/vairdict/vairdict/internal/state"
 )
 
 func TestChooseBackend(t *testing.T) {
@@ -207,6 +209,51 @@ func TestResolveCompleter_PlanJudgeCapsMaxTokens(t *testing.T) {
 				t.Errorf("%s max_tokens = %d, want %d", tc.role, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSeedAndCaptureCLISession: the wiring between state.Task and the
+// claudecli.Client must round-trip cleanly so a `vairdict resume` after
+// an interrupt mid-plan-phase reattaches to the same session, and so
+// loop 2+ within a single phase reuses the session captured on loop 1.
+// #137.
+func TestSeedAndCaptureCLISession(t *testing.T) {
+	cli := claudecli.New()
+	task := state.NewTask("t1", "intent")
+
+	// 1. Seed with a session id from a prior run — Client picks it up.
+	task.CLISessionIDs = map[string]string{string(rolePlanner): "sess_seeded"}
+	seedCLISession(cli, task, rolePlanner)
+	if cli.SessionID() != "sess_seeded" {
+		t.Errorf("seedCLISession: client SessionID = %q, want sess_seeded", cli.SessionID())
+	}
+
+	// 2. Capture writes the current id back to the task. Simulate a
+	//    fresh id that overrides the seeded one (as a real call would).
+	cli.SetSessionID("sess_after_call")
+	emptyTask := state.NewTask("t2", "intent")
+	captureCLISession(cli, emptyTask, rolePlanner)
+	if emptyTask.CLISessionIDs[string(rolePlanner)] != "sess_after_call" {
+		t.Errorf("captureCLISession: task CLISessionIDs[planner] = %q, want sess_after_call",
+			emptyTask.CLISessionIDs[string(rolePlanner)])
+	}
+}
+
+func TestSeedCLISession_NoOpForAPIClient(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	apiClient, err := claude.NewClient(nil)
+	if err != nil {
+		t.Fatalf("creating api client: %v", err)
+	}
+	task := state.NewTask("t", "i")
+	task.CLISessionIDs = map[string]string{string(rolePlanner): "ignored"}
+	// Must not panic; api client doesn't have a session concept.
+	seedCLISession(apiClient, task, rolePlanner)
+	captureCLISession(apiClient, task, rolePlanner)
+	// Original entry stays untouched (capture doesn't add anything for
+	// the api client because it has no session to capture).
+	if task.CLISessionIDs[string(rolePlanner)] != "ignored" {
+		t.Errorf("api client should not affect task session ids, got %v", task.CLISessionIDs)
 	}
 }
 

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -586,11 +586,6 @@ func runTasks(intents []string, issues []int, mode ui.Mode, colors ui.ColorSchem
 		return fmt.Errorf("backend validation: %w", err)
 	}
 
-	comps, err := resolveAllCompleters(cfg)
-	if err != nil {
-		return err
-	}
-
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("resolving working directory: %w", err)
@@ -619,7 +614,16 @@ func runTasks(intents []string, issues []int, mode ui.Mode, colors ui.ColorSchem
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			results[idx] = runSingleTask(ctx, cfg, comps, store, repoRoot, intent, issueNum, priority)
+			// #137: each task gets its own completer instances so
+			// claudecli session state doesn't bleed between
+			// concurrent tasks. Each session belongs to exactly
+			// one logical task.
+			perTaskComps, err := resolveAllCompleters(cfg)
+			if err != nil {
+				results[idx] = taskResult{Intent: intent, Err: err}
+				return
+			}
+			results[idx] = runSingleTask(ctx, cfg, perTaskComps, store, repoRoot, intent, issueNum, priority)
 			r := results[idx]
 			status := "pass"
 			if r.Err != nil {
@@ -1171,6 +1175,13 @@ func lastGapsForPhase(task *state.Task, phase state.Phase) []state.Gap {
 func runPlanPhase(ctx context.Context, cfg *config.Config, planner, judgeClient completer, store *state.Store, task *state.Task, r ui.Renderer) (*planphase.PhaseResult, error) {
 	r.PhaseStart(state.PhasePlan)
 
+	// #137: reattach to any persisted Claude CLI session so loop 2+
+	// of this phase (or a `vairdict resume` continuation) skips
+	// re-sending the system prompt and standards block. No-op when
+	// the client is the HTTP API path or no prior session exists.
+	seedCLISession(planner, task, rolePlanner)
+	seedCLISession(judgeClient, task, rolePlanJudge)
+
 	judge := planjudge.New(judgeClient, cfg.Phases.Plan)
 	phase := planphase.New(planner, judge, cfg.Phases.Plan)
 
@@ -1193,6 +1204,11 @@ func runPlanPhase(ctx context.Context, cfg *config.Config, planner, judgeClient 
 
 	result, err := phase.Run(ctx, task)
 	spin.Stop()
+	// Capture session IDs BEFORE returning so the persisted task
+	// row carries the session ids even on the error path. The next
+	// `vairdict resume` will reuse them.
+	captureCLISession(planner, task, rolePlanner)
+	captureCLISession(judgeClient, task, rolePlanJudge)
 	if err != nil {
 		if updateErr := store.UpdateTask(task); updateErr != nil {
 			slog.Error("failed to persist task state", "error", updateErr)
@@ -1430,6 +1446,10 @@ func runQualityPhase(
 ) (*qualityphase.PhaseResult, error) {
 	r.PhaseStart(state.PhaseQuality)
 
+	// #137: reattach to any persisted Claude CLI session for the
+	// quality judge. Same lifecycle as the plan phase wiring.
+	seedCLISession(client, task, roleQualityJudge)
+
 	judge := qualityjudge.New(client, &qualityjudge.ExecRunner{}, *cfg).WithCodeFacts(codeFacts)
 	// Compute the unified diff once, here, so the judge gets concrete
 	// code content rather than just a working-directory path. The diff
@@ -1443,6 +1463,7 @@ func runQualityPhase(
 
 	result, err := phase.Run(ctx, task, plan)
 	spin.Stop()
+	captureCLISession(client, task, roleQualityJudge)
 	if err != nil {
 		if updateErr := store.UpdateTask(task); updateErr != nil {
 			slog.Error("failed to persist task state", "error", updateErr)

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -1176,6 +1176,20 @@ func runPlanPhase(ctx context.Context, cfg *config.Config, planner, judgeClient 
 
 	spin := ui.NewSpinner(os.Stdout, "", ui.PaletteForCLI(r), ui.IsASCII(r))
 	phase.OnProgress = phaseProgressHandler(spin, r, state.PhasePlan)
+	// Stream planner output to the renderer when it supports it (CLI
+	// only — json/ci would have structured output mangled by raw
+	// deltas). The first delta stops the spinner so its line redraws
+	// don't overwrite streamed text; the next StepUpdate restarts it.
+	if dp, ok := r.(ui.DeltaPrinter); ok {
+		spinnerStopped := false
+		phase.OnDelta = func(text string) {
+			if !spinnerStopped {
+				spin.Stop()
+				spinnerStopped = true
+			}
+			dp.PhaseDelta(state.PhasePlan, text)
+		}
+	}
 
 	result, err := phase.Run(ctx, task)
 	spin.Stop()

--- a/internal/agents/claude/client.go
+++ b/internal/agents/claude/client.go
@@ -26,6 +26,12 @@ const (
 	defaultMaxTokens        = 4096
 	maxRetries              = 3
 	baseBackoff             = 1 * time.Second
+
+	// cacheThresholdChars is the minimum size of a system prompt before the
+	// client adds an ephemeral cache_control marker. ~4 chars/token gives
+	// roughly 1024 tokens — Anthropic's documented minimum cacheable prefix.
+	// Below this, paying the cache-write cost isn't worth it.
+	cacheThresholdChars = 4096
 )
 
 // AuthError is returned when the API key is missing or rejected.
@@ -71,14 +77,55 @@ func (e *APIError) Error() string {
 }
 
 // messagesRequest is the request body for the Anthropic Messages API.
+//
+// System is `any` so the client can send the field either as a plain
+// string (small prompts) or as a typed-block array carrying a
+// cache_control marker (large prompts that benefit from prompt
+// caching). Use systemPayload to construct the value.
 type messagesRequest struct {
 	Model       string      `json:"model"`
 	MaxTokens   int         `json:"max_tokens"`
-	System      string      `json:"system,omitempty"`
+	System      any         `json:"system,omitempty"`
 	Messages    []message   `json:"messages"`
 	Temperature *float64    `json:"temperature,omitempty"`
 	Tools       []Tool      `json:"tools,omitempty"`
 	ToolChoice  *ToolChoice `json:"tool_choice,omitempty"`
+}
+
+// systemBlock is the typed-content-block form of a system prompt. Used
+// when the prompt is large enough to benefit from prompt caching; below
+// the threshold the client sends `system` as a plain string instead.
+type systemBlock struct {
+	Type         string        `json:"type"`
+	Text         string        `json:"text"`
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
+}
+
+// cacheControl marks a content block as cacheable. "ephemeral" is the
+// only currently-supported type; Anthropic stores the cached prefix for
+// ~5 minutes.
+type cacheControl struct {
+	Type string `json:"type"`
+}
+
+// systemPayload returns the value to send as the `system` field. An
+// empty string returns nil so omitempty drops the field; below the
+// cache threshold it returns the plain string (preserving existing
+// behavior); at or above the threshold it returns a single typed text
+// block carrying an ephemeral cache_control marker so Anthropic caches
+// the prefix between calls.
+func systemPayload(text string) any {
+	if text == "" {
+		return nil
+	}
+	if len(text) >= cacheThresholdChars {
+		return []systemBlock{{
+			Type:         "text",
+			Text:         text,
+			CacheControl: &cacheControl{Type: "ephemeral"},
+		}}
+	}
+	return text
 }
 
 type message struct {
@@ -139,6 +186,14 @@ type ToolHandler func(ctx context.Context, input json.RawMessage) (string, error
 type usage struct {
 	InputTokens  int `json:"input_tokens"`
 	OutputTokens int `json:"output_tokens"`
+	// CacheCreationInputTokens is the number of input tokens written to
+	// the prompt cache on this request. Non-zero on the first call that
+	// crosses the cache threshold and pays the cache-write cost.
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	// CacheReadInputTokens is the number of input tokens read from the
+	// prompt cache. Non-zero on subsequent calls that hit a still-warm
+	// cached prefix — the dominant lever for plan-phase loop latency.
+	CacheReadInputTokens int `json:"cache_read_input_tokens"`
 }
 
 // HTTPClient is the interface for making HTTP requests. This allows injecting
@@ -239,7 +294,7 @@ func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, 
 	reqBody := messagesRequest{
 		Model:       c.model,
 		MaxTokens:   defaultMaxTokens,
-		System:      system,
+		System:      systemPayload(system),
 		Messages:    []message{{Role: "user", Content: prompt}},
 		Temperature: c.temperature,
 	}
@@ -256,7 +311,7 @@ func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, to
 	reqBody := messagesRequest{
 		Model:       c.model,
 		MaxTokens:   defaultMaxTokens,
-		System:      system,
+		System:      systemPayload(system),
 		Messages:    []message{{Role: "user", Content: prompt}},
 		Temperature: c.temperature,
 		Tools:       []Tool{tool},
@@ -271,11 +326,12 @@ func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, to
 const maxToolRounds = 10
 
 // multiTurnRequest is like messagesRequest but uses anyMessage to support
-// structured content (tool results) in the conversation.
+// structured content (tool results) in the conversation. System is `any`
+// for the same string-or-typed-block reason as messagesRequest.
 type multiTurnRequest struct {
 	Model       string       `json:"model"`
 	MaxTokens   int          `json:"max_tokens"`
-	System      string       `json:"system,omitempty"`
+	System      any          `json:"system,omitempty"`
 	Messages    []anyMessage `json:"messages"`
 	Temperature *float64     `json:"temperature,omitempty"`
 	Tools       []Tool       `json:"tools,omitempty"`
@@ -303,7 +359,7 @@ func (c *Client) CompleteWithTools(
 		reqBody := multiTurnRequest{
 			Model:       c.model,
 			MaxTokens:   defaultMaxTokens,
-			System:      system,
+			System:      systemPayload(system),
 			Messages:    messages,
 			Temperature: c.temperature,
 			Tools:       tools,
@@ -319,6 +375,7 @@ func (c *Client) CompleteWithTools(
 		if err := json.Unmarshal(body, &resp); err != nil {
 			return &ParseError{Body: string(body), Err: fmt.Errorf("unmarshalling response: %w", err)}
 		}
+		logUsage(c.model, resp.Usage)
 
 		// Check if the model called the final tool.
 		for _, block := range resp.Content {
@@ -435,6 +492,20 @@ func (c *Client) doRequestAny(ctx context.Context, reqBody any) ([]byte, error) 
 	return nil, fmt.Errorf("completing request after %d retries: %w", maxRetries, lastErr)
 }
 
+// logUsage emits a single slog.Info per successful Anthropic response so
+// cache hit / miss behavior is greppable in `vairdict logs`. The fields
+// match the issue #137 observability contract: model, input_tokens,
+// output_tokens, cache_creation_input_tokens, cache_read_input_tokens.
+func logUsage(model string, u usage) {
+	slog.Info("anthropic response",
+		"model", model,
+		"input_tokens", u.InputTokens,
+		"output_tokens", u.OutputTokens,
+		"cache_creation_input_tokens", u.CacheCreationInputTokens,
+		"cache_read_input_tokens", u.CacheReadInputTokens,
+	)
+}
+
 // sendAndParse drives the retry loop for a single request and hands the
 // decoded response to the caller-supplied extractor.
 func (c *Client) sendAndParse(ctx context.Context, reqBody messagesRequest, extract func(*messagesResponse) error) error {
@@ -450,6 +521,7 @@ func (c *Client) sendAndParse(ctx context.Context, reqBody messagesRequest, extr
 			if decodeErr := json.Unmarshal(body, &resp); decodeErr != nil {
 				return &ParseError{Body: string(body), Err: fmt.Errorf("unmarshalling response: %w", decodeErr)}
 			}
+			logUsage(c.model, resp.Usage)
 			return extract(&resp)
 		}
 

--- a/internal/agents/claude/client.go
+++ b/internal/agents/claude/client.go
@@ -209,6 +209,7 @@ type Client struct {
 	endpoint    string
 	httpClient  HTTPClient
 	temperature *float64
+	maxTokens   int
 }
 
 // Option configures a Client.
@@ -243,6 +244,19 @@ func WithTemperature(t float64) Option {
 	}
 }
 
+// WithMaxTokens caps max_tokens on every request from this client.
+// Defaults to defaultMaxTokens (4096). The plan judge uses this with
+// 1024 — verdicts are typically 300-800 tokens, the larger default
+// just buys headroom that's never used. Non-positive values are
+// ignored so callers can pass a config-derived 0 without surprise.
+func WithMaxTokens(n int) Option {
+	return func(cl *Client) {
+		if n > 0 {
+			cl.maxTokens = n
+		}
+	}
+}
+
 // NewClient creates a new Anthropic API client. It resolves the API key from:
 // 1. ANTHROPIC_API_KEY environment variable
 // 2. ~/.config/vairdict/config.yaml
@@ -267,6 +281,7 @@ func NewClient(cfg *config.Config, opts ...Option) (*Client, error) {
 		model:      model,
 		endpoint:   defaultEndpoint,
 		httpClient: &http.Client{Timeout: 120 * time.Second},
+		maxTokens:  defaultMaxTokens,
 	}
 
 	for _, opt := range opts {
@@ -288,12 +303,18 @@ func (c *Client) Complete(ctx context.Context, prompt string, target any) error 
 // it so PR comments and logs can show which model graded the change.
 func (c *Client) Model() string { return c.model }
 
+// MaxTokens returns the max_tokens value the client caps every request
+// at. Defaults to defaultMaxTokens (4096); the plan judge constructs
+// a client with WithMaxTokens(1024). Exposed for symmetry with Model()
+// so the resolver can be unit-tested.
+func (c *Client) MaxTokens() int { return c.maxTokens }
+
 // CompleteWithSystem sends a prompt with a system message to the Anthropic
 // Messages API and unmarshals the JSON response into the target struct.
 func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, target any) error {
 	reqBody := messagesRequest{
 		Model:       c.model,
-		MaxTokens:   defaultMaxTokens,
+		MaxTokens:   c.maxTokens,
 		System:      systemPayload(system),
 		Messages:    []message{{Role: "user", Content: prompt}},
 		Temperature: c.temperature,
@@ -310,7 +331,7 @@ func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, 
 func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, tool Tool, target any) error {
 	reqBody := messagesRequest{
 		Model:       c.model,
-		MaxTokens:   defaultMaxTokens,
+		MaxTokens:   c.maxTokens,
 		System:      systemPayload(system),
 		Messages:    []message{{Role: "user", Content: prompt}},
 		Temperature: c.temperature,
@@ -358,7 +379,7 @@ func (c *Client) CompleteWithTools(
 
 		reqBody := multiTurnRequest{
 			Model:       c.model,
-			MaxTokens:   defaultMaxTokens,
+			MaxTokens:   c.maxTokens,
 			System:      systemPayload(system),
 			Messages:    messages,
 			Temperature: c.temperature,

--- a/internal/agents/claude/client_test.go
+++ b/internal/agents/claude/client_test.go
@@ -1008,6 +1008,116 @@ func truncateForLog(s string, n int) string {
 	return s[:n] + "...(truncated)"
 }
 
+// --- Per-client max_tokens tests (#137) ---
+
+func TestWithMaxTokens_DefaultsTo4096(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var captured messagesRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`{"answer":"ok","score":1}`)))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result testResult
+	if err := c.Complete(context.Background(), "p", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.MaxTokens != defaultMaxTokens {
+		t.Errorf("expected default max_tokens=%d, got %d", defaultMaxTokens, captured.MaxTokens)
+	}
+}
+
+func TestWithMaxTokens_OverridesDefault(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var captured messagesRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`{"answer":"ok","score":1}`)))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL), WithMaxTokens(1024))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result testResult
+	if err := c.Complete(context.Background(), "p", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.MaxTokens != 1024 {
+		t.Errorf("expected max_tokens=1024, got %d", captured.MaxTokens)
+	}
+}
+
+func TestWithMaxTokens_NonPositiveIgnored(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var captured messagesRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`{"answer":"ok","score":1}`)))
+	}))
+	defer srv.Close()
+
+	// 0 should fall through to the default — protects callers that
+	// pass a config-derived value without a sentinel guard.
+	c, err := NewClient(nil, WithEndpoint(srv.URL), WithMaxTokens(0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result testResult
+	if err := c.Complete(context.Background(), "p", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.MaxTokens != defaultMaxTokens {
+		t.Errorf("expected default max_tokens when 0 passed, got %d", captured.MaxTokens)
+	}
+}
+
+func TestWithMaxTokens_AppliesToToolCall(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var captured messagesRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		resp := messagesResponse{
+			Content: []contentBlock{{
+				Type:  "tool_use",
+				Name:  "submit_verdict",
+				Input: json.RawMessage(`{"answer":"ok"}`),
+			}},
+			StopReason: "tool_use",
+		}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL), WithMaxTokens(1024))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result testResult
+	tool := Tool{Name: "submit_verdict", InputSchema: json.RawMessage(`{}`)}
+	if err := c.CompleteWithTool(context.Background(), "", "p", tool, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.MaxTokens != 1024 {
+		t.Errorf("expected max_tokens=1024 on tool call, got %d", captured.MaxTokens)
+	}
+}
+
 func TestExtractJSON(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/agents/claude/client_test.go
+++ b/internal/agents/claude/client_test.go
@@ -760,6 +760,254 @@ func TestCompleteWithTools_UnknownTool(t *testing.T) {
 	}
 }
 
+// --- Prompt caching tests (#137) ---
+
+// largeSystemPrompt is a system prompt deterministically padded above the
+// cache threshold so caching tests don't depend on the exact threshold value.
+func largeSystemPrompt() string {
+	const base = "You are a senior engineer. "
+	out := strings.Builder{}
+	for out.Len() < cacheThresholdChars+256 {
+		out.WriteString(base)
+	}
+	return out.String()
+}
+
+func TestCompleteWithSystem_CacheControlAboveThreshold(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`{"answer":"ok","score":1}`)))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	sys := largeSystemPrompt()
+	if err := c.CompleteWithSystem(context.Background(), sys, "prompt", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Inspect the marshalled body — System should be a typed-block array
+	// with cache_control.ephemeral, not a string.
+	var probe struct {
+		System []struct {
+			Type         string         `json:"type"`
+			Text         string         `json:"text"`
+			CacheControl map[string]any `json:"cache_control"`
+		} `json:"system"`
+	}
+	if err := json.Unmarshal(rawBody, &probe); err != nil {
+		t.Fatalf("decoding request body: %v\nraw: %s", err, rawBody)
+	}
+	if len(probe.System) != 1 {
+		t.Fatalf("expected 1 system block, got %d (raw: %s)", len(probe.System), rawBody)
+	}
+	if probe.System[0].Type != "text" {
+		t.Errorf("expected system block type=text, got %q", probe.System[0].Type)
+	}
+	if probe.System[0].Text != sys {
+		t.Errorf("system block text mismatch (len=%d vs %d)", len(probe.System[0].Text), len(sys))
+	}
+	if got := probe.System[0].CacheControl["type"]; got != "ephemeral" {
+		t.Errorf("expected cache_control.type=ephemeral, got %v", got)
+	}
+}
+
+func TestCompleteWithSystem_NoCacheControlBelowThreshold(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`{"answer":"ok","score":1}`)))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	if err := c.CompleteWithSystem(context.Background(), "you are a judge", "prompt", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Below the threshold, system must be a plain string — preserves
+	// existing behavior and avoids paying the cache-write cost on small
+	// prefixes.
+	var probe struct {
+		System json.RawMessage `json:"system"`
+	}
+	if err := json.Unmarshal(rawBody, &probe); err != nil {
+		t.Fatalf("decoding request body: %v", err)
+	}
+	if len(probe.System) == 0 || probe.System[0] != '"' {
+		t.Errorf("expected system to be a JSON string, got %s", probe.System)
+	}
+	if strings.Contains(string(rawBody), "cache_control") {
+		t.Errorf("expected no cache_control on small system prompt, got body: %s", rawBody)
+	}
+}
+
+func TestCompleteWithSystem_EmptySystemOmitted(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(`{"answer":"ok","score":1}`)))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	if err := c.Complete(context.Background(), "prompt", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(rawBody), `"system"`) {
+		t.Errorf("expected empty system to be omitted, got body: %s", rawBody)
+	}
+}
+
+func TestCompleteWithTool_CacheControlAboveThreshold(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		resp := messagesResponse{
+			Content: []contentBlock{{
+				Type:  "tool_use",
+				Name:  "submit_verdict",
+				Input: json.RawMessage(`{"answer":"ok"}`),
+			}},
+			StopReason: "tool_use",
+		}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tool := Tool{Name: "submit_verdict", InputSchema: json.RawMessage(`{}`)}
+	var result testResult
+	if err := c.CompleteWithTool(context.Background(), largeSystemPrompt(), "prompt", tool, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(rawBody), `"cache_control":{"type":"ephemeral"}`) {
+		t.Errorf("expected cache_control marker on tool call, got body: %s", truncateForLog(string(rawBody), 500))
+	}
+}
+
+func TestCompleteWithTools_CacheControlAboveThreshold(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeToolUseResponse("t1", "submit_verdict", json.RawMessage(`{"answer":"done"}`))))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	err = c.CompleteWithTools(context.Background(), largeSystemPrompt(), "prompt",
+		[]Tool{{Name: "submit_verdict", InputSchema: json.RawMessage(`{}`)}},
+		"submit_verdict", nil, &result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(rawBody), `"cache_control":{"type":"ephemeral"}`) {
+		t.Errorf("expected cache_control marker on multi-turn call, got body: %s", truncateForLog(string(rawBody), 500))
+	}
+}
+
+func TestUsage_CacheTokensDecoded(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := messagesResponse{
+			Content:    []contentBlock{{Type: "text", Text: `{"answer":"cached","score":1}`}},
+			StopReason: "end_turn",
+			Usage: usage{
+				InputTokens:              4,
+				OutputTokens:              7,
+				CacheCreationInputTokens: 1500,
+				CacheReadInputTokens:     2300,
+			},
+		}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Drive a successful call; the test verifies the usage struct
+	// can decode cache fields without dropping them.
+	var result testResult
+	if err := c.Complete(context.Background(), "prompt", &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Answer != "cached" {
+		t.Errorf("unexpected result: %+v", result)
+	}
+
+	// Direct round-trip check on the usage struct so the response
+	// shape regression is caught even if logging is changed later.
+	var u usage
+	body, _ := json.Marshal(map[string]int{
+		"input_tokens":                 4,
+		"output_tokens":                7,
+		"cache_creation_input_tokens":  1500,
+		"cache_read_input_tokens":      2300,
+	})
+	if err := json.Unmarshal(body, &u); err != nil {
+		t.Fatalf("decoding usage: %v", err)
+	}
+	if u.CacheCreationInputTokens != 1500 || u.CacheReadInputTokens != 2300 {
+		t.Errorf("cache tokens not decoded: %+v", u)
+	}
+}
+
+// truncateForLog avoids dragging the full base64-sized request body into
+// test failure output. Only used for assertion error messages.
+func truncateForLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}
+
 func TestExtractJSON(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/agents/claude/client_test.go
+++ b/internal/agents/claude/client_test.go
@@ -956,7 +956,7 @@ func TestUsage_CacheTokensDecoded(t *testing.T) {
 			StopReason: "end_turn",
 			Usage: usage{
 				InputTokens:              4,
-				OutputTokens:              7,
+				OutputTokens:             7,
 				CacheCreationInputTokens: 1500,
 				CacheReadInputTokens:     2300,
 			},
@@ -986,10 +986,10 @@ func TestUsage_CacheTokensDecoded(t *testing.T) {
 	// shape regression is caught even if logging is changed later.
 	var u usage
 	body, _ := json.Marshal(map[string]int{
-		"input_tokens":                 4,
-		"output_tokens":                7,
-		"cache_creation_input_tokens":  1500,
-		"cache_read_input_tokens":      2300,
+		"input_tokens":                4,
+		"output_tokens":               7,
+		"cache_creation_input_tokens": 1500,
+		"cache_read_input_tokens":     2300,
 	})
 	if err := json.Unmarshal(body, &u); err != nil {
 		t.Fatalf("decoding usage: %v", err)

--- a/internal/agents/claude/stream.go
+++ b/internal/agents/claude/stream.go
@@ -1,0 +1,201 @@
+package claude
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// CompleteWithSystemStream is the streaming variant of CompleteWithSystem.
+// When onDelta is non-nil, every text_delta from the SSE response is fed
+// to it as the model produces output. The accumulated text is then
+// extracted and unmarshalled into target the same way the non-streaming
+// path does. onDelta may be nil — in that case the call still streams
+// (paying the SSE overhead) but the caller sees only the final result.
+//
+// Streaming changes total wall-clock time only marginally; the benefit is
+// perceived latency — the user watches the planner output form in real
+// time instead of staring at "generating plan" until the final message
+// returns.
+//
+// Errors mirror the non-streaming path: AuthError on 401/403, APIError
+// on other non-2xx responses pre-stream, ParseError when accumulated
+// text cannot be decoded into target. SSE-specific failures (malformed
+// data lines, missing message_stop) surface as ParseError. Network
+// failures pre-stream are NOT retried — the caller is expected to use
+// the non-streaming path when retry semantics matter.
+func (c *Client) CompleteWithSystemStream(
+	ctx context.Context,
+	system, prompt string,
+	target any,
+	onDelta func(text string),
+) error {
+	reqBody := streamingRequest{
+		messagesRequest: messagesRequest{
+			Model:       c.model,
+			MaxTokens:   c.maxTokens,
+			System:      systemPayload(system),
+			Messages:    []message{{Role: "user", Content: prompt}},
+			Temperature: c.temperature,
+		},
+		Stream: true,
+	}
+
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshalling streaming request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("creating streaming request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", defaultAnthropicVersion)
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending streaming request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// fall through to SSE consumer
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		body, _ := io.ReadAll(resp.Body)
+		return &AuthError{Message: string(body)}
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return &APIError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+
+	text, finalUsage, err := consumeSSE(resp.Body, onDelta)
+	if err != nil {
+		return err
+	}
+	logUsage(c.model, finalUsage)
+
+	cleaned := extractJSON(text)
+	if err := json.Unmarshal([]byte(cleaned), target); err != nil {
+		return &ParseError{Body: text, Err: fmt.Errorf("unmarshalling streamed text: %w", err)}
+	}
+	return nil
+}
+
+// streamingRequest embeds messagesRequest and adds the stream flag. A
+// dedicated type keeps the non-streaming request body unchanged so
+// existing tests that decode messagesRequest don't see an unexpected
+// field.
+type streamingRequest struct {
+	messagesRequest
+	Stream bool `json:"stream"`
+}
+
+// consumeSSE reads the SSE response body, accumulating text_delta
+// payloads into a single string and feeding each delta to onDelta as
+// it arrives. Returns the accumulated text plus the final merged usage
+// snapshot (input_tokens + cache fields from message_start, plus the
+// final output_tokens from message_delta).
+func consumeSSE(body io.Reader, onDelta func(text string)) (string, usage, error) {
+	var (
+		acc      strings.Builder
+		finalUsage usage
+		sawStop  bool
+	)
+
+	// The Anthropic SSE format wraps each event in two lines:
+	//   event: <name>
+	//   data: <json>
+	//
+	// Followed by a blank line. We only need the data lines — the type
+	// field inside the JSON tells us which event it was.
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+
+		var ev streamEvent
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			return "", usage{}, &ParseError{Body: payload, Err: fmt.Errorf("decoding sse event: %w", err)}
+		}
+
+		switch ev.Type {
+		case "message_start":
+			if ev.Message != nil {
+				finalUsage.InputTokens = ev.Message.Usage.InputTokens
+				finalUsage.CacheCreationInputTokens = ev.Message.Usage.CacheCreationInputTokens
+				finalUsage.CacheReadInputTokens = ev.Message.Usage.CacheReadInputTokens
+				finalUsage.OutputTokens = ev.Message.Usage.OutputTokens
+			}
+		case "content_block_delta":
+			if ev.Delta != nil && ev.Delta.Type == "text_delta" && ev.Delta.Text != "" {
+				acc.WriteString(ev.Delta.Text)
+				if onDelta != nil {
+					onDelta(ev.Delta.Text)
+				}
+			}
+		case "message_delta":
+			// message_delta carries the cumulative output_tokens; the
+			// final value here is the authoritative count.
+			if ev.Usage != nil {
+				finalUsage.OutputTokens = ev.Usage.OutputTokens
+			}
+		case "message_stop":
+			sawStop = true
+		case "error":
+			if ev.Error != nil {
+				return "", usage{}, &APIError{StatusCode: 0, Body: ev.Error.Message}
+			}
+			return "", usage{}, &APIError{StatusCode: 0, Body: payload}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", usage{}, fmt.Errorf("reading sse stream: %w", err)
+	}
+	if !sawStop {
+		return "", usage{}, &ParseError{Body: acc.String(), Err: fmt.Errorf("sse stream ended without message_stop")}
+	}
+	return acc.String(), finalUsage, nil
+}
+
+// streamEvent is the union type for every SSE event payload we care
+// about. Fields not relevant to the dispatched type stay nil.
+type streamEvent struct {
+	Type    string             `json:"type"`
+	Message *streamMessageInfo `json:"message,omitempty"`
+	Delta   *streamDelta       `json:"delta,omitempty"`
+	Usage   *streamUsage       `json:"usage,omitempty"`
+	Error   *streamError       `json:"error,omitempty"`
+}
+
+type streamMessageInfo struct {
+	Usage usage `json:"usage"`
+}
+
+type streamDelta struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type streamUsage struct {
+	OutputTokens int `json:"output_tokens"`
+}
+
+type streamError struct {
+	Message string `json:"message"`
+}

--- a/internal/agents/claude/stream.go
+++ b/internal/agents/claude/stream.go
@@ -66,10 +66,10 @@ func (c *Client) CompleteWithSystemStream(
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	switch {
-	case resp.StatusCode == http.StatusOK:
+	switch resp.StatusCode {
+	case http.StatusOK:
 		// fall through to SSE consumer
-	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+	case http.StatusUnauthorized, http.StatusForbidden:
 		body, _ := io.ReadAll(resp.Body)
 		return &AuthError{Message: string(body)}
 	default:
@@ -106,9 +106,9 @@ type streamingRequest struct {
 // final output_tokens from message_delta).
 func consumeSSE(body io.Reader, onDelta func(text string)) (string, usage, error) {
 	var (
-		acc      strings.Builder
+		acc        strings.Builder
 		finalUsage usage
-		sawStop  bool
+		sawStop    bool
 	)
 
 	// The Anthropic SSE format wraps each event in two lines:

--- a/internal/agents/claude/stream_test.go
+++ b/internal/agents/claude/stream_test.go
@@ -28,8 +28,8 @@ func sseHandler(t *testing.T, events []sseEvent) http.HandlerFunc {
 		w.WriteHeader(http.StatusOK)
 		flusher, _ := w.(http.Flusher)
 		for _, ev := range events {
-			fmt.Fprintf(w, "event: %s\n", ev.event)
-			fmt.Fprintf(w, "data: %s\n\n", ev.data)
+			_, _ = fmt.Fprintf(w, "event: %s\n", ev.event)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", ev.data)
 			if flusher != nil {
 				flusher.Flush()
 			}
@@ -48,7 +48,7 @@ func recordedSSE(textChunks []string) []sseEvent {
 	events := []sseEvent{
 		{
 			event: "message_start",
-			data: `{"type":"message_start","message":{"id":"msg_test","usage":{"input_tokens":42,"output_tokens":0,"cache_creation_input_tokens":1500,"cache_read_input_tokens":0}}}`,
+			data:  `{"type":"message_start","message":{"id":"msg_test","usage":{"input_tokens":42,"output_tokens":0,"cache_creation_input_tokens":1500,"cache_read_input_tokens":0}}}`,
 		},
 		{
 			event: "content_block_start",
@@ -219,7 +219,7 @@ func TestCompleteWithSystemStream_HonorsCachePayload(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		for _, ev := range recordedSSE([]string{`{"answer":"ok","score":1}`}) {
-			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.event, ev.data)
+			_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.event, ev.data)
 		}
 	}))
 	defer srv.Close()

--- a/internal/agents/claude/stream_test.go
+++ b/internal/agents/claude/stream_test.go
@@ -1,0 +1,235 @@
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// sseHandler builds an http.Handler that writes the given event lines as
+// SSE payloads, separated by blank lines. Each entry is a (eventName,
+// jsonData) pair. The handler also asserts that the request body
+// included `"stream":true`.
+func sseHandler(t *testing.T, events []sseEvent) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"stream":true`) {
+			t.Errorf("expected stream:true in request body, got: %s", body)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, ev := range events {
+			fmt.Fprintf(w, "event: %s\n", ev.event)
+			fmt.Fprintf(w, "data: %s\n\n", ev.data)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+type sseEvent struct {
+	event string
+	data  string
+}
+
+// recordedSSE returns a typical Anthropic stream that emits "Hello, "
+// then "world!" as two text deltas, then a final stop event.
+func recordedSSE(textChunks []string) []sseEvent {
+	events := []sseEvent{
+		{
+			event: "message_start",
+			data: `{"type":"message_start","message":{"id":"msg_test","usage":{"input_tokens":42,"output_tokens":0,"cache_creation_input_tokens":1500,"cache_read_input_tokens":0}}}`,
+		},
+		{
+			event: "content_block_start",
+			data:  `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		},
+	}
+	for _, chunk := range textChunks {
+		// JSON-encode the chunk so we don't have to think about escaping.
+		jsonChunk, _ := json.Marshal(chunk)
+		events = append(events, sseEvent{
+			event: "content_block_delta",
+			data:  fmt.Sprintf(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":%s}}`, jsonChunk),
+		})
+	}
+	events = append(events,
+		sseEvent{event: "content_block_stop", data: `{"type":"content_block_stop","index":0}`},
+		sseEvent{event: "message_delta", data: `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":17}}`},
+		sseEvent{event: "message_stop", data: `{"type":"message_stop"}`},
+	)
+	return events
+}
+
+func TestCompleteWithSystemStream_AccumulatesDeltas(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+
+	chunks := []string{`{"answer":"`, `streamed`, `","score":7}`}
+	srv := httptest.NewServer(sseHandler(t, recordedSSE(chunks)))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var deltas []string
+	var mu sync.Mutex
+	onDelta := func(text string) {
+		mu.Lock()
+		deltas = append(deltas, text)
+		mu.Unlock()
+	}
+
+	var result testResult
+	if err := c.CompleteWithSystemStream(context.Background(), "", "prompt", &result, onDelta); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Answer != "streamed" || result.Score != 7 {
+		t.Errorf("unexpected accumulated result: %+v", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deltas) != len(chunks) {
+		t.Fatalf("expected %d deltas, got %d: %#v", len(chunks), len(deltas), deltas)
+	}
+	for i, want := range chunks {
+		if deltas[i] != want {
+			t.Errorf("delta[%d] = %q, want %q", i, deltas[i], want)
+		}
+	}
+}
+
+func TestCompleteWithSystemStream_NilOnDeltaIsOK(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+
+	srv := httptest.NewServer(sseHandler(t, recordedSSE([]string{`{"answer":"`, `nodelta`, `","score":1}`})))
+	defer srv.Close()
+
+	c, err := NewClient(nil, WithEndpoint(srv.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result testResult
+	if err := c.CompleteWithSystemStream(context.Background(), "", "p", &result, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Answer != "nodelta" {
+		t.Errorf("unexpected result: %+v", result)
+	}
+}
+
+func TestCompleteWithSystemStream_MatchesNonStreamingResult(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+
+	// Two servers — one streaming SSE, one returning the same content
+	// as a single completed messagesResponse. The accumulated text
+	// must produce the same target struct.
+	const finalJSON = `{"answer":"parity","score":42}`
+
+	streamSrv := httptest.NewServer(sseHandler(t, recordedSSE([]string{
+		`{"answer":"`, `parity`, `","score":42}`,
+	})))
+	defer streamSrv.Close()
+
+	blockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeMessagesResponse(finalJSON)))
+	}))
+	defer blockSrv.Close()
+
+	streamClient, _ := NewClient(nil, WithEndpoint(streamSrv.URL))
+	blockClient, _ := NewClient(nil, WithEndpoint(blockSrv.URL))
+
+	var streamed testResult
+	if err := streamClient.CompleteWithSystemStream(context.Background(), "", "p", &streamed, nil); err != nil {
+		t.Fatalf("streaming: %v", err)
+	}
+	var blocked testResult
+	if err := blockClient.CompleteWithSystem(context.Background(), "", "p", &blocked); err != nil {
+		t.Fatalf("blocking: %v", err)
+	}
+	if streamed != blocked {
+		t.Errorf("parity mismatch: streamed=%+v blocked=%+v", streamed, blocked)
+	}
+}
+
+func TestCompleteWithSystemStream_AuthErrorBeforeStream(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-bad")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad key"}`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(nil, WithEndpoint(srv.URL))
+	var result testResult
+	err := c.CompleteWithSystemStream(context.Background(), "", "p", &result, nil)
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthError, got %T: %v", err, err)
+	}
+}
+
+func TestCompleteWithSystemStream_MissingMessageStop(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+
+	// Truncated stream — no message_stop event. Caller must see
+	// ParseError so they don't silently consume a half-finished plan.
+	events := []sseEvent{
+		{event: "message_start", data: `{"type":"message_start","message":{"usage":{}}}`},
+		{event: "content_block_delta", data: `{"type":"content_block_delta","delta":{"type":"text_delta","text":"abc"}}`},
+		// no message_stop
+	}
+	srv := httptest.NewServer(sseHandler(t, events))
+	defer srv.Close()
+
+	c, _ := NewClient(nil, WithEndpoint(srv.URL))
+	var result testResult
+	err := c.CompleteWithSystemStream(context.Background(), "", "p", &result, nil)
+	if err == nil {
+		t.Fatal("expected error on truncated stream")
+	}
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestCompleteWithSystemStream_HonorsCachePayload(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for _, ev := range recordedSSE([]string{`{"answer":"ok","score":1}`}) {
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.event, ev.data)
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(nil, WithEndpoint(srv.URL))
+	var result testResult
+	if err := c.CompleteWithSystemStream(context.Background(), largeSystemPrompt(), "p", &result, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(rawBody), `"cache_control":{"type":"ephemeral"}`) {
+		t.Errorf("expected cache_control marker on streaming call, got body head: %s", truncateForLog(string(rawBody), 400))
+	}
+}

--- a/internal/agents/claudecli/client.go
+++ b/internal/agents/claudecli/client.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
@@ -73,13 +74,21 @@ func (e *ExitError) Unwrap() error { return e.Err }
 // (typically `sh -c` or a TestHelperProcess-style re-invocation).
 type CommandFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
 
-// Client is a Completer backed by the Claude Code CLI. It holds no state
-// between calls; options only affect argument construction and the exec seam.
+// Client is a Completer backed by the Claude Code CLI. It holds the
+// in-flight Claude session ID so calls 2+ within the same plan run
+// can `--resume <id>` instead of re-sending the full system prompt
+// and standards block on every loop. The session ID is mutex-guarded
+// because Completer methods may be invoked from different goroutines
+// in the orchestrator (each loop is sequential, but state.Store
+// access is on a separate timeline).
 type Client struct {
 	timeout    time.Duration
 	cmdFactory CommandFactory
 	extraArgs  []string
 	model      string
+
+	mu        sync.Mutex
+	sessionID string
 }
 
 // Option configures a Client.
@@ -112,6 +121,15 @@ func WithModel(model string) Option {
 	return func(c *Client) { c.model = model }
 }
 
+// WithSessionID seeds the initial Claude session ID at construction.
+// When set, the very first call switches from `-p` to
+// `--resume <id> -p` and skips re-sending the system prompt — used by
+// `vairdict resume` to reattach to the session a previous run
+// established. Empty string (the default) means "start fresh."
+func WithSessionID(id string) Option {
+	return func(c *Client) { c.sessionID = id }
+}
+
 // New constructs a Client with the given options.
 func New(opts ...Option) *Client {
 	c := &Client{
@@ -136,6 +154,26 @@ func IsAvailable() bool {
 // empty string when the client uses the CLI's default. Callers that
 // stamp verdicts with the model that produced them read this.
 func (c *Client) Model() string { return c.model }
+
+// SessionID returns the most recent Claude session ID captured from
+// the CLI envelope, or empty string when no session has been
+// established yet. The orchestrator reads this after each phase to
+// persist the session on state.Task so `vairdict resume` can
+// reattach.
+func (c *Client) SessionID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.sessionID
+}
+
+// SetSessionID seeds (or clears) the session ID at runtime. Used on
+// resume to restore the session a previous run established. Pass ""
+// to force a fresh session on the next call.
+func (c *Client) SetSessionID(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sessionID = id
+}
 
 // Complete is a convenience wrapper for CompleteWithSystem with an empty
 // system prompt. It exists so Client satisfies any narrow Completer-style
@@ -201,14 +239,16 @@ func (c *Client) CompleteWithTools(ctx context.Context, system, prompt string, t
 	return fmt.Errorf("final tool %q not found in tools list", finalTool)
 }
 
-// envelope is the subset of Claude Code's `--output-format json` result that
-// we care about. We explicitly decode only the fields we need so the rest
-// (session_id, cost, usage, …) are tolerated as extras.
+// envelope is the subset of Claude Code's `--output-format json` result
+// that we care about. SessionID was previously discarded; #137 captures
+// it so subsequent calls can `--resume <id>` instead of re-sending the
+// full system prompt on every loop.
 type envelope struct {
-	Type    string `json:"type"`
-	Subtype string `json:"subtype"`
-	IsError bool   `json:"is_error"`
-	Result  string `json:"result"`
+	Type      string `json:"type"`
+	Subtype   string `json:"subtype"`
+	IsError   bool   `json:"is_error"`
+	Result    string `json:"result"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // completeWithOpts is the core CLI invocation. When noTools is true it
@@ -216,59 +256,28 @@ type envelope struct {
 // response. This is critical for judge calls that must return JSON directly
 // rather than spending turns reading files.
 func (c *Client) completeWithOpts(ctx context.Context, system, prompt string, noTools bool, target any) error {
-	start := time.Now()
+	return c.runAndDecode(ctx, system, prompt, noTools, target)
+}
 
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
-	defer cancel()
-
-	args := []string{"-p", "--output-format", "json"}
-	if noTools {
-		args = append(args, "--tools", "")
-	}
-	if system != "" {
-		args = append(args, "--append-system-prompt", system)
-	}
-	if c.model != "" {
-		args = append(args, "--model", c.model)
-	}
-	args = append(args, c.extraArgs...)
-	args = append(args, prompt)
-
-	cmd := c.cmdFactory(ctx, "claude", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	slog.Debug("running claude cli", "args", args, "noTools", noTools, "timeout", c.timeout)
-
-	if err := cmd.Run(); err != nil {
-		if execErr, ok := err.(*exec.Error); ok {
-			return &NotInstalledError{Err: execErr}
+// runAndDecode handles session-aware CLI invocation: builds args based
+// on the current session ID, runs the subprocess, decodes the envelope,
+// captures the new session_id, and unmarshals the result into target.
+// On a stderr that looks like an expired/missing session it transparently
+// clears the session ID and retries once with full args (start fresh).
+func (c *Client) runAndDecode(ctx context.Context, system, prompt string, noTools bool, target any) error {
+	env, err := c.runOnce(ctx, system, prompt, noTools)
+	if err != nil {
+		// If the failure looks like an expired session, drop the
+		// stored ID and try once more from scratch. We log the
+		// reason so an operator can see the resume cycle in
+		// `vairdict logs`.
+		if c.maybeClearExpiredSession(err) {
+			slog.Info("claude cli session expired, retrying with fresh session", "err", err.Error())
+			env, err = c.runOnce(ctx, system, prompt, noTools)
 		}
-		if ctx.Err() != nil {
-			return fmt.Errorf("claude cli cancelled: %w", ctx.Err())
+		if err != nil {
+			return err
 		}
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return &ExitError{
-				ExitCode: exitErr.ExitCode(),
-				Stderr:   stderr.String(),
-				Err:      err,
-			}
-		}
-		return fmt.Errorf("running claude cli: %w", err)
-	}
-
-	slog.Debug("claude cli completed", "duration", time.Since(start), "noTools", noTools)
-
-	var env envelope
-	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
-		return &ParseError{Raw: stdout.String(), Err: fmt.Errorf("decoding envelope: %w", err)}
-	}
-	if env.IsError {
-		return &ParseError{Raw: env.Result, Err: fmt.Errorf("claude cli returned is_error=true (subtype=%s)", env.Subtype)}
-	}
-	if env.Result == "" {
-		return &ParseError{Raw: stdout.String(), Err: fmt.Errorf("empty result field in envelope")}
 	}
 
 	cleaned := extractJSON(env.Result)
@@ -285,92 +294,162 @@ func (c *Client) completeWithOpts(ctx context.Context, system, prompt string, no
 	return nil
 }
 
+// runOnce executes a single CLI subprocess attempt. Returns the decoded
+// envelope on success; typed errors (NotInstalledError, ExitError,
+// ParseError) on failure. Captures and stores the envelope's session_id
+// so subsequent calls within this Client lifetime can --resume.
+func (c *Client) runOnce(ctx context.Context, system, prompt string, noTools bool) (envelope, error) {
+	start := time.Now()
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	c.mu.Lock()
+	sessionID := c.sessionID
+	c.mu.Unlock()
+
+	args := buildArgs(sessionID, system, c.model, c.extraArgs, prompt, noTools)
+	cmd := c.cmdFactory(ctx, "claude", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	slog.Debug("running claude cli",
+		"args", args,
+		"noTools", noTools,
+		"timeout", c.timeout,
+		"resumed", sessionID != "",
+	)
+
+	if err := cmd.Run(); err != nil {
+		if execErr, ok := err.(*exec.Error); ok {
+			return envelope{}, &NotInstalledError{Err: execErr}
+		}
+		if ctx.Err() != nil {
+			return envelope{}, fmt.Errorf("claude cli cancelled: %w", ctx.Err())
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return envelope{}, &ExitError{
+				ExitCode: exitErr.ExitCode(),
+				Stderr:   stderr.String(),
+				Err:      err,
+			}
+		}
+		return envelope{}, fmt.Errorf("running claude cli: %w", err)
+	}
+
+	slog.Debug("claude cli completed", "duration", time.Since(start), "noTools", noTools)
+
+	var env envelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		return envelope{}, &ParseError{Raw: stdout.String(), Err: fmt.Errorf("decoding envelope: %w", err)}
+	}
+	if env.IsError {
+		return envelope{}, &ParseError{Raw: env.Result, Err: fmt.Errorf("claude cli returned is_error=true (subtype=%s)", env.Subtype)}
+	}
+	if env.Result == "" {
+		return envelope{}, &ParseError{Raw: stdout.String(), Err: fmt.Errorf("empty result field in envelope")}
+	}
+
+	if env.SessionID != "" {
+		c.mu.Lock()
+		c.sessionID = env.SessionID
+		c.mu.Unlock()
+	}
+
+	return env, nil
+}
+
+// buildArgs returns the argv for one `claude -p` invocation. When
+// sessionID is non-empty the call uses `--resume <id>` and skips
+// `--append-system-prompt` (the system prompt is already in the
+// resumed session); otherwise it sends the full first-call args.
+// Pulled out as a free function so it's trivially unit-testable.
+func buildArgs(sessionID, system, model string, extra []string, prompt string, noTools bool) []string {
+	args := make([]string, 0, 12)
+	if sessionID != "" {
+		args = append(args, "--resume", sessionID)
+	}
+	args = append(args, "-p", "--output-format", "json")
+	if noTools {
+		args = append(args, "--tools", "")
+	}
+	if sessionID == "" && system != "" {
+		args = append(args, "--append-system-prompt", system)
+	}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	args = append(args, extra...)
+	args = append(args, prompt)
+	return args
+}
+
+// maybeClearExpiredSession inspects an error from a `claude` invocation
+// and, if it looks like an expired/missing session, clears the stored
+// session ID and returns true so the caller knows to retry. Returns
+// false (and leaves state alone) when the error is unrelated to
+// session lifecycle. We only consider clearing when a session was
+// actually in use — otherwise there's nothing to clear.
+func (c *Client) maybeClearExpiredSession(err error) bool {
+	c.mu.Lock()
+	hadSession := c.sessionID != ""
+	c.mu.Unlock()
+	if !hadSession {
+		return false
+	}
+
+	exitErr, ok := err.(*ExitError)
+	if !ok {
+		return false
+	}
+	if !looksLikeSessionExpired(exitErr.Stderr) {
+		return false
+	}
+
+	c.mu.Lock()
+	c.sessionID = ""
+	c.mu.Unlock()
+	return true
+}
+
+// looksLikeSessionExpired matches the Claude CLI's stderr signatures
+// for an unusable session id. Kept loose because the CLI's wording has
+// drifted across versions; false positives just cause an extra fresh
+// invocation, which is cheap.
+func looksLikeSessionExpired(stderr string) bool {
+	if stderr == "" {
+		return false
+	}
+	low := strings.ToLower(stderr)
+	if !strings.Contains(low, "session") {
+		return false
+	}
+	for _, marker := range []string{"expired", "not found", "no such", "invalid", "does not exist"} {
+		if strings.Contains(low, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 // CompleteWithSystem runs `claude -p --output-format json` with the given
 // system and user prompts and unmarshals the assistant's JSON output into
 // target. Structure:
 //
-//  1. Spawn `claude` with args built from the options.
-//  2. Read the envelope and extract envelope.Result.
+//  1. Spawn `claude` with args built from the options (including
+//     `--resume <id>` when a prior session ID is on the Client).
+//  2. Read the envelope and extract envelope.Result. Capture
+//     envelope.SessionID so subsequent calls can resume.
 //  3. Pass envelope.Result through extractJSON (strips markdown fences).
 //  4. json.Unmarshal into target.
 //
 // Errors are typed: NotInstalledError when the binary is missing, ExitError
 // when the process exits non-zero, ParseError for any JSON decode failure.
 // ctx cancellation and the configured timeout are both honored via
-// CommandContext.
+// CommandContext. Tool use is left enabled (this is the planner path).
 func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, target any) error {
-	start := time.Now()
-
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
-	defer cancel()
-
-	args := []string{"-p", "--output-format", "json"}
-	if system != "" {
-		args = append(args, "--append-system-prompt", system)
-	}
-	if c.model != "" {
-		args = append(args, "--model", c.model)
-	}
-	args = append(args, c.extraArgs...)
-	args = append(args, prompt)
-
-	cmd := c.cmdFactory(ctx, "claude", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	slog.Debug("running claude cli", "args", args, "timeout", c.timeout)
-
-	if err := cmd.Run(); err != nil {
-		// Binary not found: exec.Error wraps the LookPath failure.
-		if execErr, ok := err.(*exec.Error); ok {
-			return &NotInstalledError{Err: execErr}
-		}
-		// ctx.Err() check must come before ExitError: a killed process
-		// also surfaces as an ExitError but the root cause is the
-		// cancellation / timeout.
-		if ctx.Err() != nil {
-			return fmt.Errorf("claude cli cancelled: %w", ctx.Err())
-		}
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return &ExitError{
-				ExitCode: exitErr.ExitCode(),
-				Stderr:   stderr.String(),
-				Err:      err,
-			}
-		}
-		return fmt.Errorf("running claude cli: %w", err)
-	}
-
-	slog.Debug("claude cli completed", "duration", time.Since(start))
-
-	var env envelope
-	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
-		return &ParseError{Raw: stdout.String(), Err: fmt.Errorf("decoding envelope: %w", err)}
-	}
-	if env.IsError {
-		return &ParseError{Raw: env.Result, Err: fmt.Errorf("claude cli returned is_error=true (subtype=%s)", env.Subtype)}
-	}
-	if env.Result == "" {
-		return &ParseError{Raw: stdout.String(), Err: fmt.Errorf("empty result field in envelope")}
-	}
-
-	cleaned := extractJSON(env.Result)
-	if err := json.Unmarshal([]byte(cleaned), target); err != nil {
-		// Log the raw output so operators can diagnose what Claude
-		// actually said when the extract+parse path fails. Slog debug
-		// only — the ParseError itself truncates to 200 chars for
-		// display, which isn't enough to see what went wrong.
-		slog.Debug("claude cli parse failed",
-			"err", err,
-			"raw_len", len(env.Result),
-			"cleaned_len", len(cleaned),
-			"raw_head", truncate(env.Result, 500),
-			"cleaned_head", truncate(cleaned, 500),
-		)
-		return &ParseError{Raw: env.Result, Err: fmt.Errorf("decoding result into target: %w", err)}
-	}
-	return nil
+	return c.runAndDecode(ctx, system, prompt, false, target)
 }
 
 // truncate returns the first n characters of s (never panics on short

--- a/internal/agents/claudecli/client_test.go
+++ b/internal/agents/claudecli/client_test.go
@@ -349,3 +349,255 @@ func TestExtractJSON(t *testing.T) {
 		})
 	}
 }
+
+// --- Session reuse tests (#137) ---
+
+// stdoutCmdWithStderr is a fake exec.Cmd that prints stdout AND stderr.
+// Used for expired-session tests so the script can exit non-zero with
+// a stderr message resembling Claude's "session not found" wording.
+func stdoutCmdWithStderr(ctx context.Context, stdout, stderr string, exit int) *exec.Cmd {
+	script := `printf '%s' "$FAKE_STDOUT"; printf '%s' "$FAKE_STDERR" >&2; exit ${FAKE_EXIT:-0}`
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"FAKE_STDOUT="+stdout,
+		"FAKE_STDERR="+stderr,
+		"FAKE_EXIT="+itoa(exit),
+	)
+	return cmd
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}
+
+func TestCompleteWithSystem_FirstCallSendsFullSystemPrompt(t *testing.T) {
+	// First call (no prior session) must send --append-system-prompt
+	// AND must NOT include --resume.
+	envelope := `{"type":"result","is_error":false,"result":"{}","session_id":"sess_abc"}`
+	var captured []string
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		captured = append([]string{name}, args...)
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "the system prompt", "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	joined := strings.Join(captured, " ")
+	if !strings.Contains(joined, "--append-system-prompt the system prompt") {
+		t.Errorf("first call must include --append-system-prompt, got: %s", joined)
+	}
+	if strings.Contains(joined, "--resume") {
+		t.Errorf("first call must NOT include --resume, got: %s", joined)
+	}
+	if c.SessionID() != "sess_abc" {
+		t.Errorf("session id not captured: got %q, want sess_abc", c.SessionID())
+	}
+}
+
+func TestCompleteWithSystem_SecondCallResumesAndSkipsSystemPrompt(t *testing.T) {
+	// Second call (session id captured from first) must include
+	// --resume <id> and must NOT re-send --append-system-prompt — that's
+	// the whole point of the optimization.
+	envelopes := []string{
+		`{"type":"result","is_error":false,"result":"{}","session_id":"sess_abc"}`,
+		`{"type":"result","is_error":false,"result":"{}","session_id":"sess_abc"}`,
+	}
+	var capturedRuns [][]string
+	idx := 0
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		capturedRuns = append(capturedRuns, append([]string{name}, args...))
+		env := envelopes[idx]
+		idx++
+		return stdoutCmd(ctx, env)
+	}))
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "system prompt v1", "p1", &got); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := c.CompleteWithSystem(context.Background(), "system prompt v1", "p2", &got); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	if len(capturedRuns) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(capturedRuns))
+	}
+	first := strings.Join(capturedRuns[0], " ")
+	second := strings.Join(capturedRuns[1], " ")
+
+	if !strings.Contains(first, "--append-system-prompt") {
+		t.Errorf("first call should include --append-system-prompt, got: %s", first)
+	}
+	if !strings.Contains(second, "--resume sess_abc") {
+		t.Errorf("second call should include --resume sess_abc, got: %s", second)
+	}
+	if strings.Contains(second, "--append-system-prompt") {
+		t.Errorf("second call must NOT re-send --append-system-prompt, got: %s", second)
+	}
+}
+
+func TestWithSessionID_FirstCallResumesImmediately(t *testing.T) {
+	// Construction-time session id (e.g. from `vairdict resume`)
+	// must take effect on the very first call.
+	envelope := `{"type":"result","is_error":false,"result":"{}","session_id":"sess_xyz"}`
+	var captured []string
+	c := New(
+		WithSessionID("sess_xyz"),
+		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			captured = append([]string{name}, args...)
+			return stdoutCmd(ctx, envelope)
+		}),
+	)
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "system prompt", "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(captured, " ")
+	if !strings.Contains(joined, "--resume sess_xyz") {
+		t.Errorf("seeded session must --resume on first call, got: %s", joined)
+	}
+	if strings.Contains(joined, "--append-system-prompt") {
+		t.Errorf("seeded session must NOT re-send system prompt, got: %s", joined)
+	}
+}
+
+func TestSetSessionID_RoundTrips(t *testing.T) {
+	c := New()
+	if c.SessionID() != "" {
+		t.Errorf("fresh client should have empty session id, got %q", c.SessionID())
+	}
+	c.SetSessionID("manual_id")
+	if c.SessionID() != "manual_id" {
+		t.Errorf("SetSessionID round-trip failed: got %q", c.SessionID())
+	}
+	c.SetSessionID("")
+	if c.SessionID() != "" {
+		t.Errorf("empty SetSessionID should clear, got %q", c.SessionID())
+	}
+}
+
+func TestCompleteWithSystem_ExpiredSessionRetriesFresh(t *testing.T) {
+	// First call: success, captures session id.
+	// Second call: simulates expired session — exits non-zero with
+	// stderr matching "session not found". Client must clear the
+	// session id and retry once with a fresh full-args invocation.
+	successEnv := `{"type":"result","is_error":false,"result":"{}","session_id":"sess_old"}`
+	freshEnv := `{"type":"result","is_error":false,"result":"{}","session_id":"sess_new"}`
+
+	var capturedRuns [][]string
+	calls := 0
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		capturedRuns = append(capturedRuns, append([]string{name}, args...))
+		calls++
+		switch calls {
+		case 1:
+			return stdoutCmd(ctx, successEnv)
+		case 2:
+			// Resume attempt — fail with expired-session stderr.
+			return stdoutCmdWithStderr(ctx, "", "Error: session not found\n", 1)
+		default:
+			// Fresh retry succeeds.
+			return stdoutCmd(ctx, freshEnv)
+		}
+	}))
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "sys", "p1", &got); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := c.CompleteWithSystem(context.Background(), "sys", "p2", &got); err != nil {
+		t.Fatalf("second call after expired-session retry: %v", err)
+	}
+
+	if calls != 3 {
+		t.Errorf("expected 3 subprocess invocations (initial, expired resume, fresh retry), got %d", calls)
+	}
+	joinedRetry := strings.Join(capturedRuns[2], " ")
+	if strings.Contains(joinedRetry, "--resume") {
+		t.Errorf("retry after expired session should NOT --resume, got: %s", joinedRetry)
+	}
+	if !strings.Contains(joinedRetry, "--append-system-prompt") {
+		t.Errorf("retry after expired session should re-send --append-system-prompt, got: %s", joinedRetry)
+	}
+	if c.SessionID() != "sess_new" {
+		t.Errorf("after retry, session id should be sess_new, got %q", c.SessionID())
+	}
+}
+
+func TestLooksLikeSessionExpired(t *testing.T) {
+	cases := []struct {
+		stderr string
+		want   bool
+	}{
+		{"Error: session not found", true},
+		{"session expired", true},
+		{"Session does not exist for id sess_xyz", true},
+		{"no such session", true},
+		{"invalid session", true},
+		{"connection timeout", false},
+		{"some other error", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := looksLikeSessionExpired(tc.stderr); got != tc.want {
+			t.Errorf("looksLikeSessionExpired(%q) = %v, want %v", tc.stderr, got, tc.want)
+		}
+	}
+}
+
+func TestBuildArgs_Shape(t *testing.T) {
+	t.Run("no_session_with_system", func(t *testing.T) {
+		args := buildArgs("", "sys", "", nil, "p", false)
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "-p --output-format json") {
+			t.Errorf("missing core flags: %s", joined)
+		}
+		if !strings.Contains(joined, "--append-system-prompt sys") {
+			t.Errorf("missing system: %s", joined)
+		}
+		if strings.Contains(joined, "--resume") {
+			t.Errorf("must not include --resume: %s", joined)
+		}
+		if args[len(args)-1] != "p" {
+			t.Errorf("prompt must be last: %v", args)
+		}
+	})
+
+	t.Run("with_session_skips_system", func(t *testing.T) {
+		args := buildArgs("sess_id", "sys", "", nil, "p", false)
+		joined := strings.Join(args, " ")
+		if !strings.HasPrefix(joined, "--resume sess_id") {
+			t.Errorf("--resume must come first, got: %s", joined)
+		}
+		if strings.Contains(joined, "--append-system-prompt") {
+			t.Errorf("must not include --append-system-prompt on resume: %s", joined)
+		}
+	})
+
+	t.Run("notools_flag", func(t *testing.T) {
+		args := buildArgs("", "", "", nil, "p", true)
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "--tools") {
+			t.Errorf("expected --tools flag: %s", joined)
+		}
+	})
+}

--- a/internal/conflicts/conflicts_test.go
+++ b/internal/conflicts/conflicts_test.go
@@ -229,6 +229,11 @@ func initTestRepo(t *testing.T) string {
 	run("init", "-b", "main")
 	run("config", "user.email", "test@test.com")
 	run("config", "user.name", "test")
+	// See workspace_test.go — disable signing on the test fixture so
+	// inherited global signing config doesn't reject the synthetic
+	// commits this test makes in a temp repo.
+	run("config", "commit.gpgsign", "false")
+	run("config", "tag.gpgsign", "false")
 
 	// Create initial commit.
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0o644); err != nil {
@@ -283,6 +288,8 @@ func TestIntegration_CleanMerge(t *testing.T) {
 	}
 	run(clone, "config", "user.email", "test@test.com")
 	run(clone, "config", "user.name", "test")
+	run(clone, "config", "commit.gpgsign", "false")
+	run(clone, "config", "tag.gpgsign", "false")
 
 	// Create a task branch with a non-conflicting change.
 	run(clone, "checkout", "-b", "vairdict/task-1")
@@ -334,6 +341,8 @@ func TestIntegration_RebaseSuccess(t *testing.T) {
 	}
 	run(clone, "config", "user.email", "test@test.com")
 	run(clone, "config", "user.name", "test")
+	run(clone, "config", "commit.gpgsign", "false")
+	run(clone, "config", "tag.gpgsign", "false")
 
 	// Create task branch with change to new file.
 	run(clone, "checkout", "-b", "vairdict/task-1")
@@ -395,6 +404,8 @@ func TestIntegration_ConflictEscalation(t *testing.T) {
 	}
 	run(clone, "config", "user.email", "test@test.com")
 	run(clone, "config", "user.name", "test")
+	run(clone, "config", "commit.gpgsign", "false")
+	run(clone, "config", "tag.gpgsign", "false")
 
 	// Create task branch that modifies README.md.
 	run(clone, "checkout", "-b", "vairdict/task-1")
@@ -488,6 +499,8 @@ func TestIntegration_ConcurrentTaskOverlap(t *testing.T) {
 		}
 		runIn(dir, "config", "user.email", "test@test.com")
 		runIn(dir, "config", "user.name", "test")
+		runIn(dir, "config", "commit.gpgsign", "false")
+		runIn(dir, "config", "tag.gpgsign", "false")
 		runIn(dir, "checkout", "-b", "vairdict/"+name)
 		if err := os.WriteFile(filepath.Join(dir, file), []byte(content), 0o644); err != nil {
 			t.Fatal(err)

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -36,6 +36,14 @@ type Planner interface {
 	CompleteWithSystem(ctx context.Context, system, prompt string, target any) error
 }
 
+// streamingPlanner is the optional capability satisfied by planners that
+// can stream output. PlanPhase type-asserts against it; planners that
+// don't satisfy it (e.g. claudecli — the CLI doesn't expose SSE) silently
+// fall back to the non-streaming Planner path even when OnDelta is set.
+type streamingPlanner interface {
+	CompleteWithSystemStream(ctx context.Context, system, prompt string, target any, onDelta func(text string)) error
+}
+
 // Judge is the interface for the plan judge that evaluates plans.
 type Judge interface {
 	Judge(ctx context.Context, intent string, plan string, acknowledged []state.Assumption) (*state.Verdict, error)
@@ -47,6 +55,15 @@ type PlanPhase struct {
 	judge      Judge
 	cfg        config.PlanPhaseConfig
 	OnProgress func(loop, max int, step string, score float64, pass bool, gaps []state.Gap)
+	// OnDelta, when non-nil, receives partial planner output as it
+	// streams in. The total wall-clock time of a planner call is
+	// roughly unchanged — this exists so the user sees the plan
+	// forming instead of staring at "generating plan" until the
+	// final message returns. Only takes effect when the underlying
+	// planner satisfies the streamingPlanner capability (the
+	// claude-api client does; claudecli does not). Nil is the
+	// default and matches pre-#137 behavior exactly.
+	OnDelta func(text string)
 }
 
 // New creates a PlanPhase with the given planner client, judge, and config.
@@ -62,6 +79,18 @@ func (p *PlanPhase) notify(loop, max int, step string, score float64, pass bool,
 	if p.OnProgress != nil {
 		p.OnProgress(loop, max, step, score, pass, gaps)
 	}
+}
+
+// completePlanner dispatches to the streaming planner when both the
+// client supports it and OnDelta is wired; otherwise the original
+// blocking path. Pulled out so Run stays focused on phase orchestration.
+func (p *PlanPhase) completePlanner(ctx context.Context, system, prompt string, target any) error {
+	if p.OnDelta != nil {
+		if sp, ok := p.planner.(streamingPlanner); ok {
+			return sp.CompleteWithSystemStream(ctx, system, prompt, target, p.OnDelta)
+		}
+	}
+	return p.planner.CompleteWithSystem(ctx, system, prompt, target)
 }
 
 const plannerSystemPromptCore = `You are a software development planner. Your job is to take a task intent and produce a detailed requirements document and implementation plan.
@@ -120,10 +149,13 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 			task.Notes = nil
 		}
 
-		// Call the planner agent.
+		// Call the planner agent. Stream when both the underlying
+		// client supports it AND OnDelta is set; otherwise fall
+		// back to the blocking call so claudecli (no SSE) and
+		// callers that don't care about deltas keep working.
 		p.notify(loop+1, p.cfg.MaxLoops, "generating plan", 0, false, nil)
 		var resp plannerResponse
-		if err := p.planner.CompleteWithSystem(ctx, plannerSystemPrompt, prompt, &resp); err != nil {
+		if err := p.completePlanner(ctx, plannerSystemPrompt, prompt, &resp); err != nil {
 			return nil, fmt.Errorf("calling planner agent: %w", err)
 		}
 

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -710,3 +710,97 @@ func TestBuildFeedbackSummary(t *testing.T) {
 		t.Errorf("expected question, got: %s", summary)
 	}
 }
+
+// --- Streaming planner tests (#137) ---
+
+// streamingClient is a test double that implements both Planner and the
+// streamingPlanner capability. blockingCalls / streamingCalls let tests
+// assert which dispatch path was actually taken.
+type streamingClient struct {
+	response       plannerResponse
+	deltaChunks    []string
+	blockingCalls  int
+	streamingCalls int
+}
+
+func (s *streamingClient) CompleteWithSystem(_ context.Context, _, _ string, target any) error {
+	s.blockingCalls++
+	data, _ := json.Marshal(s.response)
+	return json.Unmarshal(data, target)
+}
+
+func (s *streamingClient) CompleteWithSystemStream(_ context.Context, _, _ string, target any, onDelta func(text string)) error {
+	s.streamingCalls++
+	for _, c := range s.deltaChunks {
+		if onDelta != nil {
+			onDelta(c)
+		}
+	}
+	data, _ := json.Marshal(s.response)
+	return json.Unmarshal(data, target)
+}
+
+func TestPlanPhase_OnDeltaWithStreamingClient_UsesStreamingPath(t *testing.T) {
+	planner := &streamingClient{
+		response:    passingPlanResponse(),
+		deltaChunks: []string{"chunk-1 ", "chunk-2"},
+	}
+	judge := &fakeJudge{verdicts: []*state.Verdict{passingVerdict()}}
+
+	phase := New(planner, judge, testConfig())
+	var got []string
+	phase.OnDelta = func(text string) { got = append(got, text) }
+
+	if _, err := phase.Run(context.Background(), newPendingTask()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if planner.streamingCalls != 1 {
+		t.Errorf("expected 1 streaming call, got %d", planner.streamingCalls)
+	}
+	if planner.blockingCalls != 0 {
+		t.Errorf("expected 0 blocking calls, got %d", planner.blockingCalls)
+	}
+	if strings.Join(got, "") != "chunk-1 chunk-2" {
+		t.Errorf("delta accumulator mismatch: %v", got)
+	}
+}
+
+func TestPlanPhase_NoOnDelta_UsesBlockingPath(t *testing.T) {
+	// Default behavior — no OnDelta set, even on a streaming-capable
+	// client we must not pay the SSE cost.
+	planner := &streamingClient{response: passingPlanResponse()}
+	judge := &fakeJudge{verdicts: []*state.Verdict{passingVerdict()}}
+
+	phase := New(planner, judge, testConfig())
+
+	if _, err := phase.Run(context.Background(), newPendingTask()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if planner.streamingCalls != 0 {
+		t.Errorf("expected 0 streaming calls when OnDelta nil, got %d", planner.streamingCalls)
+	}
+	if planner.blockingCalls != 1 {
+		t.Errorf("expected 1 blocking call, got %d", planner.blockingCalls)
+	}
+}
+
+func TestPlanPhase_OnDeltaSet_NonStreamingClient_FallsBack(t *testing.T) {
+	// multiResponseClient does NOT implement streamingPlanner. Setting
+	// OnDelta must not blow up — fall back to the blocking path.
+	planner := &multiResponseClient{responses: []any{passingPlanResponse()}}
+	judge := &fakeJudge{verdicts: []*state.Verdict{passingVerdict()}}
+
+	phase := New(planner, judge, testConfig())
+	deltaCalls := 0
+	phase.OnDelta = func(string) { deltaCalls++ }
+
+	if _, err := phase.Run(context.Background(), newPendingTask()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deltaCalls != 0 {
+		t.Errorf("expected OnDelta unused on non-streaming client, got %d calls", deltaCalls)
+	}
+	if len(planner.calls) != 1 {
+		t.Errorf("expected 1 blocking call, got %d", len(planner.calls))
+	}
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -95,6 +95,7 @@ func (s *Store) migrate() error {
 		{"rewind_contexts", `ALTER TABLE tasks ADD COLUMN rewind_contexts TEXT NOT NULL DEFAULT '[]'`},
 		{"plan_output", `ALTER TABLE tasks ADD COLUMN plan_output TEXT NOT NULL DEFAULT ''`},
 		{"pid", `ALTER TABLE tasks ADD COLUMN pid INTEGER NOT NULL DEFAULT 0`},
+		{"cli_session_ids", `ALTER TABLE tasks ADD COLUMN cli_session_ids TEXT NOT NULL DEFAULT '{}'`},
 	} {
 		if _, err := s.db.Exec(alter.stmt); err != nil && !isDuplicateColumnErr(err) {
 			return fmt.Errorf("adding %s column: %w", alter.column, err)
@@ -142,6 +143,10 @@ func (s *Store) CreateTask(t *Task) error {
 	if err != nil {
 		return fmt.Errorf("marshaling rewind_contexts: %w", err)
 	}
+	cliSessionIDsJSON, err := json.Marshal(t.CLISessionIDs)
+	if err != nil {
+		return fmt.Errorf("marshaling cli_session_ids: %w", err)
+	}
 
 	priority := t.Priority
 	if priority == "" {
@@ -149,12 +154,12 @@ func (s *Store) CreateTask(t *Task) error {
 	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO tasks (id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO tasks (id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, cli_session_ids, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		t.ID, t.Intent, string(t.State), string(t.Phase),
 		string(loopJSON), string(assumptionsJSON), string(attemptsJSON), string(dependsOnJSON),
 		priority, string(hardConstraintsJSON), string(rewindContextsJSON),
-		t.PlanOutput, t.PID,
+		t.PlanOutput, t.PID, string(cliSessionIDsJSON),
 		t.CreatedAt.Format(time.RFC3339Nano), t.UpdatedAt.Format(time.RFC3339Nano),
 	)
 	if err != nil {
@@ -166,7 +171,7 @@ func (s *Store) CreateTask(t *Task) error {
 // GetTask retrieves a task by ID. Returns sql.ErrNoRows if not found.
 func (s *Store) GetTask(id string) (*Task, error) {
 	row := s.db.QueryRow(
-		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at
+		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, cli_session_ids, created_at, updated_at
 		 FROM tasks WHERE id = ?`, id,
 	)
 	return s.scanTask(row)
@@ -198,6 +203,10 @@ func (s *Store) UpdateTask(t *Task) error {
 	if err != nil {
 		return fmt.Errorf("marshaling rewind_contexts: %w", err)
 	}
+	cliSessionIDsJSON, err := json.Marshal(t.CLISessionIDs)
+	if err != nil {
+		return fmt.Errorf("marshaling cli_session_ids: %w", err)
+	}
 
 	priority := t.Priority
 	if priority == "" {
@@ -205,12 +214,12 @@ func (s *Store) UpdateTask(t *Task) error {
 	}
 
 	result, err := s.db.Exec(
-		`UPDATE tasks SET intent=?, state=?, phase=?, loop_count=?, assumptions=?, attempts=?, depends_on=?, priority=?, hard_constraints=?, rewind_contexts=?, plan_output=?, pid=?, updated_at=?
+		`UPDATE tasks SET intent=?, state=?, phase=?, loop_count=?, assumptions=?, attempts=?, depends_on=?, priority=?, hard_constraints=?, rewind_contexts=?, plan_output=?, pid=?, cli_session_ids=?, updated_at=?
 		 WHERE id=?`,
 		t.Intent, string(t.State), string(t.Phase),
 		string(loopJSON), string(assumptionsJSON), string(attemptsJSON), string(dependsOnJSON),
 		priority, string(hardConstraintsJSON), string(rewindContextsJSON),
-		t.PlanOutput, t.PID,
+		t.PlanOutput, t.PID, string(cliSessionIDsJSON),
 		t.UpdatedAt.Format(time.RFC3339Nano), t.ID,
 	)
 	if err != nil {
@@ -235,12 +244,12 @@ func (s *Store) ListTasks(filterState TaskState) ([]*Task, error) {
 
 	if filterState == "" {
 		rows, err = s.db.Query(
-			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at
+			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, cli_session_ids, created_at, updated_at
 			 FROM tasks ORDER BY created_at ASC`,
 		)
 	} else {
 		rows, err = s.db.Query(
-			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at
+			`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, cli_session_ids, created_at, updated_at
 			 FROM tasks WHERE state = ? ORDER BY created_at ASC`,
 			string(filterState),
 		)
@@ -270,7 +279,7 @@ func (s *Store) ListTasks(filterState TaskState) ([]*Task, error) {
 // unfinished work ahead of completed runs.
 func (s *Store) ListResumable() ([]*Task, error) {
 	rows, err := s.db.Query(
-		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, created_at, updated_at
+		`SELECT id, intent, state, phase, loop_count, assumptions, attempts, depends_on, priority, hard_constraints, rewind_contexts, plan_output, pid, cli_session_ids, created_at, updated_at
 		 FROM tasks
 		 WHERE state IN ('planning','plan_review','coding','code_review','quality','quality_review')
 		 ORDER BY updated_at DESC`,
@@ -320,6 +329,7 @@ func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 		rewindContextsJSON  string
 		planOutput          string
 		pid                 int
+		cliSessionIDsJSON   string
 		createdAt           string
 		updatedAt           string
 	)
@@ -327,7 +337,7 @@ func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 	err := sc.Scan(&t.ID, &t.Intent, &state, &phase,
 		&loopJSON, &assumptionsJSON, &attemptsJSON, &dependsOnJSON, &priority,
 		&hardConstraintsJSON, &rewindContextsJSON,
-		&planOutput, &pid,
+		&planOutput, &pid, &cliSessionIDsJSON,
 		&createdAt, &updatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("scanning task: %w", err)
@@ -367,6 +377,12 @@ func (s *Store) scanFromScanner(sc scanner) (*Task, error) {
 	if rewindContextsJSON != "" {
 		if err := json.Unmarshal([]byte(rewindContextsJSON), &t.RewindContexts); err != nil {
 			return nil, fmt.Errorf("unmarshaling rewind_contexts: %w", err)
+		}
+	}
+
+	if cliSessionIDsJSON != "" && cliSessionIDsJSON != "{}" {
+		if err := json.Unmarshal([]byte(cliSessionIDsJSON), &t.CLISessionIDs); err != nil {
+			return nil, fmt.Errorf("unmarshaling cli_session_ids: %w", err)
 		}
 	}
 

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -249,7 +249,7 @@ func TestUpdateTask(t *testing.T) {
 
 	_ = task.Transition(StatePlanning)
 	task.Assumptions = []Assumption{
-		{Description: "API is stable", Severity: SeverityP2, Phase: PhasePlan},
+		{Description: "API is stable", Severity: SeverityMedium, Phase: PhasePlan},
 	}
 	task.Attempts = []Attempt{
 		{Phase: PhasePlan, Loop: 0, CreatedAt: time.Now()},
@@ -361,12 +361,12 @@ func TestPersistenceAcrossReopen(t *testing.T) {
 	_ = task.Transition(StatePlanning)
 	task.LoopCount[PhasePlan] = 2
 	task.Assumptions = []Assumption{
-		{Description: "test assumption", Severity: SeverityP1, Phase: PhasePlan},
+		{Description: "test assumption", Severity: SeverityHigh, Phase: PhasePlan},
 	}
 	task.Attempts = []Attempt{
 		{
 			Phase: PhasePlan, Loop: 1,
-			Verdict:   &Verdict{Score: 0.8, Pass: true, Gaps: []Gap{{Severity: SeverityP2, Description: "minor gap", Blocking: false}}},
+			Verdict:   &Verdict{Score: 0.8, Pass: true, Gaps: []Gap{{Severity: SeverityMedium, Description: "minor gap", Blocking: false}}},
 			CreatedAt: time.Now(),
 		},
 	}
@@ -394,7 +394,7 @@ func TestPersistenceAcrossReopen(t *testing.T) {
 	if len(got.Assumptions) != 1 {
 		t.Fatalf("expected 1 assumption, got %d", len(got.Assumptions))
 	}
-	if got.Assumptions[0].Severity != SeverityP1 {
+	if got.Assumptions[0].Severity != SeverityHigh {
 		t.Errorf("expected severity P1, got %s", got.Assumptions[0].Severity)
 	}
 	if len(got.Attempts) != 1 {

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -90,6 +90,71 @@ func TestCreateAndGetTask_HardConstraintsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCreateAndGetTask_CLISessionIDsRoundTrip(t *testing.T) {
+	// #137: cli_session_ids column persists per-role Claude CLI session
+	// IDs so `vairdict resume` reattaches to the same session a previous
+	// run established instead of starting fresh.
+	store := newTestStore(t)
+	task := NewTask("task-cli", "ship the streaming feature")
+	task.CLISessionIDs = map[string]string{
+		"planner":    "sess_planner_abc",
+		"plan_judge": "sess_judge_xyz",
+	}
+
+	if err := store.CreateTask(task); err != nil {
+		t.Fatalf("creating task: %v", err)
+	}
+	got, err := store.GetTask("task-cli")
+	if err != nil {
+		t.Fatalf("getting task: %v", err)
+	}
+	if len(got.CLISessionIDs) != 2 {
+		t.Fatalf("expected 2 session ids, got %d: %v", len(got.CLISessionIDs), got.CLISessionIDs)
+	}
+	if got.CLISessionIDs["planner"] != "sess_planner_abc" {
+		t.Errorf("planner session id = %q, want sess_planner_abc", got.CLISessionIDs["planner"])
+	}
+	if got.CLISessionIDs["plan_judge"] != "sess_judge_xyz" {
+		t.Errorf("plan_judge session id = %q, want sess_judge_xyz", got.CLISessionIDs["plan_judge"])
+	}
+
+	// Update path: add a new role, change an existing one.
+	got.CLISessionIDs["planner"] = "sess_planner_updated"
+	got.CLISessionIDs["quality_judge"] = "sess_quality_new"
+	got.UpdatedAt = time.Now()
+	if err := store.UpdateTask(got); err != nil {
+		t.Fatalf("updating task: %v", err)
+	}
+	refetched, err := store.GetTask("task-cli")
+	if err != nil {
+		t.Fatalf("refetching: %v", err)
+	}
+	if refetched.CLISessionIDs["planner"] != "sess_planner_updated" {
+		t.Errorf("updated planner session id mismatch: %q", refetched.CLISessionIDs["planner"])
+	}
+	if refetched.CLISessionIDs["quality_judge"] != "sess_quality_new" {
+		t.Errorf("new quality_judge session id mismatch: %q", refetched.CLISessionIDs["quality_judge"])
+	}
+}
+
+func TestCreateAndGetTask_NoCLISessionIDs(t *testing.T) {
+	// Tasks created without any CLI session IDs (API path or pre-#137)
+	// must round-trip a nil/empty map cleanly — no panics, no spurious
+	// entries.
+	store := newTestStore(t)
+	task := NewTask("task-no-cli", "intent")
+	if err := store.CreateTask(task); err != nil {
+		t.Fatalf("creating task: %v", err)
+	}
+	got, err := store.GetTask("task-no-cli")
+	if err != nil {
+		t.Fatalf("getting task: %v", err)
+	}
+	if len(got.CLISessionIDs) != 0 {
+		t.Errorf("expected empty session map, got %v", got.CLISessionIDs)
+	}
+}
+
 func TestCreateAndGetTask_RewindContextsRoundTrip(t *testing.T) {
 	// #86: rewind_contexts column must persist and hydrate so structured
 	// failure context survives a process restart. Without persistence,

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -415,6 +415,14 @@ type Task struct {
 	// liveness check; stale PIDs (process died without cleanup) show as
 	// not running and the task is resumable.
 	PID int `json:"pid,omitempty"`
+	// CLISessionIDs maps a completer role name (planner / plan_judge /
+	// quality_judge) to the most recent Claude CLI session ID captured
+	// from that role's claudecli client. `vairdict resume` reads this
+	// to reattach to the same session a previous run established
+	// instead of starting fresh and re-paying the system-prompt cost.
+	// Empty for tasks that ran on the API path (claudecli not used)
+	// or that were created before #137 — additive, no migration.
+	CLISessionIDs map[string]string `json:"cli_session_ids,omitempty"`
 	// Notes are transient, per-phase user guidance drained from the
 	// interactive run loop (#91). Never persisted (the `json:"-"` tag
 	// keeps them out of the DB column) — consumed exactly once by the

--- a/internal/ui/cli.go
+++ b/internal/ui/cli.go
@@ -126,6 +126,20 @@ func (r *cliRenderer) StepUpdate(phase state.Phase, step string) {
 	r.activeStep = step
 }
 
+// PhaseDelta streams partial planner output to the user as it arrives.
+// Writes go through the same buffered writer as other CLI output and
+// are flushed immediately so the stream feels live. The caller in
+// run.go is responsible for stopping the spinner before the first
+// delta — otherwise spinner redraws will overwrite streamed text on
+// the same line.
+func (r *cliRenderer) PhaseDelta(_ state.Phase, text string) {
+	if text == "" {
+		return
+	}
+	_, _ = r.w.WriteString(text)
+	r.flush()
+}
+
 func (r *cliRenderer) PhaseLoop(phase state.Phase, loop, max int, score float64, pass bool) {
 	defer r.flush()
 	r.scores[phase] = score

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -150,6 +150,15 @@ type Renderer interface {
 	Close() error
 }
 
+// DeltaPrinter is the optional capability satisfied by renderers that
+// can show streaming planner output. cli mode implements it; json and
+// ci modes do not — for those, deltas would mangle structured output.
+// Callers in cmd/vairdict/run.go type-assert against this and wire
+// PlanPhase.OnDelta only when the renderer supports it.
+type DeltaPrinter interface {
+	PhaseDelta(phase state.Phase, text string)
+}
+
 // PaletteForCLI extracts the palette from a Renderer if it is the CLI
 // renderer. Returns a zero palette (no ANSI escapes) for other renderers.
 // This is used by the spinner, which writes directly to stdout.

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -107,6 +107,29 @@ func TestCLIRendererWritesOutput(t *testing.T) {
 	}
 }
 
+func TestCLIRendererPhaseDelta_StreamsToWriter(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(Options{Out: &buf, Mode: ModeCLI, Colors: ColorsNone})
+	dp, ok := r.(DeltaPrinter)
+	if !ok {
+		t.Fatalf("cliRenderer must implement DeltaPrinter")
+	}
+	dp.PhaseDelta(state.PhasePlan, "first ")
+	dp.PhaseDelta(state.PhasePlan, "second ")
+	dp.PhaseDelta(state.PhasePlan, "third")
+	if got := buf.String(); got != "first second third" {
+		t.Errorf("expected concatenated stream, got %q", got)
+	}
+}
+
+func TestJSONRendererDoesNotImplementDeltaPrinter(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(Options{Out: &buf, Mode: ModeJSON})
+	if _, ok := r.(DeltaPrinter); ok {
+		t.Error("json renderer must NOT implement DeltaPrinter — would mangle structured output")
+	}
+}
+
 func TestJSONRendererEmitsValidJSON(t *testing.T) {
 	var buf bytes.Buffer
 	r := New(Options{Out: &buf, Mode: ModeJSON})

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -28,6 +28,14 @@ func setupTestRepo(t *testing.T) string {
 	run("init", "-b", "main")
 	run("config", "user.email", "test@test.com")
 	run("config", "user.name", "test")
+	// Disable commit signing for the test fixture. CI / sandbox
+	// environments may inherit a global signing config that injects
+	// itself into every `git commit` and fails on temp repos that
+	// don't have a matching key. This setting is scoped to the
+	// per-test temp repo only and does not change anything about
+	// how vairdict signs production commits.
+	run("config", "commit.gpgsign", "false")
+	run("config", "tag.gpgsign", "false")
 
 	// Create an initial commit so HEAD exists.
 	initial := filepath.Join(dir, "README.md")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,8 +7,18 @@
 # Respects:
 #   INSTALL_DIR  — where to put the binary (default: /usr/local/bin)
 #   VERSION      — specific version to install (default: latest)
+#   GITHUB_TOKEN — bearer token for the releases API call. When set,
+#                  the latest-version probe is authenticated, raising
+#                  the rate limit from 60/hour (anon) to 5000/hour
+#                  and avoiding the "Failed to detect latest version"
+#                  exit that hits CI runner pools sharing IP space.
 
 set -e
+# pipefail makes a curl failure inside a `curl | grep | sed` pipeline
+# propagate to set -e instead of producing empty output that the
+# downstream tools cheerfully consume. Posix /bin/sh doesn't all
+# support `set -o pipefail`; guard so this still runs on dash etc.
+(set -o pipefail) 2>/dev/null && set -o pipefail || true
 
 REPO="vairdict/vairdict"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
@@ -39,9 +49,41 @@ esac
 # --- Resolve version ---
 
 if [ -z "$VERSION" ]; then
-  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')"
+  # fetch_latest queries the releases/latest API. When GITHUB_TOKEN is
+  # set, sends Authorization so the request is authenticated (5000/hour
+  # rate limit) instead of anonymous (60/hour shared by IP across the
+  # runner pool — easy to exhaust on busy days). Two branches keep the
+  # quoting clean: building one with a header injected via shell
+  # variable would word-split badly.
+  fetch_latest() {
+    if [ -n "$GITHUB_TOKEN" ]; then
+      curl -fsSL \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "User-Agent: vairdict-install.sh" \
+        "https://api.github.com/repos/${REPO}/releases/latest"
+    else
+      curl -fsSL \
+        -H "Accept: application/vnd.github+json" \
+        -H "User-Agent: vairdict-install.sh" \
+        "https://api.github.com/repos/${REPO}/releases/latest"
+    fi
+  }
+
+  # Retry on transient API failures (rate-limit blips, network jitter,
+  # transient 5xx). Without retry the latest-version probe is a single
+  # point of failure on every PR's review check.
+  attempt=1
+  while [ "$attempt" -le 3 ]; do
+    if VERSION="$(fetch_latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')" && [ -n "$VERSION" ]; then
+      break
+    fi
+    echo "Attempt ${attempt}: failed to fetch latest version, retrying..." >&2
+    attempt=$((attempt + 1))
+    sleep 2
+  done
   if [ -z "$VERSION" ]; then
-    echo "Failed to detect latest version. Set VERSION explicitly." >&2
+    echo "Failed to detect latest version after 3 attempts. Set VERSION explicitly." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
Switch system field from string to typed-block array carrying an
ephemeral cache_control marker when the prompt crosses the
cacheThresholdChars threshold (~1024 tokens). Below threshold, the
field is sent as a plain string — preserves existing behavior and
avoids paying the cache-write cost on small prefixes.

usage struct gains cache_creation_input_tokens and
cache_read_input_tokens. logUsage emits a single slog.Info per
successful response so cache hit / miss is greppable in vairdict logs.

Refs #137 (sub-change 1 of 4).