### PR TITLE
feat(state): introduce Critical/High/Medium/Low severity vocabulary

### DIFF
--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -79,7 +79,7 @@ func passingVerdict() *state.Verdict {
 
 func failingVerdict() *state.Verdict {
 	return &state.Verdict{Score: 30, Pass: false, Gaps: []state.Gap{
-		{Severity: state.SeverityP0, Description: "broken", Blocking: true},
+		{Severity: state.SeverityCritical, Description: "broken", Blocking: true},
 	}}
 }
 

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -1062,10 +1062,10 @@ func buildRewindContext(cycle int, target state.Phase, v *state.Verdict, priorAp
 		// Fall back to a gap description when the judge didn't write a
 		// summary. Prefix with severity so a P3 gap can't masquerade as
 		// the blocking diagnosis when it ends up being the only one.
-		rc.RootCause = fmt.Sprintf("[%s] %s", g.Severity, g.Description)
+		rc.RootCause = fmt.Sprintf("[%s] %s", g.Severity.Display(), g.Description)
 	}
 	for _, g := range v.Gaps {
-		line := fmt.Sprintf("[%s] %s", g.Severity, g.Description)
+		line := fmt.Sprintf("[%s] %s", g.Severity.Display(), g.Description)
 		if g.File != "" {
 			if g.Line > 0 {
 				line = fmt.Sprintf("%s (%s:%d)", line, g.File, g.Line)
@@ -1109,7 +1109,7 @@ func buildQualityHardConstraints(v *state.Verdict) []string {
 		if !g.Blocking {
 			continue
 		}
-		c := fmt.Sprintf("[quality judge, %s] %s", g.Severity, g.Description)
+		c := fmt.Sprintf("[quality judge, %s] %s", g.Severity.Display(), g.Description)
 		if g.File != "" {
 			if g.Line > 0 {
 				c = fmt.Sprintf("%s (ref: %s:%d)", c, g.File, g.Line)

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -983,7 +983,7 @@ func runOrchestrationWithResume(ctx context.Context, deps runDeps, task *state.T
 			conflictGaps := make([]state.Gap, 0, len(conflictResult.ConflictFiles))
 			for _, f := range conflictResult.ConflictFiles {
 				conflictGaps = append(conflictGaps, state.Gap{
-					Severity:    state.SeverityP0,
+					Severity:    state.SeverityCritical,
 					Description: fmt.Sprintf("merge conflict in %s", f),
 					Blocking:    true,
 					File:        f,

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -471,7 +471,7 @@ func TestBuildQualityHardConstraints_OnlyBlockingGaps(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("expected 2 blocking constraints, got %d: %v", len(got), got)
 	}
-	if !strings.Contains(got[0], "P0") || !strings.Contains(got[0], "critical gap") {
+	if !strings.Contains(got[0], "Critical") || !strings.Contains(got[0], "critical gap") {
 		t.Errorf("first constraint should carry severity + description, got %q", got[0])
 	}
 	// File/line anchor should be preserved so the planner can reference

--- a/cmd/vairdict/run_test.go
+++ b/cmd/vairdict/run_test.go
@@ -106,7 +106,7 @@ func TestLastGapsForPhase_Empty(t *testing.T) {
 func TestLastGapsForPhase_ReturnsGaps(t *testing.T) {
 	task := state.NewTask("t-1", "intent")
 	gaps := []state.Gap{
-		{Severity: state.SeverityP1, Description: "broken thing", Blocking: true},
+		{Severity: state.SeverityHigh, Description: "broken thing", Blocking: true},
 	}
 	task.Attempts = []state.Attempt{
 		{Phase: state.PhaseQuality, Loop: 1, Verdict: &state.Verdict{Score: 40, Gaps: gaps}},
@@ -146,7 +146,7 @@ func TestDispatchEscalation_StdoutChannel(t *testing.T) {
 			Loops:     3,
 			LastScore: 42,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "missing feature", Blocking: true},
+				{Severity: state.SeverityHigh, Description: "missing feature", Blocking: true},
 			},
 		},
 		config.EscalationConfig{NotifyVia: "stdout", AfterLoops: 3},
@@ -371,7 +371,7 @@ func TestEmitPhaseDone_OutcomeMapping(t *testing.T) {
 			Score:   92,
 			Pass:    true,
 			Summary: "## Decided\n- thing",
-			Gaps:    []state.Gap{{Severity: state.SeverityP2, Description: "note"}},
+			Gaps:    []state.Gap{{Severity: state.SeverityMedium, Description: "note"}},
 		}},
 	}
 
@@ -462,9 +462,9 @@ func TestBuildQualityHardConstraints_OnlyBlockingGaps(t *testing.T) {
 	// the builder must filter them out.
 	v := &state.Verdict{
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP0, Description: "critical gap", Blocking: true},
-			{Severity: state.SeverityP1, Description: "another gap", Blocking: true, File: "foo.go", Line: 42},
-			{Severity: state.SeverityP3, Description: "just a nit", Blocking: false},
+			{Severity: state.SeverityCritical, Description: "critical gap", Blocking: true},
+			{Severity: state.SeverityHigh, Description: "another gap", Blocking: true, File: "foo.go", Line: 42},
+			{Severity: state.SeverityLow, Description: "just a nit", Blocking: false},
 		},
 	}
 	got := buildQualityHardConstraints(v)
@@ -823,7 +823,7 @@ func TestRunOrchestration_PlanEscalates(t *testing.T) {
 	t.Parallel()
 	b := newOrchBundle()
 	b.plan.result = &planphase.PhaseResult{Escalate: true, Loops: 3, LastScore: 40}
-	b.plan.gaps = []state.Gap{{Severity: state.SeverityP1, Description: "missing req", Blocking: true}}
+	b.plan.gaps = []state.Gap{{Severity: state.SeverityHigh, Description: "missing req", Blocking: true}}
 	task := state.NewTask("t-1", "intent")
 	r := &fakeRenderer{}
 
@@ -912,7 +912,7 @@ func TestRunOrchestration_QualityReturnToCode_RetriesAndPasses(t *testing.T) {
 		{Pass: true, Loops: 1, LastScore: 95, Diff: "diff-2"},
 	}
 	b.quality.gapsByCall = [][]state.Gap{
-		{{Severity: state.SeverityP0, Description: "code broken", Blocking: true}},
+		{{Severity: state.SeverityCritical, Description: "code broken", Blocking: true}},
 		nil,
 	}
 	b.code.results = []*codephase.PhaseResult{
@@ -962,7 +962,7 @@ func TestRunOrchestration_QualityReturnToPlan_Replans(t *testing.T) {
 		{Pass: true, Loops: 1, LastScore: 95, Diff: "diff-2"},
 	}
 	b.quality.gapsByCall = [][]state.Gap{
-		{{Severity: state.SeverityP0, Description: "plan too narrow", Blocking: true}},
+		{{Severity: state.SeverityCritical, Description: "plan too narrow", Blocking: true}},
 		nil,
 	}
 	task := state.NewTask("t-rewind-plan", "intent")
@@ -1003,7 +1003,7 @@ func TestRunOrchestration_QualityReturnToEscalate(t *testing.T) {
 		Escalate: true,
 		Loops:    1, LastScore: 10,
 	}
-	b.quality.gaps = []state.Gap{{Severity: state.SeverityP0, Description: "intent ambiguous", Blocking: true}}
+	b.quality.gaps = []state.Gap{{Severity: state.SeverityCritical, Description: "intent ambiguous", Blocking: true}}
 	task := state.NewTask("t-1", "intent")
 	r := &fakeRenderer{}
 
@@ -1032,7 +1032,7 @@ func TestRunOrchestration_CycleBudgetExhausted(t *testing.T) {
 		ReturnTo: state.ReturnToCode,
 		Loops:    1, LastScore: 40,
 	}
-	b.quality.gaps = []state.Gap{{Severity: state.SeverityP0, Description: "still broken", Blocking: true}}
+	b.quality.gaps = []state.Gap{{Severity: state.SeverityCritical, Description: "still broken", Blocking: true}}
 	task := state.NewTask("t-budget", "intent")
 	r := &fakeRenderer{}
 
@@ -1066,7 +1066,7 @@ func TestRunOrchestration_QualityReturnToCode_AppendsRewindContext(t *testing.T)
 		{Pass: true, Loops: 1, LastScore: 95, Diff: "diff-2"},
 	}
 	b.quality.gapsByCall = [][]state.Gap{
-		{{Severity: state.SeverityP0, Description: "race in retry loop", Blocking: true}},
+		{{Severity: state.SeverityCritical, Description: "race in retry loop", Blocking: true}},
 		nil,
 	}
 	task := state.NewTask("t-rc", "intent")
@@ -1118,8 +1118,8 @@ func TestRunOrchestration_MultipleRewindsAccumulateContext(t *testing.T) {
 		{Pass: true, Loops: 1, LastScore: 95, Diff: "d3"},
 	}
 	b.quality.gapsByCall = [][]state.Gap{
-		{{Severity: state.SeverityP0, Description: "first failure", Blocking: true}},
-		{{Severity: state.SeverityP0, Description: "second failure", Blocking: true}},
+		{{Severity: state.SeverityCritical, Description: "first failure", Blocking: true}},
+		{{Severity: state.SeverityCritical, Description: "second failure", Blocking: true}},
 		nil,
 	}
 	task := state.NewTask("t-acc", "intent")
@@ -1161,7 +1161,7 @@ func TestRunOrchestration_QualityReturnToPlan_AppendsRewindContext(t *testing.T)
 		{Pass: true, Loops: 1, LastScore: 95, Diff: "d2"},
 	}
 	b.quality.gapsByCall = [][]state.Gap{
-		{{Severity: state.SeverityP0, Description: "plan too narrow", Blocking: true}},
+		{{Severity: state.SeverityCritical, Description: "plan too narrow", Blocking: true}},
 		nil,
 	}
 	task := state.NewTask("t-rp", "intent")
@@ -1370,7 +1370,7 @@ func TestRunOrchestration_ConflictDetection_Conflicts_Escalate(t *testing.T) {
 		t.Fatalf("expected 2 conflict gaps, got %d", len(b.escalationResult.Gaps))
 	}
 	for _, g := range b.escalationResult.Gaps {
-		if g.Severity != state.SeverityP0 {
+		if g.Severity != state.SeverityCritical {
 			t.Errorf("conflict gap should be P0, got %s", g.Severity)
 		}
 		if !g.Blocking {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/vairdict/vairdict/internal/standards"
 )
 
 type Config struct {
@@ -19,6 +21,31 @@ type Config struct {
 	Conventions  ConventionsConfig `yaml:"conventions"`
 	Parallel     ParallelConfig    `yaml:"parallel"`
 	AutoVairdict bool              `yaml:"auto_vairdict"`
+
+	// Standards holds the team's per-rule Standards setting parsed
+	// from the `standards:` block. Values are raw strings ("off" / "on"
+	// / "block"); call StandardsConfig to get a typed standards.Config
+	// merged on top of the package-level defaults so unset rules carry
+	// their default state (on) without every config having to enumerate
+	// the full rule list.
+	Standards map[string]string `yaml:"standards,omitempty"`
+}
+
+// StandardsConfig returns the team's Standards config — defaults
+// (every known rule on) merged with the per-rule overrides parsed
+// from vairdict.yaml. Invalid state strings (anything other than
+// off / on / block) surface as an error so a typo fails the run at
+// load time rather than silently disabling a rule.
+func (c *Config) StandardsConfig() (standards.Config, error) {
+	out := standards.Default()
+	for name, raw := range c.Standards {
+		state, err := standards.ParseRuleState(raw)
+		if err != nil {
+			return standards.Config{}, fmt.Errorf("standards.%s: %w", name, err)
+		}
+		out.Rules[name] = state
+	}
+	return out, nil
 }
 
 type ParallelConfig struct {
@@ -525,6 +552,9 @@ func validate(cfg *Config) error {
 	if cfg.Parallel.MaxTasks < 1 {
 		return fmt.Errorf("validating config: parallel.max_tasks must be >= 1")
 	}
+	if _, err := cfg.StandardsConfig(); err != nil {
+		return fmt.Errorf("validating config: %w", err)
+	}
 	return nil
 }
 
@@ -535,6 +565,7 @@ func warnUnknownFields(data []byte) {
 		"project": true, "agents": true, "environment": true,
 		"commands": true, "phases": true, "escalation": true,
 		"conventions": true, "parallel": true, "auto_vairdict": true,
+		"standards": true,
 	}
 
 	var raw map[string]any

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -529,3 +529,91 @@ func TestMerge_DoesNotMutateBase(t *testing.T) {
 		t.Errorf("base was mutated: project.name = %q, want %q", base.Project.Name, "original")
 	}
 }
+
+// TestParseConfig_StandardsBlock pins the standards: yaml block contract.
+// The block parses as a map of rule name -> state ("off"/"on"/"block"),
+// rules absent from the file fall through to the default ("on"), and an
+// invalid state value surfaces at config-load time rather than silently
+// disabling a rule.
+func TestParseConfig_StandardsBlock(t *testing.T) {
+	data := []byte(`
+project:
+  name: t
+phases:
+  plan:
+    max_loops: 3
+  code:
+    max_loops: 3
+  quality:
+    max_loops: 3
+escalation:
+  after_loops: 3
+parallel:
+  max_tasks: 3
+standards:
+  naming: "on"
+  indent: "off"
+  error_logging: "block"
+`)
+	cfg, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Standards["naming"] != "on" {
+		t.Errorf("naming = %q, want on", cfg.Standards["naming"])
+	}
+	if cfg.Standards["indent"] != "off" {
+		t.Errorf("indent = %q, want off", cfg.Standards["indent"])
+	}
+	if cfg.Standards["error_logging"] != "block" {
+		t.Errorf("error_logging = %q, want block", cfg.Standards["error_logging"])
+	}
+
+	// StandardsConfig() returns a merged Config: defaults for unset
+	// rules, parsed states for set rules, with state types from the
+	// standards package.
+	scfg, err := cfg.StandardsConfig()
+	if err != nil {
+		t.Fatalf("StandardsConfig: %v", err)
+	}
+	if state, _ := scfg.Rule("naming"); string(state) != "on" {
+		t.Errorf("scfg.naming = %q, want on", state)
+	}
+	if state, _ := scfg.Rule("indent"); string(state) != "off" {
+		t.Errorf("scfg.indent = %q, want off", state)
+	}
+	if state, _ := scfg.Rule("error_logging"); string(state) != "block" {
+		t.Errorf("scfg.error_logging = %q, want block", state)
+	}
+	// Rules not mentioned in vairdict.yaml fall through to the default.
+	if state, _ := scfg.Rule("class_naming"); string(state) != "on" {
+		t.Errorf("class_naming default = %q, want on (the implicit default)", state)
+	}
+}
+
+// TestParseConfig_StandardsInvalidState — a typo or a wrong value in
+// the standards: block must fail loudly at parse time. Silent fallback
+// would be exactly the kind of "thought I disabled it but it kept
+// firing" footgun this category is meant to avoid.
+func TestParseConfig_StandardsInvalidState(t *testing.T) {
+	data := []byte(`
+project:
+  name: t
+phases:
+  plan:
+    max_loops: 3
+  code:
+    max_loops: 3
+  quality:
+    max_loops: 3
+escalation:
+  after_loops: 3
+parallel:
+  max_tasks: 3
+standards:
+  naming: "yes"
+`)
+	if _, err := ParseConfig(data); err == nil {
+		t.Fatal("expected error for invalid rule state, got nil")
+	}
+}

--- a/internal/escalation/escalation.go
+++ b/internal/escalation/escalation.go
@@ -131,7 +131,7 @@ func FormatSummary(task *state.Task, result Result) string {
 	if len(blocking) > 0 {
 		b.WriteString("### Blocking gaps\n")
 		for _, g := range blocking {
-			fmt.Fprintf(&b, "- **[%s]** %s\n", g.Severity, g.Description)
+			fmt.Fprintf(&b, "- **[%s]** %s\n", g.Severity.Display(), g.Description)
 		}
 	} else {
 		b.WriteString("_No blocking gaps recorded._\n")

--- a/internal/escalation/escalation_test.go
+++ b/internal/escalation/escalation_test.go
@@ -47,9 +47,9 @@ func sampleResult() Result {
 		Loops:     3,
 		LastScore: 42,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP0, Description: "missing auth requirement", Blocking: true},
-			{Severity: state.SeverityP2, Description: "minor doc nit", Blocking: false},
-			{Severity: state.SeverityP1, Description: "no error handling", Blocking: true},
+			{Severity: state.SeverityCritical, Description: "missing auth requirement", Blocking: true},
+			{Severity: state.SeverityMedium, Description: "minor doc nit", Blocking: false},
+			{Severity: state.SeverityHigh, Description: "no error handling", Blocking: true},
 		},
 	}
 }
@@ -339,7 +339,7 @@ func TestFormatSummary_ContainsAllFields(t *testing.T) {
 		Loops:     3,
 		LastScore: 55.7,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP0, Description: "intent mismatch", Blocking: true},
+			{Severity: state.SeverityCritical, Description: "intent mismatch", Blocking: true},
 		},
 	}
 
@@ -370,9 +370,9 @@ func TestFormatSummary_OnlyBlockingGapsListed(t *testing.T) {
 		Phase: state.PhaseCode,
 		Loops: 2,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP0, Description: "blocking-one", Blocking: true},
-			{Severity: state.SeverityP2, Description: "non-blocking-nit", Blocking: false},
-			{Severity: state.SeverityP3, Description: "deferred-thing", Blocking: false},
+			{Severity: state.SeverityCritical, Description: "blocking-one", Blocking: true},
+			{Severity: state.SeverityMedium, Description: "non-blocking-nit", Blocking: false},
+			{Severity: state.SeverityLow, Description: "deferred-thing", Blocking: false},
 		},
 	}
 
@@ -395,7 +395,7 @@ func TestFormatSummary_NoBlockingGapsPlaceholder(t *testing.T) {
 		Phase: state.PhaseCode,
 		Loops: 1,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP2, Description: "minor", Blocking: false},
+			{Severity: state.SeverityMedium, Description: "minor", Blocking: false},
 		},
 	}
 

--- a/internal/escalation/escalation_test.go
+++ b/internal/escalation/escalation_test.go
@@ -353,7 +353,7 @@ func TestFormatSummary_ContainsAllFields(t *testing.T) {
 		"Loops used:** 3",
 		"56", // 55.7 rounds to 56 with %.0f
 		"Blocking gaps",
-		"P0",
+		"Critical",
 		"intent mismatch",
 		"Human intervention required",
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -664,11 +664,35 @@ type InlineReviewResult struct {
 	InlineGapIndices map[int]bool
 }
 
+// StandardsMarker is the prefix the post-processor places on a gap's
+// description when it represents a Standards finding (mechanical /
+// style — naming, indent, error_logging, etc). The inline dispatch
+// reads it to keep Standards findings on the inline surface even
+// though their Severity is empty (Standards is its own category, not
+// a severity tier).
+const StandardsMarker = "STANDARDS:"
+
+// inlineEligible reports whether a gap should surface as an inline
+// review comment. Critical and High are eligible (they block — must
+// be visible at the line they touch); Medium and Low are not (notes-
+// only). Standards findings are always eligible regardless of the
+// severity ladder — the post-processor stamps their description with
+// StandardsMarker so the dispatch can recognise them without coupling
+// to the standards package.
+func inlineEligible(g state.Gap) bool {
+	if strings.HasPrefix(g.Description, StandardsMarker) {
+		return true
+	}
+	return g.Severity.InlineEligible()
+}
+
 // BuildInlineReview turns a verdict + diff into a review payload whose
-// comments point only at lines present in the diff. Gaps without File/Line
-// or whose line does not appear in the diff are collected into the review
-// body so reviewers still see every concern — previously they were dropped
-// silently and only surfaced in the verdict table.
+// comments point only at lines present in the diff. The inline
+// dispatch table is enforced here: Critical/High and Standards
+// findings become inline comments; Medium/Low (and gaps without a
+// diff anchor, regardless of severity) flow into the review body so
+// the concern is not lost but doesn't clutter the diff with non-
+// blocking nits the author can't apply with one click.
 // Returns a result with a nil Payload only when the verdict has no gaps at all.
 func BuildInlineReview(verdict *state.Verdict, diff string) *InlineReviewResult {
 	positions := ParseDiffPositions(diff)
@@ -678,6 +702,12 @@ func BuildInlineReview(verdict *state.Verdict, diff string) *InlineReviewResult 
 	inlineIndices := make(map[int]bool)
 	for i, g := range verdict.Gaps {
 		if g.File == "" || g.Line == 0 {
+			unanchored = append(unanchored, g)
+			continue
+		}
+		if !inlineEligible(g) {
+			// Inline-ineligible severities (Medium, Low) carry their
+			// concern into the review body, not onto the diff.
 			unanchored = append(unanchored, g)
 			continue
 		}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -768,7 +768,7 @@ func formatInlineComment(g state.Gap) string {
 	if g.Blocking {
 		icon = "🚫"
 	}
-	body := fmt.Sprintf("%s **[%s]** %s", icon, g.Severity, g.Description)
+	body := fmt.Sprintf("%s **[%s]** %s", icon, g.Severity.Display(), g.Description)
 	if g.Suggestion != "" {
 		body += "\n\n```suggestion\n" + g.Suggestion + "\n```"
 	}
@@ -860,7 +860,7 @@ func FormatPRBody(task *state.Task, issueNumber int, summary string) string {
 	if len(task.Assumptions) > 0 {
 		b.WriteString("## Assumptions made\n")
 		for _, a := range task.Assumptions {
-			fmt.Fprintf(&b, "- [%s] %s\n", a.Severity, a.Description)
+			fmt.Fprintf(&b, "- [%s] %s\n", a.Severity.Display(), a.Description)
 		}
 		b.WriteString("\n")
 	}
@@ -938,7 +938,7 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int, i
 			if g.Blocking {
 				status = "BLOCKING"
 			}
-			fmt.Fprintf(&b, "| %s | %s | %s |\n", g.Severity, status, g.Description)
+			fmt.Fprintf(&b, "| %s | %s | %s |\n", g.Severity.Display(), status, g.Description)
 		}
 		b.WriteString("\n")
 	} else if verdict.Pass {
@@ -961,7 +961,7 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int, i
 		if len(blocking) > 0 {
 			b.WriteString("### Blocking Gaps\n\n")
 			for _, g := range blocking {
-				fmt.Fprintf(&b, "- **[%s]** %s\n", g.Severity, g.Description)
+				fmt.Fprintf(&b, "- **[%s]** %s\n", g.Severity.Display(), g.Description)
 			}
 			b.WriteString("\n")
 		}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1576,8 +1576,12 @@ func TestPostVerdictWithDiff_ResolvesPriorThreadsBeforePosting(t *testing.T) {
 	verdict := &state.Verdict{
 		Score: 80,
 		Pass:  true,
+		// Critical so it's inline-eligible under the new dispatch and
+		// the review POST path is exercised. (Pre-dispatch this test
+		// used a Medium gap, but only Critical/High/Standards reach the
+		// inline surface now — see TestBuildInlineReview_Dispatch...)
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP2, Description: "tiny nit", Blocking: false, File: "foo.go", Line: 3},
+			{Severity: state.SeverityCritical, Description: "blocking issue", Blocking: true, File: "foo.go", Line: 3},
 		},
 	}
 
@@ -1612,5 +1616,105 @@ func TestPostVerdictWithDiff_ResolvesPriorThreadsBeforePosting(t *testing.T) {
 	}
 	if resolveIdx >= postIdx {
 		t.Errorf("resolveReviewThread (idx %d) must run BEFORE review POST (idx %d)", resolveIdx, postIdx)
+	}
+}
+
+// TestBuildInlineReview_DispatchByInlineEligibility encodes the new
+// dispatch rule: only Critical and High gaps surface as inline review
+// comments. Medium and Low go into the unanchored review body so they
+// stop cluttering the PR diff with non-blocking nits the author can't
+// apply with one click — the user-facing complaint that "every PR
+// gets 2-3 inline comments of varying noise."
+//
+// Fixture: one diff position; one gap of each tier all anchored at
+// that line. The Critical and High gaps must end up as Comments;
+// Medium and Low must end up in the unanchored body — even though
+// they have a valid file/line that would have made them inline-
+// eligible under the old "any gap with file:line goes inline" rule.
+func TestBuildInlineReview_DispatchByInlineEligibility(t *testing.T) {
+	diff := "diff --git a/x.go b/x.go\n" +
+		"--- a/x.go\n" +
+		"+++ b/x.go\n" +
+		"@@ -1,3 +1,4 @@\n" +
+		" package x\n" +
+		"+var added = 1\n" +
+		" var existing = 2\n"
+	verdict := &state.Verdict{
+		Gaps: []state.Gap{
+			{Severity: state.SeverityCritical, Description: "crit", Blocking: true, File: "x.go", Line: 2},
+			{Severity: state.SeverityHigh, Description: "high", Blocking: true, File: "x.go", Line: 2},
+			{Severity: state.SeverityMedium, Description: "med", Blocking: false, File: "x.go", Line: 2},
+			{Severity: state.SeverityLow, Description: "low", Blocking: false, File: "x.go", Line: 2},
+		},
+	}
+
+	got := BuildInlineReview(verdict, diff)
+	if got == nil || got.Payload == nil {
+		t.Fatalf("expected payload, got %+v", got)
+	}
+	if len(got.Payload.Comments) != 2 {
+		t.Errorf("expected 2 inline comments (Critical+High), got %d: %+v",
+			len(got.Payload.Comments), got.Payload.Comments)
+	}
+	bodies := []string{}
+	for _, c := range got.Payload.Comments {
+		bodies = append(bodies, c.Body)
+	}
+	joined := strings.Join(bodies, "\n")
+	if !contains(joined, "crit") || !contains(joined, "high") {
+		t.Errorf("inline bodies should include Critical+High, got: %s", joined)
+	}
+	if contains(joined, "[Medium]") || contains(joined, "[Low]") {
+		t.Errorf("inline bodies must NOT include Medium/Low, got: %s", joined)
+	}
+	// Medium and Low surface in the review body so the concern is not lost.
+	if !contains(got.Payload.Body, "med") || !contains(got.Payload.Body, "low") {
+		t.Errorf("Medium/Low must surface in review body, got: %s", got.Payload.Body)
+	}
+
+	// inlineIndices reflects only the Critical and High gaps, so the
+	// summary-comment renderer keeps Medium/Low in its criteria table.
+	if got.InlineGapIndices[2] || got.InlineGapIndices[3] {
+		t.Errorf("Medium (idx 2) and Low (idx 3) must not be marked inline: %+v",
+			got.InlineGapIndices)
+	}
+	if !got.InlineGapIndices[0] || !got.InlineGapIndices[1] {
+		t.Errorf("Critical (idx 0) and High (idx 1) must be marked inline: %+v",
+			got.InlineGapIndices)
+	}
+}
+
+// TestBuildInlineReview_StandardsAlwaysInline pins that any gap whose
+// description carries the Standards marker (added by the post-
+// processor for FilterFindings output) is inline regardless of the
+// severity ladder — Standards finding are mechanical/easy-fix and
+// the user explicitly asked for them to surface inline.
+//
+// This test goes red until BuildInlineReview learns the marker and
+// also flips inline eligibility on it. Standards findings travel as
+// state.Gap with Severity left empty (or set to a sentinel) and a
+// description prefixed with the standards marker.
+func TestBuildInlineReview_StandardsAlwaysInline(t *testing.T) {
+	diff := "diff --git a/x.go b/x.go\n" +
+		"--- a/x.go\n" +
+		"+++ b/x.go\n" +
+		"@@ -1,3 +1,4 @@\n" +
+		" package x\n" +
+		"+var addedNoCamelCase = 1\n" +
+		" var existing = 2\n"
+	verdict := &state.Verdict{
+		Gaps: []state.Gap{
+			{
+				Severity:    state.Severity(""),
+				Description: "STANDARDS:naming use camelCase",
+				Blocking:    false,
+				File:        "x.go", Line: 2,
+				Suggestion: "var addedNoCamelCase = 1",
+			},
+		},
+	}
+	got := BuildInlineReview(verdict, diff)
+	if got == nil || got.Payload == nil || len(got.Payload.Comments) != 1 {
+		t.Fatalf("expected 1 inline Standards comment, got %+v", got)
 	}
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -410,7 +410,7 @@ func TestFormatVerdictComment_Pass(t *testing.T) {
 		{"score", "**Score:** 95%"},
 		{"phase", "**Phase:** quality"},
 		{"loop", "**Loop:** 1"},
-		{"gap severity", "| P3 |"},
+		{"gap severity", "| Low |"},
 		{"gap description", "minor style nit"},
 		{"footer", "@vairdict-judge"},
 	}
@@ -454,8 +454,8 @@ func TestFormatVerdictComment_Fail(t *testing.T) {
 		{"score", "**Score:** 40%"},
 		{"loop", "**Loop:** 2"},
 		{"blocking section", "### Blocking Gaps"},
-		{"P0 gap", "**[P0]** build broken"},
-		{"P1 gap", "**[P1]** tests fail"},
+		{"critical gap", "**[Critical]** build broken"},
+		{"high gap", "**[High]** tests fail"},
 		{"question", "Is the API stable?"},
 		{"criteria table", "| Severity | Status | Description |"},
 	}
@@ -1013,7 +1013,7 @@ func TestBuildInlineReview_MixedInlineAndSummary(t *testing.T) {
 	// When inlineGapIndices is passed, the inline gap should be excluded
 	// from the criteria table but the non-inline gap should remain.
 	summary := FormatVerdictComment(verdict, state.PhaseQuality, 1, result.InlineGapIndices)
-	if contains(summary, "| P1 |") {
+	if contains(summary, "| High |") {
 		t.Error("inline gap should NOT appear in criteria table when inlineGapIndices is set")
 	}
 	if !contains(summary, "architectural concern") {
@@ -1027,8 +1027,8 @@ func TestBuildInlineReview_MixedInlineAndSummary(t *testing.T) {
 func TestFormatInlineComment_Blocking(t *testing.T) {
 	g := state.Gap{Severity: state.SeverityP1, Description: "security issue", Blocking: true}
 	body := formatInlineComment(g)
-	if !contains(body, "[P1]") {
-		t.Errorf("expected [P1] in body, got %q", body)
+	if !contains(body, "[High]") {
+		t.Errorf("expected [High] in body, got %q", body)
 	}
 	if !contains(body, "security issue") {
 		t.Errorf("expected description in body, got %q", body)
@@ -1038,8 +1038,8 @@ func TestFormatInlineComment_Blocking(t *testing.T) {
 func TestFormatInlineComment_NonBlocking(t *testing.T) {
 	g := state.Gap{Severity: state.SeverityP3, Description: "style nit", Blocking: false}
 	body := formatInlineComment(g)
-	if !contains(body, "[P3]") {
-		t.Errorf("expected [P3] in body, got %q", body)
+	if !contains(body, "[Low]") {
+		t.Errorf("expected [Low] in body, got %q", body)
 	}
 }
 
@@ -1057,7 +1057,7 @@ func TestFormatInlineComment_WithSuggestion(t *testing.T) {
 	if !contains(body, "os.Getenv") {
 		t.Errorf("expected suggestion content, got %q", body)
 	}
-	if !contains(body, "[P1]") {
+	if !contains(body, "[High]") {
 		t.Errorf("expected severity prefix, got %q", body)
 	}
 	if !contains(body, "hardcoded key") {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -172,7 +172,7 @@ func TestPostVerdict_Pass_ApprovesAndComments(t *testing.T) {
 		Score: 95,
 		Pass:  true,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP3, Description: "minor style", Blocking: false},
+			{Severity: state.SeverityLow, Description: "minor style", Blocking: false},
 		},
 	}
 
@@ -275,8 +275,8 @@ func TestPostVerdict_Fail_CommentsOnly(t *testing.T) {
 		Score: 40,
 		Pass:  false,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP0, Description: "build fails", Blocking: true},
-			{Severity: state.SeverityP1, Description: "tests fail", Blocking: true},
+			{Severity: state.SeverityCritical, Description: "build fails", Blocking: true},
+			{Severity: state.SeverityHigh, Description: "tests fail", Blocking: true},
 		},
 	}
 
@@ -393,7 +393,7 @@ func TestFormatVerdictComment_Pass(t *testing.T) {
 		Score: 95,
 		Pass:  true,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP3, Description: "minor style nit", Blocking: false},
+			{Severity: state.SeverityLow, Description: "minor style nit", Blocking: false},
 		},
 	}
 
@@ -432,9 +432,9 @@ func TestFormatVerdictComment_Fail(t *testing.T) {
 		Score: 40,
 		Pass:  false,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP0, Description: "build broken", Blocking: true},
-			{Severity: state.SeverityP1, Description: "tests fail", Blocking: true},
-			{Severity: state.SeverityP3, Description: "docs missing", Blocking: false},
+			{Severity: state.SeverityCritical, Description: "build broken", Blocking: true},
+			{Severity: state.SeverityHigh, Description: "tests fail", Blocking: true},
+			{Severity: state.SeverityLow, Description: "docs missing", Blocking: false},
 		},
 		Questions: []state.Question{
 			{Text: "Is the API stable?", Priority: "high"},
@@ -623,7 +623,7 @@ func TestFormatPRBody(t *testing.T) {
 	task := &state.Task{
 		Intent: "add feature X",
 		Assumptions: []state.Assumption{
-			{Severity: state.SeverityP2, Description: "assumed Y"},
+			{Severity: state.SeverityMedium, Description: "assumed Y"},
 		},
 		Attempts: []state.Attempt{
 			{
@@ -783,9 +783,9 @@ func TestPostVerdictWithDiff_InlineComments(t *testing.T) {
 		Score: 40,
 		Pass:  false,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP1, Description: "bug on added line", Blocking: true, File: "internal/foo/bar.go", Line: 12},
-			{Severity: state.SeverityP2, Description: "style issue elsewhere", Blocking: false}, // no file/line
-			{Severity: state.SeverityP3, Description: "line not in diff", Blocking: false, File: "internal/foo/bar.go", Line: 1},
+			{Severity: state.SeverityHigh, Description: "bug on added line", Blocking: true, File: "internal/foo/bar.go", Line: 12},
+			{Severity: state.SeverityMedium, Description: "style issue elsewhere", Blocking: false}, // no file/line
+			{Severity: state.SeverityLow, Description: "line not in diff", Blocking: false, File: "internal/foo/bar.go", Line: 1},
 		},
 	}
 
@@ -827,7 +827,7 @@ func TestPostVerdictWithDiff_UnanchoredGapsSurfaceInComment(t *testing.T) {
 		Score: 80,
 		Pass:  false,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP2, Description: "missing docs", Blocking: false},
+			{Severity: state.SeverityMedium, Description: "missing docs", Blocking: false},
 		},
 	}
 
@@ -859,7 +859,7 @@ func TestPostVerdictWithDiff_EmptyDiffSkipsInline(t *testing.T) {
 		Score: 90,
 		Pass:  true,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP3, Description: "nit", Blocking: false, File: "x.go", Line: 5},
+			{Severity: state.SeverityLow, Description: "nit", Blocking: false, File: "x.go", Line: 5},
 		},
 	}
 
@@ -887,10 +887,10 @@ func TestBuildInlineReview_FiltersByResolvability(t *testing.T) {
 `
 	verdict := &state.Verdict{
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP1, Description: "in diff", Blocking: true, File: "foo.go", Line: 11},
-			{Severity: state.SeverityP2, Description: "no file info"},
-			{Severity: state.SeverityP3, Description: "line outside diff", File: "foo.go", Line: 999},
-			{Severity: state.SeverityP0, Description: "wrong file", File: "bar.go", Line: 11},
+			{Severity: state.SeverityHigh, Description: "in diff", Blocking: true, File: "foo.go", Line: 11},
+			{Severity: state.SeverityMedium, Description: "no file info"},
+			{Severity: state.SeverityLow, Description: "line outside diff", File: "foo.go", Line: 999},
+			{Severity: state.SeverityCritical, Description: "wrong file", File: "bar.go", Line: 11},
 		},
 	}
 
@@ -945,8 +945,8 @@ func TestBuildInlineReview_UnanchoredGapsStillSurface(t *testing.T) {
 `
 	verdict := &state.Verdict{
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP2, Description: "no location"},
-			{Severity: state.SeverityP3, Description: "out of diff", File: "x.go", Line: 99},
+			{Severity: state.SeverityMedium, Description: "no location"},
+			{Severity: state.SeverityLow, Description: "out of diff", File: "x.go", Line: 99},
 		},
 	}
 
@@ -1000,8 +1000,8 @@ func TestBuildInlineReview_MixedInlineAndSummary(t *testing.T) {
 		Score: 60,
 		Pass:  false,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP1, Description: "bad on added line", Blocking: true, File: "p.go", Line: 2},
-			{Severity: state.SeverityP2, Description: "architectural concern"},
+			{Severity: state.SeverityHigh, Description: "bad on added line", Blocking: true, File: "p.go", Line: 2},
+			{Severity: state.SeverityMedium, Description: "architectural concern"},
 		},
 	}
 
@@ -1025,7 +1025,7 @@ func TestBuildInlineReview_MixedInlineAndSummary(t *testing.T) {
 }
 
 func TestFormatInlineComment_Blocking(t *testing.T) {
-	g := state.Gap{Severity: state.SeverityP1, Description: "security issue", Blocking: true}
+	g := state.Gap{Severity: state.SeverityHigh, Description: "security issue", Blocking: true}
 	body := formatInlineComment(g)
 	if !contains(body, "[High]") {
 		t.Errorf("expected [High] in body, got %q", body)
@@ -1036,7 +1036,7 @@ func TestFormatInlineComment_Blocking(t *testing.T) {
 }
 
 func TestFormatInlineComment_NonBlocking(t *testing.T) {
-	g := state.Gap{Severity: state.SeverityP3, Description: "style nit", Blocking: false}
+	g := state.Gap{Severity: state.SeverityLow, Description: "style nit", Blocking: false}
 	body := formatInlineComment(g)
 	if !contains(body, "[Low]") {
 		t.Errorf("expected [Low] in body, got %q", body)
@@ -1045,7 +1045,7 @@ func TestFormatInlineComment_NonBlocking(t *testing.T) {
 
 func TestFormatInlineComment_WithSuggestion(t *testing.T) {
 	g := state.Gap{
-		Severity:    state.SeverityP1,
+		Severity:    state.SeverityHigh,
 		Description: "hardcoded key",
 		Blocking:    true,
 		Suggestion:  "\tapiKey := os.Getenv(\"API_KEY\")",
@@ -1067,7 +1067,7 @@ func TestFormatInlineComment_WithSuggestion(t *testing.T) {
 
 func TestFormatInlineComment_NoSuggestion(t *testing.T) {
 	g := state.Gap{
-		Severity:    state.SeverityP2,
+		Severity:    state.SeverityMedium,
 		Description: "design concern",
 		Blocking:    false,
 		Suggestion:  "",
@@ -1092,7 +1092,7 @@ func TestBuildInlineReview_SuggestionPreserved(t *testing.T) {
 		Pass:  false,
 		Gaps: []state.Gap{
 			{
-				Severity:    state.SeverityP1,
+				Severity:    state.SeverityHigh,
 				Description: "hardcoded secret",
 				Blocking:    true,
 				File:        "foo.go",
@@ -1123,8 +1123,8 @@ func TestFormatVerdictComment_GapWithFileLocation(t *testing.T) {
 		Score: 70,
 		Pass:  true,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP2, Description: "magic number", Blocking: false, File: "foo.go", Line: 42},
-			{Severity: state.SeverityP3, Description: "style nit", Blocking: false},
+			{Severity: state.SeverityMedium, Description: "magic number", Blocking: false, File: "foo.go", Line: 42},
+			{Severity: state.SeverityLow, Description: "style nit", Blocking: false},
 		},
 	}
 

--- a/internal/judges/code/judge.go
+++ b/internal/judges/code/judge.go
@@ -95,7 +95,7 @@ func (j *CodeJudge) Judge(ctx context.Context, workDir string) (*state.Verdict, 
 		gaps = append(gaps, state.Gap{
 			Severity:    c.Severity,
 			Description: fmt.Sprintf("%s failed: %s", c.Name, truncate(strings.TrimSpace(c.Output), 500)),
-			Blocking:    c.Severity == state.SeverityP0 || c.Severity == state.SeverityP1,
+			Blocking:    c.Severity == state.SeverityCritical || c.Severity == state.SeverityHigh,
 		})
 	}
 
@@ -118,10 +118,10 @@ func (j *CodeJudge) Judge(ctx context.Context, workDir string) (*state.Verdict, 
 // Severity: build=P0, test=P1, lint/format=P2.
 func (j *CodeJudge) buildChecks() []check {
 	return []check{
-		{Name: "format", Command: j.formatCommand(), Severity: state.SeverityP2},
-		{Name: "lint", Command: j.cfg.Commands.Lint, Severity: state.SeverityP2},
-		{Name: "test", Command: j.cfg.Commands.Test, Severity: state.SeverityP1},
-		{Name: "build", Command: j.cfg.Commands.Build, Severity: state.SeverityP0},
+		{Name: "format", Command: j.formatCommand(), Severity: state.SeverityMedium},
+		{Name: "lint", Command: j.cfg.Commands.Lint, Severity: state.SeverityMedium},
+		{Name: "test", Command: j.cfg.Commands.Test, Severity: state.SeverityHigh},
+		{Name: "build", Command: j.cfg.Commands.Build, Severity: state.SeverityCritical},
 	}
 }
 

--- a/internal/judges/code/judge_test.go
+++ b/internal/judges/code/judge_test.go
@@ -93,7 +93,7 @@ func TestJudge_BuildFailed(t *testing.T) {
 	if len(verdict.Gaps) != 1 {
 		t.Fatalf("gaps = %d, want 1", len(verdict.Gaps))
 	}
-	if verdict.Gaps[0].Severity != state.SeverityP0 {
+	if verdict.Gaps[0].Severity != state.SeverityCritical {
 		t.Errorf("severity = %v, want P0", verdict.Gaps[0].Severity)
 	}
 	if !verdict.Gaps[0].Blocking {
@@ -125,7 +125,7 @@ func TestJudge_TestFailed(t *testing.T) {
 	if len(verdict.Gaps) != 1 {
 		t.Fatalf("gaps = %d, want 1", len(verdict.Gaps))
 	}
-	if verdict.Gaps[0].Severity != state.SeverityP1 {
+	if verdict.Gaps[0].Severity != state.SeverityHigh {
 		t.Errorf("severity = %v, want P1", verdict.Gaps[0].Severity)
 	}
 }
@@ -151,7 +151,7 @@ func TestJudge_LintFailed(t *testing.T) {
 	if len(verdict.Gaps) != 1 {
 		t.Fatalf("gaps = %d, want 1", len(verdict.Gaps))
 	}
-	if verdict.Gaps[0].Severity != state.SeverityP2 {
+	if verdict.Gaps[0].Severity != state.SeverityMedium {
 		t.Errorf("severity = %v, want P2", verdict.Gaps[0].Severity)
 	}
 	if verdict.Gaps[0].Blocking {
@@ -177,7 +177,7 @@ func TestJudge_FormatFailed(t *testing.T) {
 	if verdict.Pass {
 		t.Error("expected fail")
 	}
-	if verdict.Gaps[0].Severity != state.SeverityP2 {
+	if verdict.Gaps[0].Severity != state.SeverityMedium {
 		t.Errorf("severity = %v, want P2", verdict.Gaps[0].Severity)
 	}
 }

--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -47,7 +47,7 @@ the stated intent.
 You care about correctness, clarity, and future maintenance pain. You are
 considered and deliberate — every observation earns its place. A thoughtful
 review surfaces design decisions, risks, and follow-ups — not just bugs.
-On a non-trivial plan, surfacing P3/P2 design observations is expected when
+On a non-trivial plan, surfacing medium/low design observations is expected when
 genuine concerns exist. However, if prior concerns have been acknowledged
 (see Acknowledged Assumptions section in the user prompt when present),
 fewer new observations is the correct outcome — do not re-discover concerns
@@ -64,10 +64,10 @@ single source of truth for the response shape — do not emit free-form JSON,
 markdown fences, or prose outside the tool call.
 
 Severity levels for gaps:
-- P0: next steps cannot proceed without resolving this — critical blocker
-- P1: required, must be addressed this loop — important but not a total blocker
-- P2: ambiguous, agent will document assumption and proceed — not blocking
-- P3: nice to have, deferred to future issue — not blocking
+- critical: next steps cannot proceed without resolving this — blocker
+- high:     required, must be addressed this loop — important but not a total blocker
+- medium:   ambiguous, agent will document assumption and proceed — not blocking
+- low:      nice to have, deferred to future issue — not blocking
 
 Do NOT set "blocking" on gaps and do NOT estimate a score — the orchestrator
 computes both deterministically from severities.
@@ -93,7 +93,7 @@ as a finding, use a gap.
 
 ## Examples
 
-On a substantive plan, design observations (P3/P2) are expected when genuine
+On a substantive plan, design observations (medium/low) are expected when genuine
 concerns exist — what a senior reviewer would raise in a real plan review.
 When Acknowledged Assumptions are present, those concerns have already been
 accepted; flag only NEW issues. Never pad with nits to hit a target.
@@ -109,9 +109,9 @@ submit_verdict input:
 {
   "summary": "## Decided\n- Tenant threaded via middleware on the 4 handlers\n- DB gets tenant_id column via migration\n## Risks\n- Backfill strategy deferred to post-rollout\n## Files to touch\n- internal/middleware/tenant.go — new\n- internal/db/queryHelpers.go — scope 6 queries by tenant",
   "gaps": [
-    {"severity": "P2", "description": "Plan does not decide whether tenant_id is required or nullable on the new column — affects backfill and rollout order."},
-    {"severity": "P3", "description": "6 near-identical WHERE clauses in queryHelpers will drift; extract a tenantScope() helper once a second table needs the same pattern."},
-    {"severity": "P3", "description": "Plan threads Tenant through function signatures rather than context.Context; fine now, worth revisiting as the scoped-call surface grows."}
+    {"severity": "medium", "description": "Plan does not decide whether tenant_id is required or nullable on the new column — affects backfill and rollout order."},
+    {"severity": "low", "description": "6 near-identical WHERE clauses in queryHelpers will drift; extract a tenantScope() helper once a second table needs the same pattern."},
+    {"severity": "low", "description": "Plan threads Tenant through function signatures rather than context.Context; fine now, worth revisiting as the scoped-call surface grows."}
   ],
   "questions": []
 }
@@ -125,8 +125,8 @@ submit_verdict input:
 {
   "summary": "## Risks\n- Plan does not satisfy the persistence requirement",
   "gaps": [
-    {"severity": "P0", "description": "In-memory storage is lost on restart — intent explicitly requires persistence across restarts."},
-    {"severity": "P1", "description": "No mention of a storage backend, schema, or migration strategy."}
+    {"severity": "critical", "description": "In-memory storage is lost on restart — intent explicitly requires persistence across restarts."},
+    {"severity": "high", "description": "No mention of a storage backend, schema, or migration strategy."}
   ],
   "questions": []
 }`
@@ -148,7 +148,7 @@ func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string, ackno
 		prompt += "These concerns were already raised in a previous loop, acknowledged by the planner, and accepted by the orchestrator. "
 		prompt += "Do NOT re-flag these as gaps unless the plan has actively regressed on them.\n"
 		for _, a := range acknowledged {
-			prompt += fmt.Sprintf("- [%s] %s\n", a.Severity, a.Description)
+			prompt += fmt.Sprintf("- [%s] %s\n", a.Severity.Display(), a.Description)
 		}
 	}
 

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -41,7 +41,7 @@ func TestJudge_BaselineViolationForcedBlocking_UnderPermissiveConfig(t *testing.
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "BASELINE: no-secrets: literal token"},
+				{Severity: state.SeverityHigh, Description: "BASELINE: no-secrets: literal token"},
 			},
 		},
 	}
@@ -72,7 +72,7 @@ func TestJudge_NonBaselineP1StillGovernedByConfig(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "missing validation"},
+				{Severity: state.SeverityHigh, Description: "missing validation"},
 			},
 		},
 	}
@@ -134,8 +134,8 @@ func TestJudge_Fail_BlockingGapsDriveScoreDown(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "no error handling"},
-				{Severity: state.SeverityP1, Description: "missing auth"},
+				{Severity: state.SeverityCritical, Description: "no error handling"},
+				{Severity: state.SeverityHigh, Description: "missing auth"},
 			},
 			Questions: []state.Question{
 				{Text: "What database?", Priority: "high"},
@@ -169,8 +169,8 @@ func TestJudge_BlockingIgnoresLLMOpinion(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "critical gap", Blocking: false},
-				{Severity: state.SeverityP2, Description: "ambiguous gap", Blocking: true},
+				{Severity: state.SeverityCritical, Description: "critical gap", Blocking: false},
+				{Severity: state.SeverityMedium, Description: "ambiguous gap", Blocking: true},
 			},
 		},
 	}
@@ -195,9 +195,9 @@ func TestJudge_AccumulatedP2sDragScoreBelowThreshold(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "a"},
-				{Severity: state.SeverityP2, Description: "b"},
-				{Severity: state.SeverityP2, Description: "c"},
+				{Severity: state.SeverityMedium, Description: "a"},
+				{Severity: state.SeverityMedium, Description: "b"},
+				{Severity: state.SeverityMedium, Description: "c"},
 			},
 		},
 	}
@@ -221,8 +221,8 @@ func TestJudge_PassTrueAtExactThreshold(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "a"},
-				{Severity: state.SeverityP2, Description: "b"},
+				{Severity: state.SeverityMedium, Description: "a"},
+				{Severity: state.SeverityMedium, Description: "b"},
 			},
 		},
 	}
@@ -245,7 +245,7 @@ func TestJudge_P3GapsDeferred(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP3, Description: "nice to have"},
+				{Severity: state.SeverityLow, Description: "nice to have"},
 			},
 		},
 	}
@@ -294,7 +294,7 @@ func TestJudge_CustomSeverityConfig(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "important"},
+				{Severity: state.SeverityHigh, Description: "important"},
 			},
 		},
 	}
@@ -391,8 +391,8 @@ func TestJudge_AcknowledgedAssumptionsInPrompt(t *testing.T) {
 
 	judge := New(fake, defaultCfg())
 	assumptions := []state.Assumption{
-		{Description: "database choice unclear", Severity: state.SeverityP2, Phase: state.PhasePlan},
-		{Description: "caching strategy TBD", Severity: state.SeverityP2, Phase: state.PhasePlan},
+		{Description: "database choice unclear", Severity: state.SeverityMedium, Phase: state.PhasePlan},
+		{Description: "caching strategy TBD", Severity: state.SeverityMedium, Phase: state.PhasePlan},
 	}
 
 	_, err := judge.Judge(context.Background(), "intent", "plan", assumptions)
@@ -442,15 +442,15 @@ func TestJudge_ReflaggedGapHalvedPenalty(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "database choice unclear"},
-				{Severity: state.SeverityP2, Description: "new naming concern"},
+				{Severity: state.SeverityMedium, Description: "database choice unclear"},
+				{Severity: state.SeverityMedium, Description: "new naming concern"},
 			},
 		},
 	}
 
 	judge := New(fake, defaultCfg())
 	acknowledged := []state.Assumption{
-		{Description: "database choice unclear", Severity: state.SeverityP2},
+		{Description: "database choice unclear", Severity: state.SeverityMedium},
 	}
 
 	verdict, err := judge.Judge(context.Background(), "intent", "plan", acknowledged)

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -215,6 +215,29 @@ You MUST NOT:
 
 These are NOT bugs. They are existing code that was not modified.
 
+## Before flagging Medium / Low / Standards: check for an existing fix
+
+Before emitting a Medium-, Low-, or Standards-severity gap, search the
+surrounding file(s) for an existing handler, guard, helper, or
+convention that already addresses the concern. If you find one,
+do not flag — the issue is not a real gap, it is a documentation
+miss in your read. Examples:
+
+- About to flag "no error handling" on a returned err — scan the
+  function: is there a defer that wraps or a wrapper at the call
+  site that already handles it? If yes, do not flag.
+- About to flag "missing input validation" — check whether the
+  caller validates, or whether a typed wrapper has already narrowed
+  the input.
+- About to flag a Standards naming nit — check whether the file
+  already establishes a convention for that identifier kind.
+
+Critical and High findings are exempt from this rubric: a real
+correctness or security bug stands on its own and you must flag it
+even if a partial mitigation exists elsewhere. The rubric exists to
+suppress the lower-severity false positives where "I noticed X" turns
+out to be "X is already handled, I just didn't read far enough."
+
 ## Read the whole hunk before flagging "missing X"
 
 Before raising any gap of the form "missing doc comment", "missing nil
@@ -560,6 +583,47 @@ CORRECT submit_verdict for this diff:
 // engineering standards appended. Baseline rules reach the judge so it
 // flags violations regardless of team config.
 var systemPrompt = systemPromptCore + "\n\n" + standards.Block
+
+// RenderCrossPushFraming produces the cross-push framing block the
+// quality judge prepends to its user prompt when prior verdict gaps
+// exist. The framing closes the "judge invents a finding on push N
+// that was already there on push N-1" failure mode that produces the
+// nagging-comment behaviour the user asked us to fix.
+//
+// The rules baked into the framing:
+//
+//   - the prior review's gaps are listed verbatim with severities;
+//   - each prior gap must be checked for current applicability and
+//     dropped from the new verdict if the latest push fixed it;
+//   - new findings are only valid for code introduced or changed in
+//     the diff since the prior review;
+//   - findings that pre-date the prior review must NOT be introduced
+//     now — if the previous round missed them, they were either not
+//     real or not the judge's responsibility to flag at this point.
+//
+// Returns "" for nil/empty input so the framing disappears on the
+// first review of a PR (no prior gaps -> no cross-push pressure).
+func RenderCrossPushFraming(priorGaps []state.Gap) string {
+	if len(priorGaps) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Cross-push awareness — prior review gaps\n\n")
+	b.WriteString("This PR has been reviewed before. The prior review emitted the following gaps:\n\n")
+	for _, g := range priorGaps {
+		fmt.Fprintf(&b, "- [%s] %s\n", g.Severity.Display(), g.Description)
+	}
+	b.WriteString("\nWhen producing this review:\n")
+	b.WriteString("\n1. Verify each prior gap above for current applicability in the diff. ")
+	b.WriteString("If the latest push has fixed it, drop it; do not re-flag a resolved concern. ")
+	b.WriteString("If it is still present, keep it with the same severity.\n")
+	b.WriteString("\n2. Scan only the diff since the prior review for new findings. ")
+	b.WriteString("Anything outside the most recent push is not a new finding.\n")
+	b.WriteString("\n3. Do not introduce findings that pre-dated the prior review. ")
+	b.WriteString("If the previous round missed them, they were either not real or not in scope; ")
+	b.WriteString("emitting them now would be a nagging-comment failure mode, not a useful review.\n")
+	return b.String()
+}
 
 // Judge evaluates whether the given diff fulfills the original intent and plan.
 // It runs AI-based intent verification (against the diff content, not a

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -153,17 +153,17 @@ Before submitting a verdict on a substantive diff, perform a
 severity-ordered scan of the added code:
 
 1. Correctness bugs visible in added code (wrong logic, broken
-   invariants, tautological asserts, dead branches) → P0/P1
-2. Security or authorisation gaps in new code paths → P0/P1
+   invariants, tautological asserts, dead branches) → critical/high
+2. Security or authorisation gaps in new code paths → critical/high
 3. Non-obvious trade-offs or assumptions the author should name
-   explicitly so future maintainers see them → P2
-4. Concrete follow-ups worth filing so the work isn't lost → P3
+   explicitly so future maintainers see them → medium
+4. Concrete follow-ups worth filing so the work isn't lost → low
 
 The number of gaps is whatever this scan actually surfaces. Severity,
 not count, drives the verdict:
 - Zero gaps is the correct verdict on a mechanical, well-tested
   change where the scan finds nothing real.
-- One P0 plus nothing else is correct when there is one real bug
+- One critical plus nothing else is correct when there is one real bug
   and no other concerns.
 - Many gaps is correct when there are many real concerns.
 
@@ -273,26 +273,26 @@ Do NOT call check_path for:
 
 ## Severity levels for gaps
 
-- P0: intent mismatch — the code does not solve the stated problem or is fundamentally wrong
-- P1: significant gap — major feature or requirement is missing or broken.
+- critical: intent mismatch — the code does not solve the stated problem or is fundamentally wrong
+- high:     significant gap — major feature or requirement is missing or broken.
   This includes any correctness bug in production code OR test code, such as:
   tautological assertions (e.g. errors.Is(err, err)), unreachable branches,
   tests that can never fail, wrong variable compared, dead code that masks
   missing coverage.
-  NEVER use P1 for a symbol that is referenced but not defined in the diff —
+  NEVER use high for a symbol that is referenced but not defined in the diff —
   that symbol exists in the codebase already.
-- P2: minor issue — style, naming, docs, minor edge cases that do not affect correctness
-- P3: nice to have — deferred to future work
+- medium:   minor issue — style, naming, docs, minor edge cases that do not affect correctness
+- low:      nice to have — deferred to future work
 
 Do NOT set "blocking" on gaps and do NOT estimate a score — the orchestrator
 computes both deterministically from severities.
-A correctness bug is ALWAYS at least P1, never P2 — even if it is in test code.
+A correctness bug is ALWAYS at least high, never medium — even if it is in test code.
 
 ## Additional checks
 
 In addition to intent/plan alignment, scan the diff for the following.
 
-### Security (P1 blocking)
+### Security (high — blocking)
 Flag any of these patterns visible in the diff:
 - Hardcoded secrets, API keys, tokens, or passwords (look for string literals
   assigned to variables named key, secret, token, password, etc.)
@@ -307,7 +307,7 @@ Flag any of these patterns visible in the diff:
 
 Only flag what is actually visible in the diff.
 
-### Code reuse (P2 non-blocking)
+### Code reuse (medium — non-blocking)
 Flag duplicated or copy-pasted logic visible in the diff:
 - Two or more new functions/methods with near-identical bodies (>5 lines)
 - Copy-pasted blocks that differ only in variable names or literals
@@ -321,14 +321,14 @@ handlers, the same args slice extended in two methods — compare the
 sites against each other and pick severity by what the divergence
 actually causes:
 - Identical bodies in 2+ locations with no behavioural divergence →
-  P2: flag for extraction, or note that a future third instance
+  medium: flag for extraction, or note that a future third instance
   should trigger one.
-- Cosmetic differences only (argument order, error wording) → P2:
+- Cosmetic differences only (argument order, error wording) → medium:
   drift risk worth tightening before bugs hide in it.
 - Divergence that produces incorrect behaviour at one of the sites
   (one site missing a guard the others have, one path silently
   skipping the new flag, one branch returning the wrong type) →
-  P1: this is a correctness bug, not a style issue, and must be
+  high: this is a correctness bug, not a style issue, and must be
   graded as such.
 
 Anchor the gap on one of the diverging locations and name the other
@@ -336,7 +336,7 @@ site explicitly so the author can see both. Do not flag a single
 isolated change as cross-file drift — this rule applies only when the
 same pattern is genuinely repeated in the diff.
 
-### Style & maintainability (P3 non-blocking)
+### Style & maintainability (low — non-blocking)
 Flag readability and maintainability issues visible in the diff:
 - Functions longer than ~80 lines (suggest splitting)
 - Magic numbers or string literals that should be named constants
@@ -380,9 +380,9 @@ symptom:
 On a PASSING verdict, omit "return_to" or set it to "". Never set
 "return_to" to a value that is not one of {code, plan, escalate, ""}.
 
-If a failing verdict has only non-blocking (P2/P3) gaps, it may get
+If a failing verdict has only non-blocking (medium/low) gaps, it may get
 another in-phase retry; in that case omit "return_to" or set it to "".
-If ANY gap is P0 or P1 blocking, "return_to" must be one of code/plan/
+If ANY gap is critical or high (blocking), "return_to" must be one of code/plan/
 escalate.
 
 ## Output rules
@@ -427,9 +427,9 @@ submit_verdict input:
 {
   "summary": "## Reviewed\n- Tenant threading through the 4 handlers\n- Migration adds tenant_id with default ''\n## Notes\n- Design-level follow-ups noted below for post-merge consideration",
   "gaps": [
-    {"severity": "P3", "description": "Migration defaults tenant_id to empty string; once real tenants arrive, the backfill strategy will need to be decided before the column becomes authoritative.", "file": "migrations/0042.sql", "line": 7},
-    {"severity": "P2", "description": "queryHelpers.go now has 6 near-identical 'WHERE tenant_id = ?' clauses — extract a tenantScope() helper once a second table needs the same pattern.", "file": "internal/db/queryHelpers.go", "line": 18},
-    {"severity": "P3", "description": "Tenant is threaded through function signatures rather than context.Context; fine for now, but as the set of tenant-scoped calls grows, context propagation will reduce parameter churn."}
+    {"severity": "low", "description": "Migration defaults tenant_id to empty string; once real tenants arrive, the backfill strategy will need to be decided before the column becomes authoritative.", "file": "migrations/0042.sql", "line": 7},
+    {"severity": "medium", "description": "queryHelpers.go now has 6 near-identical 'WHERE tenant_id = ?' clauses — extract a tenantScope() helper once a second table needs the same pattern.", "file": "internal/db/queryHelpers.go", "line": 18},
+    {"severity": "low", "description": "Tenant is threaded through function signatures rather than context.Context; fine for now, but as the set of tenant-scoped calls grows, context propagation will reduce parameter churn."}
   ],
   "questions": [],
   "return_to": ""
@@ -453,8 +453,8 @@ submit_verdict input:
 {
   "summary": "## Reviewed\n- admin route wiring and literal credential\n## Notes\n- Hardcoded key must move to env or config",
   "gaps": [
-    {"severity": "P0", "description": "No authentication middleware on /admin — intent requires basic auth."},
-    {"severity": "P1", "description": "Hardcoded API key in source (apiKey = 'sk-live-...'). Move to environment variable.", "file": "cmd/admin/main.go", "line": 14, "suggestion": "\tapiKey := os.Getenv(\"ADMIN_API_KEY\")"}
+    {"severity": "critical", "description": "No authentication middleware on /admin — intent requires basic auth."},
+    {"severity": "high", "description": "Hardcoded API key in source (apiKey = 'sk-live-...'). Move to environment variable.", "file": "cmd/admin/main.go", "line": 14, "suggestion": "\tapiKey := os.Getenv(\"ADMIN_API_KEY\")"}
   ],
   "questions": [],
   "return_to": "code"
@@ -476,7 +476,7 @@ Diff (abridged):
 INCORRECT submit_verdict (do NOT produce this):
 {
   "gaps": [
-    {"severity": "P1", "description": "runSingleTask is called but not defined or imported — compilation error"}
+    {"severity": "high", "description": "runSingleTask is called but not defined or imported — compilation error"}
   ]
 }
 
@@ -509,7 +509,7 @@ submit_verdict input:
 {
   "summary": "## Reviewed\n- /admin wrap is correct\n## Notes\n- /admin/users and /admin/logs are unprotected sibling routes",
   "gaps": [
-    {"severity": "P0", "description": "Plan only covered /admin, but the intent says 'every admin route' — /admin/users and /admin/logs remain unauthenticated. The plan is too narrow to satisfy the intent."}
+    {"severity": "critical", "description": "Plan only covered /admin, but the intent says 'every admin route' — /admin/users and /admin/logs remain unauthenticated. The plan is too narrow to satisfy the intent."}
   ],
   "questions": [],
   "return_to": "plan"
@@ -560,7 +560,7 @@ Diff (abridged):
 INCORRECT submit_verdict (do NOT produce this):
 {
   "gaps": [
-    {"severity": "P3", "description": "CodeJudgeModel is undocumented; consider explaining its purpose and why it is currently unused.", "file": "internal/config/config.go", "line": 60}
+    {"severity": "low", "description": "CodeJudgeModel is undocumented; consider explaining its purpose and why it is currently unused.", "file": "internal/config/config.go", "line": 60}
   ]
 }
 
@@ -721,7 +721,7 @@ func (j *QualityJudge) runE2E(ctx context.Context, workDir string) *state.Gap {
 		outStr := string(output)
 		slog.Info("e2e tests failed", "output", truncate(outStr, 200))
 		return &state.Gap{
-			Severity:    state.SeverityP1,
+			Severity:    state.SeverityHigh,
 			Description: fmt.Sprintf("e2e tests failed: %s", truncate(strings.TrimSpace(outStr), 500)),
 		}
 	}
@@ -736,7 +736,7 @@ func (j *QualityJudge) runE2E(ctx context.Context, workDir string) *state.Gap {
 // we enforce the invariants the outer loop relies on:
 //
 //   - A passing verdict never rewinds; clear ReturnTo.
-//   - A failing verdict with a blocking gap (P0/P1) must rewind. If the
+//   - A failing verdict with a blocking gap (critical/high) must rewind. If the
 //     LLM forgot to set ReturnTo we default to ReturnToCode — that matches
 //     the pre-ReturnTo heuristic (see the removed needsCodeRework) and is
 //     the safer default: code retries are cheaper than replans.

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -1063,3 +1063,95 @@ func TestJudge_UsesCompleteWithTools(t *testing.T) {
 		t.Errorf("expected final tool %q, got %q", verdictschema.ToolName, fake.Calls[0].ToolName)
 	}
 }
+
+// TestJudge_SystemPromptHasBeforeFlaggingRubric pins the new
+// rubric: before emitting a Medium / Low / Standards gap, the judge
+// must search the surrounding file for an existing handler / guard /
+// convention that already addresses the concern. If found, drop the
+// gap. This is a generalization of the whole-hunk-reading rule
+// (already covered) extended explicitly to the lower severities and
+// to Standards findings — exactly the tiers most likely to be false
+// positives, since by definition they don't change correctness.
+func TestJudge_SystemPromptHasBeforeFlaggingRubric(t *testing.T) {
+	for _, keyword := range []string{
+		"Before flagging",
+		"Medium",
+		"Low",
+		"Standards",
+		"existing handler",
+		"do not flag",
+	} {
+		if !strings.Contains(systemPrompt, keyword) {
+			t.Errorf("system prompt missing before-flagging-rubric marker %q", keyword)
+		}
+	}
+}
+
+// TestJudge_SystemPromptHasCountAnchorScan goes red if any phrasing
+// that anchors the gap count to a specific number creeps back into
+// the prompt. PR #141 removed "typically 2-3 P3/P2 design observations";
+// PR #145 added Medium/Low/Standards to the dispatch table where
+// padding nits are most expensive. This guard pins the absence of
+// the regression.
+func TestJudge_SystemPromptHasNoCountAnchor(t *testing.T) {
+	for _, banned := range []string{
+		"typically 2",
+		"typically 3",
+		"at least 2",
+		"at least 3",
+		"2-3 P",
+		"2-3 gaps",
+		"2 to 3",
+		"up to 3 gaps",
+	} {
+		if strings.Contains(systemPrompt, banned) {
+			t.Errorf("system prompt re-introduced count-anchor phrase %q — see PR #141", banned)
+		}
+	}
+}
+
+// TestRenderCrossPushFraming produces the cross-push framing the
+// quality judge prepends to the user prompt when prior verdict gaps
+// exist. The framing tells the judge:
+//
+//   - the prior review's gap list (with severities)
+//   - to verify each prior gap is still applicable in the current diff
+//     and drop it if fixed
+//   - to scan only the diff since the prior review for new findings
+//   - NOT to introduce findings that existed before the prior review
+//     (if the previous round missed them, they're not flagged now)
+//
+// Empty prior-gap list returns the empty string so the framing
+// disappears on the first review of a PR.
+func TestRenderCrossPushFraming_EmptyOnFirstReview(t *testing.T) {
+	if got := RenderCrossPushFraming(nil); got != "" {
+		t.Errorf("RenderCrossPushFraming(nil) = %q, want empty", got)
+	}
+	if got := RenderCrossPushFraming([]state.Gap{}); got != "" {
+		t.Errorf("RenderCrossPushFraming(empty) = %q, want empty", got)
+	}
+}
+
+func TestRenderCrossPushFraming_IncludesPriorGapsAndInstructions(t *testing.T) {
+	prior := []state.Gap{
+		{Severity: state.SeverityCritical, Description: "missing auth on /admin"},
+		{Severity: state.SeverityHigh, Description: "tests fail"},
+	}
+	got := RenderCrossPushFraming(prior)
+
+	for _, want := range []string{
+		"prior review",
+		"missing auth on /admin",
+		"tests fail",
+		"Critical",
+		"High",
+		"Verify each",
+		"drop it",
+		"new findings",
+		"Do not introduce",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("RenderCrossPushFraming missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+}

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -38,7 +38,7 @@ func TestQualityJudge_BaselineMarkerForcesBlocking(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "BASELINE: no-secrets: hardcoded token", Blocking: false},
+				{Severity: state.SeverityHigh, Description: "BASELINE: no-secrets: hardcoded token", Blocking: false},
 			},
 		},
 	}
@@ -153,7 +153,7 @@ func TestJudge_IntentMismatch_P0Blocks(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "code implements CRUD but intent was auth system"},
+				{Severity: state.SeverityCritical, Description: "code implements CRUD but intent was auth system"},
 			},
 		},
 	}
@@ -232,7 +232,7 @@ func TestJudge_E2EFail_AddsBlockingGap(t *testing.T) {
 	if len(verdict.Gaps) != 1 {
 		t.Fatalf("expected 1 gap from e2e, got %d", len(verdict.Gaps))
 	}
-	if verdict.Gaps[0].Severity != state.SeverityP1 {
+	if verdict.Gaps[0].Severity != state.SeverityHigh {
 		t.Errorf("expected P1 severity for e2e failure, got %s", verdict.Gaps[0].Severity)
 	}
 	if !verdict.Gaps[0].Blocking {
@@ -295,10 +295,10 @@ func TestJudge_AccumulatedP2sDragBelowThreshold(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "a"},
-				{Severity: state.SeverityP2, Description: "b"},
-				{Severity: state.SeverityP2, Description: "c"},
-				{Severity: state.SeverityP2, Description: "d"},
+				{Severity: state.SeverityMedium, Description: "a"},
+				{Severity: state.SeverityMedium, Description: "b"},
+				{Severity: state.SeverityMedium, Description: "c"},
+				{Severity: state.SeverityMedium, Description: "d"},
 			},
 		},
 	}
@@ -322,9 +322,9 @@ func TestJudge_PassAtExactThreshold(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "a"},
-				{Severity: state.SeverityP2, Description: "b"},
-				{Severity: state.SeverityP2, Description: "c"},
+				{Severity: state.SeverityMedium, Description: "a"},
+				{Severity: state.SeverityMedium, Description: "b"},
+				{Severity: state.SeverityMedium, Description: "c"},
 			},
 		},
 	}
@@ -359,7 +359,7 @@ func TestJudge_MixedGapsWithE2E(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "missing edge case handling"},
+				{Severity: state.SeverityMedium, Description: "missing edge case handling"},
 			},
 			Questions: []state.Question{
 				{Text: "Should we add retry logic?", Priority: "medium"},
@@ -389,7 +389,7 @@ func TestJudge_MixedGapsWithE2E(t *testing.T) {
 	if len(verdict.Gaps) != 2 {
 		t.Fatalf("expected 2 gaps (1 AI + 1 e2e), got %d", len(verdict.Gaps))
 	}
-	if verdict.Gaps[1].Severity != state.SeverityP1 {
+	if verdict.Gaps[1].Severity != state.SeverityHigh {
 		t.Errorf("expected second gap P1 (e2e), got %s", verdict.Gaps[1].Severity)
 	}
 	if len(verdict.Questions) != 1 {
@@ -402,9 +402,9 @@ func TestJudge_ScoreFloorAtZero(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "wrong feature"},
-				{Severity: state.SeverityP0, Description: "missing core"},
-				{Severity: state.SeverityP0, Description: "broken api"},
+				{Severity: state.SeverityCritical, Description: "wrong feature"},
+				{Severity: state.SeverityCritical, Description: "missing core"},
+				{Severity: state.SeverityCritical, Description: "broken api"},
 			},
 		},
 	}
@@ -549,8 +549,8 @@ func TestJudge_SystemPromptContainsStyleChecks(t *testing.T) {
 }
 
 func TestJudge_SecurityChecksAreBlocking(t *testing.T) {
-	if !strings.Contains(systemPrompt, "P1 blocking") {
-		t.Error("system prompt should mark security checks as P1 blocking")
+	if !strings.Contains(systemPrompt, "high — blocking") {
+		t.Error("system prompt should mark security checks as high — blocking")
 	}
 }
 
@@ -652,11 +652,11 @@ func TestJudge_SystemPromptEstablishesFreshReviewerMindset(t *testing.T) {
 }
 
 func TestJudge_CodeReuseAndStyleAreNonBlocking(t *testing.T) {
-	if !strings.Contains(systemPrompt, "P2 non-blocking") {
-		t.Error("system prompt should mark code-reuse checks as P2 non-blocking")
+	if !strings.Contains(systemPrompt, "medium — non-blocking") {
+		t.Error("system prompt should mark code-reuse checks as medium — non-blocking")
 	}
-	if !strings.Contains(systemPrompt, "P3 non-blocking") {
-		t.Error("system prompt should mark style checks as P3 non-blocking")
+	if !strings.Contains(systemPrompt, "low — non-blocking") {
+		t.Error("system prompt should mark style checks as low — non-blocking")
 	}
 }
 
@@ -684,7 +684,7 @@ func TestJudge_GapWithFileAndLine(t *testing.T) {
 		Response: state.Verdict{
 			Gaps: []state.Gap{
 				{
-					Severity:    state.SeverityP2,
+					Severity:    state.SeverityMedium,
 					Description: "magic number",
 					File:        "internal/foo/bar.go",
 					Line:        42,
@@ -779,7 +779,7 @@ func TestJudge_BlockingGapFailsEvenWithHighScore(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "tautological assertion"},
+				{Severity: state.SeverityHigh, Description: "tautological assertion"},
 			},
 		},
 	}
@@ -803,8 +803,8 @@ func TestJudge_NonBlockingGapsAllowPass(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "magic number"},
-				{Severity: state.SeverityP3, Description: "long function"},
+				{Severity: state.SeverityMedium, Description: "magic number"},
+				{Severity: state.SeverityLow, Description: "long function"},
 			},
 		},
 	}
@@ -933,7 +933,7 @@ func TestJudge_ReturnTo_Propagated(t *testing.T) {
 			fake := &claude.FakeClient{
 				Response: state.Verdict{
 					Gaps: []state.Gap{
-						{Severity: state.SeverityP0, Description: "failing"},
+						{Severity: state.SeverityCritical, Description: "failing"},
 					},
 					ReturnTo: tc.in,
 				},
@@ -960,7 +960,7 @@ func TestJudge_ReturnTo_DefaultsToCodeOnBlockingFailure(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP1, Description: "bug"},
+				{Severity: state.SeverityHigh, Description: "bug"},
 			},
 			// ReturnTo deliberately empty.
 		},
@@ -985,10 +985,10 @@ func TestJudge_ReturnTo_EmptyForNonBlockingFailure(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "a"},
-				{Severity: state.SeverityP2, Description: "b"},
-				{Severity: state.SeverityP2, Description: "c"},
-				{Severity: state.SeverityP2, Description: "d"},
+				{Severity: state.SeverityMedium, Description: "a"},
+				{Severity: state.SeverityMedium, Description: "b"},
+				{Severity: state.SeverityMedium, Description: "c"},
+				{Severity: state.SeverityMedium, Description: "d"},
 			},
 		},
 	}
@@ -1013,7 +1013,7 @@ func TestJudge_ReturnTo_UnknownValueCollapsesToCode(t *testing.T) {
 	fake := &claude.FakeClient{
 		Response: state.Verdict{
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "bug"},
+				{Severity: state.SeverityCritical, Description: "bug"},
 			},
 			ReturnTo: state.ReturnTo("rewrite"),
 		},

--- a/internal/judges/verdictschema/schema.go
+++ b/internal/judges/verdictschema/schema.go
@@ -35,8 +35,8 @@ const inputSchema = `{
         "properties": {
           "severity": {
             "type": "string",
-            "enum": ["P0", "P1", "P2", "P3"],
-            "description": "P0/P1 are blocking; P2/P3 are advisory."
+            "enum": ["critical", "high", "medium", "low"],
+            "description": "critical/high are blocking; medium/low are advisory. Legacy P0/P1/P2/P3 strings are still accepted by the post-processor (NormalizeSeverity) for backward compatibility, but new judge calls should emit the canonical lowercase wording."
           },
           "description": {"type": "string"},
           "file": {"type": "string", "description": "Optional file path when the gap maps to a specific diff location."},
@@ -96,13 +96,13 @@ func ComputeScore(gaps []state.Gap) float64 {
 	penalty := 0.0
 	for _, g := range gaps {
 		switch g.Severity {
-		case state.SeverityP0:
+		case state.SeverityCritical:
 			penalty += weightP0
-		case state.SeverityP1:
+		case state.SeverityHigh:
 			penalty += weightP1
-		case state.SeverityP2:
+		case state.SeverityMedium:
 			penalty += weightP2
-		case state.SeverityP3:
+		case state.SeverityLow:
 			penalty += weightP3
 		}
 	}
@@ -185,13 +185,13 @@ func ComputeScoreWithAcknowledged(gaps []state.Gap, acknowledged []state.Assumpt
 	for _, g := range gaps {
 		w := 0.0
 		switch g.Severity {
-		case state.SeverityP0:
+		case state.SeverityCritical:
 			w = weightP0
-		case state.SeverityP1:
+		case state.SeverityHigh:
 			w = weightP1
-		case state.SeverityP2:
+		case state.SeverityMedium:
 			w = weightP2
-		case state.SeverityP3:
+		case state.SeverityLow:
 			w = weightP3
 		}
 		if IsReflagged(g, acknowledged) {

--- a/internal/judges/verdictschema/schema.go
+++ b/internal/judges/verdictschema/schema.go
@@ -119,16 +119,25 @@ func ComputeScore(gaps []state.Gap) float64 {
 
 // ApplyBlocking sets the Blocking flag on each gap based on severity, using
 // the caller-supplied set of severities that count as blocking. Passing a nil
-// set means the default (P0 and P1) applies.
+// set means the default (Critical and High — formerly P0/P1) applies.
+//
+// Both the map keys and each gap's stored severity are run through
+// state.NormalizeSeverity, so vairdict.yaml configs that still spell the
+// blocking set as ["P0","P1"] continue to gate the new "critical"/"high"
+// gaps without any user-visible change.
 func ApplyBlocking(gaps []state.Gap, blockOn map[string]bool) {
 	if blockOn == nil {
 		blockOn = map[string]bool{
-			string(state.SeverityP0): true,
-			string(state.SeverityP1): true,
+			string(state.SeverityCritical): true,
+			string(state.SeverityHigh):     true,
 		}
 	}
+	normalized := make(map[state.Severity]bool, len(blockOn))
+	for k, v := range blockOn {
+		normalized[state.NormalizeSeverity(state.Severity(k))] = v
+	}
 	for i := range gaps {
-		gaps[i].Blocking = blockOn[string(gaps[i].Severity)]
+		gaps[i].Blocking = normalized[state.NormalizeSeverity(gaps[i].Severity)]
 	}
 }
 

--- a/internal/judges/verdictschema/schema_test.go
+++ b/internal/judges/verdictschema/schema_test.go
@@ -14,19 +14,19 @@ func TestComputeScore(t *testing.T) {
 		want float64
 	}{
 		{"empty", nil, 100},
-		{"one_p3", []state.Gap{{Severity: state.SeverityP3}}, 95},
-		{"one_p2", []state.Gap{{Severity: state.SeverityP2}}, 90},
-		{"one_p1", []state.Gap{{Severity: state.SeverityP1}}, 80},
-		{"one_p0", []state.Gap{{Severity: state.SeverityP0}}, 60},
+		{"one_p3", []state.Gap{{Severity: state.SeverityLow}}, 95},
+		{"one_p2", []state.Gap{{Severity: state.SeverityMedium}}, 90},
+		{"one_p1", []state.Gap{{Severity: state.SeverityHigh}}, 80},
+		{"one_p0", []state.Gap{{Severity: state.SeverityCritical}}, 60},
 		{"mixed", []state.Gap{
-			{Severity: state.SeverityP1},
-			{Severity: state.SeverityP2},
-			{Severity: state.SeverityP3},
+			{Severity: state.SeverityHigh},
+			{Severity: state.SeverityMedium},
+			{Severity: state.SeverityLow},
 		}, 65},
 		{"floors_at_zero", []state.Gap{
-			{Severity: state.SeverityP0},
-			{Severity: state.SeverityP0},
-			{Severity: state.SeverityP0},
+			{Severity: state.SeverityCritical},
+			{Severity: state.SeverityCritical},
+			{Severity: state.SeverityCritical},
 		}, 0},
 		{"unknown_severity_ignored", []state.Gap{{Severity: "PX"}}, 100},
 	}
@@ -42,10 +42,10 @@ func TestComputeScore(t *testing.T) {
 
 func TestApplyBlocking_DefaultSet(t *testing.T) {
 	gaps := []state.Gap{
-		{Severity: state.SeverityP0},
-		{Severity: state.SeverityP1},
-		{Severity: state.SeverityP2},
-		{Severity: state.SeverityP3},
+		{Severity: state.SeverityCritical},
+		{Severity: state.SeverityHigh},
+		{Severity: state.SeverityMedium},
+		{Severity: state.SeverityLow},
 	}
 
 	ApplyBlocking(gaps, nil)
@@ -61,8 +61,8 @@ func TestApplyBlocking_DefaultSet(t *testing.T) {
 
 func TestApplyBlocking_CustomSet(t *testing.T) {
 	gaps := []state.Gap{
-		{Severity: state.SeverityP0, Blocking: false},
-		{Severity: state.SeverityP1, Blocking: true}, // LLM opinion — must be overridden
+		{Severity: state.SeverityCritical, Blocking: false},
+		{Severity: state.SeverityHigh, Blocking: true}, // LLM opinion — must be overridden
 	}
 
 	// Only P0 blocks in this config.
@@ -80,8 +80,8 @@ func TestApplyBlocking_EmptySetBlocksNothing(t *testing.T) {
 	// Explicit empty map must mean "nothing is blocking" — not "fall back
 	// to default".
 	gaps := []state.Gap{
-		{Severity: state.SeverityP0},
-		{Severity: state.SeverityP1},
+		{Severity: state.SeverityCritical},
+		{Severity: state.SeverityHigh},
 	}
 	ApplyBlocking(gaps, map[string]bool{})
 
@@ -106,8 +106,8 @@ func TestHasBlockingGap(t *testing.T) {
 
 func TestIsReflagged(t *testing.T) {
 	ack := []state.Assumption{
-		{Description: "database choice unclear", Severity: state.SeverityP2},
-		{Description: "caching strategy not defined", Severity: state.SeverityP2},
+		{Description: "database choice unclear", Severity: state.SeverityMedium},
+		{Description: "caching strategy not defined", Severity: state.SeverityMedium},
 	}
 
 	tests := []struct {
@@ -139,11 +139,11 @@ func TestIsReflagged(t *testing.T) {
 
 func TestComputeScoreWithAcknowledged_HalvesPenalty(t *testing.T) {
 	ack := []state.Assumption{
-		{Description: "database choice unclear", Severity: state.SeverityP2},
+		{Description: "database choice unclear", Severity: state.SeverityMedium},
 	}
 	gaps := []state.Gap{
-		{Severity: state.SeverityP2, Description: "database choice unclear"},  // re-flagged: 10/2 = 5
-		{Severity: state.SeverityP2, Description: "new concern about naming"}, // fresh: 10
+		{Severity: state.SeverityMedium, Description: "database choice unclear"},  // re-flagged: 10/2 = 5
+		{Severity: state.SeverityMedium, Description: "new concern about naming"}, // fresh: 10
 	}
 
 	got := ComputeScoreWithAcknowledged(gaps, ack)
@@ -155,8 +155,8 @@ func TestComputeScoreWithAcknowledged_HalvesPenalty(t *testing.T) {
 
 func TestComputeScoreWithAcknowledged_NoAcknowledged(t *testing.T) {
 	gaps := []state.Gap{
-		{Severity: state.SeverityP2, Description: "a"},
-		{Severity: state.SeverityP2, Description: "b"},
+		{Severity: state.SeverityMedium, Description: "a"},
+		{Severity: state.SeverityMedium, Description: "b"},
 	}
 
 	withAck := ComputeScoreWithAcknowledged(gaps, nil)

--- a/internal/phases/code/phase_test.go
+++ b/internal/phases/code/phase_test.go
@@ -110,7 +110,7 @@ func TestRun_PassFirstTry(t *testing.T) {
 func TestRun_PassOnRetry(t *testing.T) {
 	coder := &fakeCoder{}
 	judge := &fakeJudge{verdicts: []*state.Verdict{
-		{Score: 50, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityP1, Description: "test failed", Blocking: true}}},
+		{Score: 50, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityHigh, Description: "test failed", Blocking: true}}},
 		{Score: 100, Pass: true},
 	}}
 
@@ -135,7 +135,7 @@ func TestRun_PassOnRetry(t *testing.T) {
 func TestRun_Escalation(t *testing.T) {
 	coder := &fakeCoder{}
 	judge := &fakeJudge{verdicts: []*state.Verdict{
-		{Score: 25, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityP0, Description: "build broken"}}},
+		{Score: 25, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityCritical, Description: "build broken"}}},
 	}}
 
 	task := codingTask()
@@ -227,7 +227,7 @@ func TestRun_AttemptsStored(t *testing.T) {
 
 func TestBuildCoderPrompt(t *testing.T) {
 	prompt := buildCoderPrompt("intent", "plan", "fix tests", []state.Assumption{
-		{Severity: state.SeverityP2, Description: "assumed X"},
+		{Severity: state.SeverityMedium, Description: "assumed X"},
 	}, nil, nil)
 
 	if !containsStr(prompt, "intent") {

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -215,17 +215,17 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 func (p *PlanPhase) processGaps(task *state.Task, gaps []state.Gap) {
 	for _, gap := range gaps {
 		switch gap.Severity {
-		case state.SeverityP2:
+		case state.SeverityMedium:
 			slog.Info("logging P2 gap as assumption",
 				"task_id", task.ID,
 				"description", gap.Description,
 			)
 			task.Assumptions = append(task.Assumptions, state.Assumption{
 				Description: gap.Description,
-				Severity:    state.SeverityP2,
+				Severity:    state.SeverityMedium,
 				Phase:       state.PhasePlan,
 			})
-		case state.SeverityP3:
+		case state.SeverityLow:
 			slog.Info("deferring P3 gap to future issue",
 				"task_id", task.ID,
 				"description", gap.Description,

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -285,7 +285,7 @@ func buildPlannerPrompt(intent string, feedback string, assumptions []state.Assu
 	if len(assumptions) > 0 {
 		b.WriteString("\n## Assumptions from Previous Loops\n")
 		for _, a := range assumptions {
-			fmt.Fprintf(&b, "- [%s] %s\n", a.Severity, a.Description)
+			fmt.Fprintf(&b, "- [%s] %s\n", a.Severity.Display(), a.Description)
 		}
 	}
 
@@ -305,7 +305,7 @@ func buildFeedbackSummary(verdict *state.Verdict) string {
 			if gap.Blocking {
 				blocking = " [BLOCKING]"
 			}
-			fmt.Fprintf(&b, "- [%s]%s %s\n", gap.Severity, blocking, gap.Description)
+			fmt.Fprintf(&b, "- [%s]%s %s\n", gap.Severity.Display(), blocking, gap.Description)
 		}
 	}
 

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -116,8 +116,8 @@ func failingVerdict() *state.Verdict {
 		Score: 50,
 		Pass:  false,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP0, Description: "no error handling", Blocking: true},
-			{Severity: state.SeverityP1, Description: "missing input validation", Blocking: true},
+			{Severity: state.SeverityCritical, Description: "no error handling", Blocking: true},
+			{Severity: state.SeverityHigh, Description: "missing input validation", Blocking: true},
 		},
 		Questions: []state.Question{
 			{Text: "What database will be used?", Priority: "high"},
@@ -308,9 +308,9 @@ func TestPlanPhase_P2GapsLoggedAsAssumptions(t *testing.T) {
 				Score: 85,
 				Pass:  true,
 				Gaps: []state.Gap{
-					{Severity: state.SeverityP2, Description: "database choice unclear", Blocking: false},
-					{Severity: state.SeverityP2, Description: "caching strategy not defined", Blocking: false},
-					{Severity: state.SeverityP3, Description: "nice to have: monitoring", Blocking: false},
+					{Severity: state.SeverityMedium, Description: "database choice unclear", Blocking: false},
+					{Severity: state.SeverityMedium, Description: "caching strategy not defined", Blocking: false},
+					{Severity: state.SeverityLow, Description: "nice to have: monitoring", Blocking: false},
 				},
 			},
 		},
@@ -336,7 +336,7 @@ func TestPlanPhase_P2GapsLoggedAsAssumptions(t *testing.T) {
 	if task.Assumptions[0].Description != "database choice unclear" {
 		t.Errorf("unexpected assumption: %s", task.Assumptions[0].Description)
 	}
-	if task.Assumptions[0].Severity != state.SeverityP2 {
+	if task.Assumptions[0].Severity != state.SeverityMedium {
 		t.Errorf("expected severity P2, got %s", task.Assumptions[0].Severity)
 	}
 	if task.Assumptions[0].Phase != state.PhasePlan {
@@ -361,8 +361,8 @@ func TestPlanPhase_AttemptsStored(t *testing.T) {
 	}
 	judge := &fakeJudge{
 		verdicts: []*state.Verdict{
-			{Score: 40, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityP0, Description: "gap1", Blocking: true}}},
-			{Score: 60, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityP1, Description: "gap2", Blocking: true}}},
+			{Score: 40, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityCritical, Description: "gap1", Blocking: true}}},
+			{Score: 60, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityHigh, Description: "gap2", Blocking: true}}},
 			{Score: 90, Pass: true, Gaps: []state.Gap{}},
 		},
 	}
@@ -459,8 +459,8 @@ func TestPlanPhase_AssumptionsIncludedInRetryPrompt(t *testing.T) {
 				Score: 60,
 				Pass:  false,
 				Gaps: []state.Gap{
-					{Severity: state.SeverityP2, Description: "unclear caching approach", Blocking: false},
-					{Severity: state.SeverityP0, Description: "missing auth", Blocking: true},
+					{Severity: state.SeverityMedium, Description: "unclear caching approach", Blocking: false},
+					{Severity: state.SeverityCritical, Description: "missing auth", Blocking: true},
 				},
 			},
 			passingVerdict(),
@@ -540,7 +540,7 @@ func TestBuildPlannerPrompt_WithFeedback(t *testing.T) {
 
 func TestBuildPlannerPrompt_WithAssumptions(t *testing.T) {
 	assumptions := []state.Assumption{
-		{Description: "using PostgreSQL", Severity: state.SeverityP2, Phase: state.PhasePlan},
+		{Description: "using PostgreSQL", Severity: state.SeverityMedium, Phase: state.PhasePlan},
 	}
 	prompt := buildPlannerPrompt("build an API", "some feedback", assumptions, nil, nil, nil)
 
@@ -687,8 +687,8 @@ func TestBuildFeedbackSummary(t *testing.T) {
 		Score: 55.5,
 		Pass:  false,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP0, Description: "critical issue", Blocking: true},
-			{Severity: state.SeverityP2, Description: "minor thing", Blocking: false},
+			{Severity: state.SeverityCritical, Description: "critical issue", Blocking: true},
+			{Severity: state.SeverityMedium, Description: "minor thing", Blocking: false},
 		},
 		Questions: []state.Question{
 			{Text: "What DB?", Priority: "high"},

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -700,11 +700,11 @@ func TestBuildFeedbackSummary(t *testing.T) {
 	if !strings.Contains(summary, "Score: 55.5") {
 		t.Errorf("expected score in summary, got: %s", summary)
 	}
-	if !strings.Contains(summary, "[P0] [BLOCKING] critical issue") {
-		t.Errorf("expected P0 blocking gap, got: %s", summary)
+	if !strings.Contains(summary, "[Critical] [BLOCKING] critical issue") {
+		t.Errorf("expected Critical blocking gap, got: %s", summary)
 	}
-	if !strings.Contains(summary, "[P2] minor thing") {
-		t.Errorf("expected P2 gap, got: %s", summary)
+	if !strings.Contains(summary, "[Medium] minor thing") {
+		t.Errorf("expected Medium gap, got: %s", summary)
 	}
 	if !strings.Contains(summary, "[high] What DB?") {
 		t.Errorf("expected question, got: %s", summary)

--- a/internal/phases/quality/phase_test.go
+++ b/internal/phases/quality/phase_test.go
@@ -91,7 +91,7 @@ func TestRun_PassOnRetry_NonBlockingGaps(t *testing.T) {
 			Score: 60,
 			Pass:  false,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP2, Description: "minor polish", Blocking: false},
+				{Severity: state.SeverityMedium, Description: "minor polish", Blocking: false},
 			},
 		},
 		{Score: 90, Pass: true},
@@ -127,7 +127,7 @@ func TestRun_ReturnToCode_OnP0Gap(t *testing.T) {
 			Score: 30,
 			Pass:  false,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "intent mismatch", Blocking: true},
+				{Severity: state.SeverityCritical, Description: "intent mismatch", Blocking: true},
 			},
 			ReturnTo: state.ReturnToCode,
 		},
@@ -165,7 +165,7 @@ func TestRun_ReturnToPlan_ForwardsToOrchestrator(t *testing.T) {
 			Score: 40,
 			Pass:  false,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "plan too narrow", Blocking: true},
+				{Severity: state.SeverityCritical, Description: "plan too narrow", Blocking: true},
 			},
 			ReturnTo: state.ReturnToPlan,
 		},
@@ -195,7 +195,7 @@ func TestRun_ReturnToEscalate_SignalsEscalate(t *testing.T) {
 			Score: 20,
 			Pass:  false,
 			Gaps: []state.Gap{
-				{Severity: state.SeverityP0, Description: "intent is ambiguous", Blocking: true},
+				{Severity: state.SeverityCritical, Description: "intent is ambiguous", Blocking: true},
 			},
 			ReturnTo: state.ReturnToEscalate,
 		},
@@ -223,7 +223,7 @@ func TestRun_Escalation_NonBlockingLoopOut(t *testing.T) {
 		Score: 60,
 		Pass:  false,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP2, Description: "polish", Blocking: false},
+			{Severity: state.SeverityMedium, Description: "polish", Blocking: false},
 		},
 	}
 	judge := &fakeJudge{verdicts: []*state.Verdict{failing, failing, failing}}
@@ -280,8 +280,8 @@ func TestRun_WrongState(t *testing.T) {
 
 func TestRun_AttemptsStored(t *testing.T) {
 	judge := &fakeJudge{verdicts: []*state.Verdict{
-		{Score: 60, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityP2, Blocking: false, Description: "x"}}},
-		{Score: 65, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityP2, Blocking: false, Description: "y"}}},
+		{Score: 60, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityMedium, Blocking: false, Description: "x"}}},
+		{Score: 65, Pass: false, Gaps: []state.Gap{{Severity: state.SeverityMedium, Blocking: false, Description: "y"}}},
 		{Score: 95, Pass: true},
 	}}
 
@@ -334,8 +334,8 @@ func TestBuildQualityFeedback(t *testing.T) {
 	v := &state.Verdict{
 		Score: 72.5,
 		Gaps: []state.Gap{
-			{Severity: state.SeverityP1, Description: "thing missing", Blocking: true},
-			{Severity: state.SeverityP3, Description: "nice to have", Blocking: false},
+			{Severity: state.SeverityHigh, Description: "thing missing", Blocking: true},
+			{Severity: state.SeverityLow, Description: "nice to have", Blocking: false},
 		},
 		Questions: []state.Question{
 			{Text: "is X required?", Priority: "high"},

--- a/internal/standards/baseline.go
+++ b/internal/standards/baseline.go
@@ -97,7 +97,7 @@ func ForceBaselineBlocking(gaps []state.Gap) int {
 		if !isBaselineDescription(gaps[i].Description) {
 			continue
 		}
-		if gaps[i].Severity != state.SeverityP0 && gaps[i].Severity != state.SeverityP1 {
+		if gaps[i].Severity != state.SeverityCritical && gaps[i].Severity != state.SeverityHigh {
 			continue
 		}
 		if !gaps[i].Blocking {

--- a/internal/standards/baseline_test.go
+++ b/internal/standards/baseline_test.go
@@ -40,8 +40,8 @@ func TestBlock_DeclaresNonNegotiable(t *testing.T) {
 
 func TestForceBaselineBlocking_PromotesP0AndP1(t *testing.T) {
 	gaps := []state.Gap{
-		{Severity: state.SeverityP0, Description: "BASELINE: no-secrets: API key committed", Blocking: false},
-		{Severity: state.SeverityP1, Description: "BASELINE: handle-errors: _ = fn()", Blocking: false},
+		{Severity: state.SeverityCritical, Description: "BASELINE: no-secrets: API key committed", Blocking: false},
+		{Severity: state.SeverityHigh, Description: "BASELINE: handle-errors: _ = fn()", Blocking: false},
 	}
 
 	n := ForceBaselineBlocking(gaps)
@@ -57,8 +57,8 @@ func TestForceBaselineBlocking_PromotesP0AndP1(t *testing.T) {
 
 func TestForceBaselineBlocking_LeavesP2AndP3Alone(t *testing.T) {
 	gaps := []state.Gap{
-		{Severity: state.SeverityP2, Description: "BASELINE: self-doc-names: tmp is unclear", Blocking: false},
-		{Severity: state.SeverityP3, Description: "BASELINE: no-duplication: tiny repetition", Blocking: false},
+		{Severity: state.SeverityMedium, Description: "BASELINE: self-doc-names: tmp is unclear", Blocking: false},
+		{Severity: state.SeverityLow, Description: "BASELINE: no-duplication: tiny repetition", Blocking: false},
 	}
 
 	n := ForceBaselineBlocking(gaps)
@@ -75,7 +75,7 @@ func TestForceBaselineBlocking_LeavesP2AndP3Alone(t *testing.T) {
 func TestForceBaselineBlocking_IgnoresNonBaselineGaps(t *testing.T) {
 	// Unmarked P1 gaps are governed by team config, not baseline.
 	gaps := []state.Gap{
-		{Severity: state.SeverityP1, Description: "missing request validation", Blocking: false},
+		{Severity: state.SeverityHigh, Description: "missing request validation", Blocking: false},
 	}
 
 	n := ForceBaselineBlocking(gaps)
@@ -91,7 +91,7 @@ func TestForceBaselineBlocking_AlreadyBlockingNotDoubleCounted(t *testing.T) {
 	// A config that already blocks P1 leaves the baseline gap already
 	// flagged. Force does not need to promote — it should report 0.
 	gaps := []state.Gap{
-		{Severity: state.SeverityP1, Description: "BASELINE: no-dead-code: unreachable branch", Blocking: true},
+		{Severity: state.SeverityHigh, Description: "BASELINE: no-dead-code: unreachable branch", Blocking: true},
 	}
 
 	if n := ForceBaselineBlocking(gaps); n != 0 {
@@ -109,7 +109,7 @@ func TestForceBaselineBlocking_OverridesPermissiveConfig(t *testing.T) {
 	// regardless of config.
 	gaps := []state.Gap{
 		// Team config already dropped Blocking=false for the P1 secret.
-		{Severity: state.SeverityP1, Description: "BASELINE: no-secrets: literal token in config.go", Blocking: false},
+		{Severity: state.SeverityHigh, Description: "BASELINE: no-secrets: literal token in config.go", Blocking: false},
 	}
 
 	if n := ForceBaselineBlocking(gaps); n != 1 {

--- a/internal/standards/config.go
+++ b/internal/standards/config.go
@@ -1,0 +1,142 @@
+package standards
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RuleState is the per-rule setting the team chooses in vairdict.yaml.
+// Three values, deliberately not a free-form string: any other input
+// at config-load time is rejected so a typo can't silently disable a
+// rule.
+type RuleState string
+
+const (
+	// RuleStateOff disables the rule entirely. The judge prompt does
+	// not list it, and any finding the model emits with this rule tag
+	// is dropped by the post-processor.
+	RuleStateOff RuleState = "off"
+	// RuleStateOn enables the rule as inline-but-non-blocking — the
+	// "easy fix" mode. The verdict gate ignores it; the inline comment
+	// shows up with a one-click suggestion when the judge supplies one.
+	RuleStateOn RuleState = "on"
+	// RuleStateBlock promotes the rule to blocking inline. A finding
+	// for a "block" rule fails the verdict gate just like a Critical
+	// or High severity gap does.
+	RuleStateBlock RuleState = "block"
+)
+
+// ParseRuleState parses a vairdict.yaml string value into a RuleState.
+// Case-insensitive on the three accepted spellings; any other value
+// is an error so the user finds out at load time, not after a wasted
+// run.
+func ParseRuleState(s string) (RuleState, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "off":
+		return RuleStateOff, nil
+	case "on":
+		return RuleStateOn, nil
+	case "block":
+		return RuleStateBlock, nil
+	}
+	return "", fmt.Errorf("invalid rule state %q: must be off, on, or block", s)
+}
+
+// KnownRules is the canonical list of configurable Standards rules.
+// Adding an entry here automatically gives every existing config the
+// rule at the default state (on) — see Default. Security-floor rules
+// (no_secrets, handle_errors) are NOT in this list: they live in the
+// security package, are hardcoded blocking, and are not configurable.
+var KnownRules = []string{
+	"naming",
+	"indent",
+	"error_logging",
+	"switch_for_multiple_cases",
+	"class_naming",
+	"no_binaries",
+	"no_dead_code",
+	"no_todo_fixme",
+	"no_duplication",
+}
+
+// Config is the team's per-rule Standards setting, parsed from the
+// `standards:` block in vairdict.yaml. Rules absent from the map fall
+// through to the Default state (on) so configs stay short — a team
+// only needs to mention rules whose state they're changing from the
+// default.
+type Config struct {
+	Rules map[string]RuleState `yaml:"-"`
+}
+
+// Default returns a Config with every known rule set to RuleStateOn.
+// Used as the merge base when loading vairdict.yaml so a fresh repo
+// gets the full Standards lint without any explicit config edits.
+func Default() Config {
+	rules := make(map[string]RuleState, len(KnownRules))
+	for _, r := range KnownRules {
+		rules[r] = RuleStateOn
+	}
+	return Config{Rules: rules}
+}
+
+// Rule returns the configured state for a rule. The second return
+// value is false when the rule is unknown — callers can use it to
+// distinguish "rule explicitly off" from "rule never configured".
+func (c Config) Rule(name string) (RuleState, bool) {
+	state, ok := c.Rules[name]
+	return state, ok
+}
+
+// IsEnabled reports whether a rule should produce findings — true for
+// "on" and "block", false for "off" and unknown rules. The post-
+// processor uses this to decide whether to keep a finding the judge
+// emitted.
+func (c Config) IsEnabled(rule string) bool {
+	switch c.Rules[rule] {
+	case RuleStateOn, RuleStateBlock:
+		return true
+	}
+	return false
+}
+
+// IsBlocking reports whether a rule promotes its findings to blocking.
+// Only "block" returns true. The verdict gate consults this when
+// deciding whether a Standards finding should fail the PR.
+func (c Config) IsBlocking(rule string) bool {
+	return c.Rules[rule] == RuleStateBlock
+}
+
+// Finding is one Standards observation the judge emitted. It carries
+// a rule tag (one of KnownRules), a one-line description, an optional
+// file/line anchor, and an optional one-click suggestion block. The
+// Blocking flag is set by FilterFindings based on the team's Config —
+// the judge never decides on its own whether a Standards finding
+// blocks; the team config does.
+type Finding struct {
+	Rule        string `json:"rule"`
+	Description string `json:"description"`
+	File        string `json:"file,omitempty"`
+	Line        int    `json:"line,omitempty"`
+	Suggestion  string `json:"suggestion,omitempty"`
+	Blocking    bool   `json:"blocking"`
+}
+
+// FilterFindings drops findings whose rule is disabled or unknown,
+// and stamps Blocking=true on findings whose rule is in the "block"
+// state. This is the single post-processor step that turns the
+// judge's raw Standards array into the user-facing Standards list.
+//
+// The drop step is the built-in false-positive guard: if the judge
+// invents a finding for a rule the team turned off — or hallucinates
+// a rule name — it never reaches the PR.
+func FilterFindings(findings []Finding, cfg Config) []Finding {
+	out := make([]Finding, 0, len(findings))
+	for _, f := range findings {
+		if !cfg.IsEnabled(f.Rule) {
+			continue
+		}
+		f.Blocking = cfg.IsBlocking(f.Rule)
+		out = append(out, f)
+	}
+	return out
+}

--- a/internal/standards/config_test.go
+++ b/internal/standards/config_test.go
@@ -1,0 +1,190 @@
+package standards
+
+import (
+	"testing"
+)
+
+// TestRuleStateValues pins the three valid states a configurable
+// standards rule can be in: off, on, block. "off" disables the rule
+// (judge does not flag, post-processor drops findings); "on" emits
+// inline non-blocking findings — the easy-fix mode; "block" promotes
+// the rule to blocking inline so the verdict gate fails when violated.
+func TestRuleStateValues(t *testing.T) {
+	cases := []struct {
+		got  RuleState
+		want string
+	}{
+		{RuleStateOff, "off"},
+		{RuleStateOn, "on"},
+		{RuleStateBlock, "block"},
+	}
+	for _, c := range cases {
+		if string(c.got) != c.want {
+			t.Errorf("RuleState %q: got %q", c.want, string(c.got))
+		}
+	}
+}
+
+// TestParseRuleState accepts the three canonical strings (case-
+// insensitive) and rejects anything else so a typo in vairdict.yaml
+// surfaces at config-load time rather than silently disabling a rule.
+func TestParseRuleState(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    RuleState
+		wantErr bool
+	}{
+		{"off", RuleStateOff, false},
+		{"on", RuleStateOn, false},
+		{"block", RuleStateBlock, false},
+		{"OFF", RuleStateOff, false},
+		{"On", RuleStateOn, false},
+		{"BLOCK", RuleStateBlock, false},
+		{"", "", true},
+		{"yes", "", true},
+		{"true", "", true},
+	}
+	for _, c := range cases {
+		got, err := ParseRuleState(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ParseRuleState(%q): err = %v, wantErr = %v", c.in, err, c.wantErr)
+			continue
+		}
+		if !c.wantErr && got != c.want {
+			t.Errorf("ParseRuleState(%q): got %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestKnownRules pins the configurable Standards rule set. Adding a
+// rule means every existing config gets it automatically (default
+// state is "on") so the post-processor can start filtering against it
+// without breaking older deployments. Removing a rule is a breaking
+// change — the test guards against accidentally dropping one in a
+// refactor.
+func TestKnownRules(t *testing.T) {
+	want := map[string]bool{
+		"naming":                    true,
+		"indent":                    true,
+		"error_logging":             true,
+		"switch_for_multiple_cases": true,
+		"class_naming":              true,
+		"no_binaries":               true,
+		"no_dead_code":              true,
+		"no_todo_fixme":             true,
+		"no_duplication":            true,
+	}
+	got := make(map[string]bool, len(KnownRules))
+	for _, r := range KnownRules {
+		got[r] = true
+	}
+	for r := range want {
+		if !got[r] {
+			t.Errorf("KnownRules missing %q", r)
+		}
+	}
+	for r := range got {
+		if !want[r] {
+			t.Errorf("KnownRules has unexpected entry %q — security-floor rules (no_secrets, handle_errors) must NOT be configurable here", r)
+		}
+	}
+}
+
+// TestDefaultConfig_AllOn — every known rule defaults to "on" so a
+// freshly-bootstrapped repo gets the full Standards lint without any
+// vairdict.yaml edits, but nothing is promoted to blocking until a team
+// explicitly opts in.
+func TestDefaultConfig_AllOn(t *testing.T) {
+	cfg := Default()
+	for _, r := range KnownRules {
+		state, ok := cfg.Rule(r)
+		if !ok {
+			t.Errorf("Default config missing rule %q", r)
+			continue
+		}
+		if state != RuleStateOn {
+			t.Errorf("Default config rule %q: got %q, want %q", r, state, RuleStateOn)
+		}
+	}
+}
+
+// TestConfig_IsEnabled — "on" and "block" both count as enabled (the
+// rule is in play); "off" and unknown rules are disabled. Used by the
+// post-processor to decide whether to keep or drop a finding the judge
+// emitted.
+func TestConfig_IsEnabled(t *testing.T) {
+	cfg := Config{Rules: map[string]RuleState{
+		"naming":        RuleStateOn,
+		"indent":        RuleStateOff,
+		"error_logging": RuleStateBlock,
+	}}
+	cases := []struct {
+		rule string
+		want bool
+	}{
+		{"naming", true},
+		{"indent", false},
+		{"error_logging", true},
+		{"unknown_rule", false},
+	}
+	for _, c := range cases {
+		if got := cfg.IsEnabled(c.rule); got != c.want {
+			t.Errorf("IsEnabled(%q) = %v, want %v", c.rule, got, c.want)
+		}
+	}
+}
+
+// TestConfig_IsBlocking — only "block" promotes a rule to blocking.
+// "on" findings are inline-but-not-blocking; "off" and unknown rules
+// are not blocking (and not even shown — the post-processor drops them).
+func TestConfig_IsBlocking(t *testing.T) {
+	cfg := Config{Rules: map[string]RuleState{
+		"naming":        RuleStateOn,
+		"indent":        RuleStateOff,
+		"error_logging": RuleStateBlock,
+	}}
+	cases := []struct {
+		rule string
+		want bool
+	}{
+		{"naming", false},
+		{"indent", false},
+		{"error_logging", true},
+		{"unknown_rule", false},
+	}
+	for _, c := range cases {
+		if got := cfg.IsBlocking(c.rule); got != c.want {
+			t.Errorf("IsBlocking(%q) = %v, want %v", c.rule, got, c.want)
+		}
+	}
+}
+
+// TestFilterFindings drops findings whose rule tag is disabled or
+// unknown — the built-in false-positive guard. A judge that emits a
+// "naming" finding when naming is "off" gets that finding silently
+// dropped before it reaches the PR comment renderer. Findings for
+// "block"-promoted rules carry Blocking=true so the verdict gate sees
+// them.
+func TestFilterFindings(t *testing.T) {
+	cfg := Config{Rules: map[string]RuleState{
+		"naming":        RuleStateOn,
+		"indent":        RuleStateOff,
+		"error_logging": RuleStateBlock,
+	}}
+	in := []Finding{
+		{Rule: "naming", Description: "var x"},
+		{Rule: "indent", Description: "tab vs space"},  // dropped — rule off
+		{Rule: "error_logging", Description: "no err"}, // kept, blocking
+		{Rule: "bogus", Description: "unknown rule"},   // dropped — unknown
+	}
+	got := FilterFindings(in, cfg)
+	if len(got) != 2 {
+		t.Fatalf("FilterFindings: got %d findings, want 2: %+v", len(got), got)
+	}
+	if got[0].Rule != "naming" || got[0].Blocking {
+		t.Errorf("first finding should be naming non-blocking, got %+v", got[0])
+	}
+	if got[1].Rule != "error_logging" || !got[1].Blocking {
+		t.Errorf("second finding should be error_logging blocking, got %+v", got[1])
+	}
+}

--- a/internal/state/checklist.go
+++ b/internal/state/checklist.go
@@ -1,0 +1,82 @@
+package state
+
+// VerdictState is the binary outcome of the new pass gate. The score
+// number that judges historically returned is now decorative — the
+// gate is mechanical, derived from the checklist + blocking gaps.
+type VerdictState string
+
+const (
+	// VerdictPass means every Required checklist item is Passed and
+	// no Blocking gap was emitted. The PR is good to merge as far as
+	// the judge is concerned.
+	VerdictPass VerdictState = "PASS"
+	// VerdictNeedsWork means at least one Required item is unticked,
+	// or at least one Blocking gap was emitted. The PR author must
+	// either resolve the gap or address the unticked item before the
+	// next review round.
+	VerdictNeedsWork VerdictState = "NEEDS_WORK"
+)
+
+// ChecklistItem is one observable check the judge ticks (Passed=true)
+// or leaves unticked (Passed=false). The Name is a stable key so the
+// gate and the renderer can refer to specific checks; the Description
+// is the human-readable label that ends up in the verdict comment.
+//
+// Required items participate in the pass gate: an unticked Required
+// item flips the verdict to NEEDS_WORK. Optional items show up in the
+// checklist for transparency but don't fail the verdict — useful for
+// "tests cover the change" style observations that aren't appropriate
+// gates for every change but are still worth recording.
+type ChecklistItem struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required"`
+	Passed      bool   `json:"passed"`
+}
+
+// ChecklistTally returns the (passed, total) counts across every
+// item in the list. Used by the verdict renderer to surface "8/10
+// checks passed" — descriptive, not a gate.
+func ChecklistTally(items []ChecklistItem) (passed, total int) {
+	for _, it := range items {
+		total++
+		if it.Passed {
+			passed++
+		}
+	}
+	return passed, total
+}
+
+// RequiredPassed reports whether every Required item in the checklist
+// is Passed. Optional items are ignored. Half of the new pass gate;
+// the other half is "zero blocking gaps" (see DeriveVerdictState).
+func RequiredPassed(items []ChecklistItem) bool {
+	for _, it := range items {
+		if it.Required && !it.Passed {
+			return false
+		}
+	}
+	return true
+}
+
+// DeriveVerdictState computes the new binary gate from the gap list
+// and the checklist. PASS requires both:
+//
+//   - zero Blocking gaps (any tier promoted to blocking — Critical,
+//     High, or a Standards finding whose rule is in the "block" state)
+//   - every Required checklist item Passed
+//
+// Anything else is NEEDS_WORK. The score number is no longer an
+// input to the gate; it's a decorative tally produced by
+// ChecklistTally for skim-readability in the PR comment.
+func DeriveVerdictState(gaps []Gap, checklist []ChecklistItem) VerdictState {
+	for _, g := range gaps {
+		if g.Blocking {
+			return VerdictNeedsWork
+		}
+	}
+	if !RequiredPassed(checklist) {
+		return VerdictNeedsWork
+	}
+	return VerdictPass
+}

--- a/internal/state/checklist_test.go
+++ b/internal/state/checklist_test.go
@@ -1,0 +1,162 @@
+package state
+
+import "testing"
+
+// TestChecklistItem_Required is the simplest contract on the new type:
+// each item carries a stable Name (the gate looks it up by name), an
+// optional Description (rendered in the verdict comment), a Passed
+// flag the judge ticks, and a Required flag the post-processor uses
+// to decide whether an unticked item fails the gate. Optional items
+// (e.g. nice-to-have observations) leave Required false so they show
+// in the checklist but never fail the verdict.
+func TestChecklistItem_Required(t *testing.T) {
+	got := ChecklistItem{
+		Name:        "tests_cover_change",
+		Description: "Tests added for the new behavior",
+		Required:    true,
+		Passed:      true,
+	}
+	if got.Name != "tests_cover_change" {
+		t.Errorf("Name = %q", got.Name)
+	}
+	if !got.Required || !got.Passed {
+		t.Errorf("flags wrong: %+v", got)
+	}
+}
+
+// TestChecklistTally counts passed vs total. Total counts every item
+// (required and optional) so the verdict comment can show "8/10
+// checks" honestly. The gate uses RequiredPassed (separately tested)
+// so an unticked optional item doesn't fail the verdict.
+func TestChecklistTally(t *testing.T) {
+	cases := []struct {
+		name              string
+		items             []ChecklistItem
+		wantPassed, total int
+	}{
+		{"empty", nil, 0, 0},
+		{"all_pass", []ChecklistItem{
+			{Name: "a", Required: true, Passed: true},
+			{Name: "b", Required: true, Passed: true},
+		}, 2, 2},
+		{"one_unticked", []ChecklistItem{
+			{Name: "a", Required: true, Passed: true},
+			{Name: "b", Required: true, Passed: false},
+		}, 1, 2},
+		{"optional_unticked_still_counts_in_total", []ChecklistItem{
+			{Name: "a", Required: true, Passed: true},
+			{Name: "b", Required: false, Passed: false},
+		}, 1, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			passed, total := ChecklistTally(c.items)
+			if passed != c.wantPassed || total != c.total {
+				t.Errorf("ChecklistTally = (%d, %d), want (%d, %d)",
+					passed, total, c.wantPassed, c.total)
+			}
+		})
+	}
+}
+
+// TestRequiredPassed reports whether every Required item in the
+// checklist is Passed. Optional items are ignored. This is one half
+// of the new pass gate (the other half: zero blocking gaps).
+func TestRequiredPassed(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []ChecklistItem
+		want  bool
+	}{
+		{"empty_passes", nil, true},
+		{"all_required_pass", []ChecklistItem{
+			{Name: "a", Required: true, Passed: true},
+			{Name: "b", Required: true, Passed: true},
+		}, true},
+		{"required_unticked_fails", []ChecklistItem{
+			{Name: "a", Required: true, Passed: true},
+			{Name: "b", Required: true, Passed: false},
+		}, false},
+		{"optional_unticked_still_passes", []ChecklistItem{
+			{Name: "a", Required: true, Passed: true},
+			{Name: "b", Required: false, Passed: false},
+		}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RequiredPassed(c.items); got != c.want {
+				t.Errorf("RequiredPassed = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestVerdictState constants — PASS and NEEDS_WORK are the only two
+// states the new gate emits. No "in-between" so the verdict doesn't
+// pretend a precision the judge can't honestly produce.
+func TestVerdictState_Values(t *testing.T) {
+	if string(VerdictPass) != "PASS" {
+		t.Errorf("VerdictPass = %q, want PASS", VerdictPass)
+	}
+	if string(VerdictNeedsWork) != "NEEDS_WORK" {
+		t.Errorf("VerdictNeedsWork = %q, want NEEDS_WORK", VerdictNeedsWork)
+	}
+}
+
+// TestDeriveVerdictState pins the new gate logic. PASS requires:
+//
+//   - zero gaps marked Blocking (any tier promoted to blocking — Critical,
+//     High, or a Standards finding for a "block"-state rule)
+//   - every Required checklist item Passed
+//
+// Anything else is NEEDS_WORK. The score is no longer a gate input.
+func TestDeriveVerdictState(t *testing.T) {
+	cases := []struct {
+		name      string
+		gaps      []Gap
+		checklist []ChecklistItem
+		want      VerdictState
+	}{
+		{
+			"empty_gaps_empty_checklist_passes",
+			nil, nil, VerdictPass,
+		},
+		{
+			"all_required_passed_no_blocking_gaps",
+			[]Gap{{Severity: SeverityLow}},
+			[]ChecklistItem{{Required: true, Passed: true}},
+			VerdictPass,
+		},
+		{
+			"blocking_gap_fails_even_with_full_checklist",
+			[]Gap{{Severity: SeverityCritical, Blocking: true}},
+			[]ChecklistItem{{Required: true, Passed: true}},
+			VerdictNeedsWork,
+		},
+		{
+			"unticked_required_item_fails_even_with_no_gaps",
+			nil,
+			[]ChecklistItem{{Required: true, Passed: false}},
+			VerdictNeedsWork,
+		},
+		{
+			"unticked_optional_does_not_fail",
+			nil,
+			[]ChecklistItem{{Required: false, Passed: false}},
+			VerdictPass,
+		},
+		{
+			"non_blocking_high_does_not_fail_alone",
+			[]Gap{{Severity: SeverityHigh, Blocking: false}},
+			nil,
+			VerdictPass,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DeriveVerdictState(c.gaps, c.checklist); got != c.want {
+				t.Errorf("DeriveVerdictState = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/state/severity_test.go
+++ b/internal/state/severity_test.go
@@ -109,6 +109,40 @@ func TestSeverityIsBlocking(t *testing.T) {
 	}
 }
 
+// TestSeverityInlineEligible pins which severities may surface as
+// inline comments on the PR diff. Critical and High block, so they
+// must be visible at the line they touch — both eligible. Medium
+// and Low don't block, so they're notes-only — keeping them out of
+// the inline surface stops Medium/Low findings from cluttering the
+// review with non-blocking nits the author can't apply with one
+// click. Standards findings are inline-eligible regardless of the
+// severity ladder; that decision lives in the standards package and
+// is not modeled on Severity.
+func TestSeverityInlineEligible(t *testing.T) {
+	cases := []struct {
+		s    Severity
+		want bool
+	}{
+		{SeverityCritical, true},
+		{SeverityHigh, true},
+		{SeverityMedium, false},
+		{SeverityLow, false},
+		// legacy
+		{"P0", true},
+		{"P1", true},
+		{"P2", false},
+		{"P3", false},
+		// unknown stays out of inline so the renderer never silently
+		// surfaces something the dispatch table doesn't know about
+		{"bogus", false},
+	}
+	for _, c := range cases {
+		if got := c.s.InlineEligible(); got != c.want {
+			t.Errorf("Severity(%q).InlineEligible() = %v, want %v", c.s, got, c.want)
+		}
+	}
+}
+
 // TestSeverityDisplay covers the user-facing rendering of a severity.
 // Stored values are lowercase ("critical"); rendered output uses Title
 // Case ("Critical") so PR comment tables and inline comments read as

--- a/internal/state/severity_test.go
+++ b/internal/state/severity_test.go
@@ -1,0 +1,171 @@
+package state
+
+import "testing"
+
+// TestSeverityCanonicalConstants pins the canonical severity ladder used
+// across the codebase from this point on: Critical / High / Medium / Low.
+// The string values are lowercase and stable — they are written to the DB,
+// surfaced in PR comments, and referenced from vairdict.yaml — so any future
+// change to them must be a deliberate, migration-aware refactor.
+func TestSeverityCanonicalConstants(t *testing.T) {
+	cases := []struct {
+		got  Severity
+		want string
+	}{
+		{SeverityCritical, "critical"},
+		{SeverityHigh, "high"},
+		{SeverityMedium, "medium"},
+		{SeverityLow, "low"},
+	}
+	for _, c := range cases {
+		if string(c.got) != c.want {
+			t.Errorf("severity constant %q: want %q, got %q", c.want, c.want, string(c.got))
+		}
+	}
+}
+
+// TestSeverityLegacyAliases verifies that the deprecated SeverityP0..P3
+// constants still exist (so existing code keeps compiling during the
+// migration) and resolve to the same string values as the new canonical
+// constants. They must be drop-in equal.
+func TestSeverityLegacyAliases(t *testing.T) {
+	pairs := []struct {
+		legacy, canonical Severity
+		name              string
+	}{
+		{SeverityP0, SeverityCritical, "P0->Critical"},
+		{SeverityP1, SeverityHigh, "P1->High"},
+		{SeverityP2, SeverityMedium, "P2->Medium"},
+		{SeverityP3, SeverityLow, "P3->Low"},
+	}
+	for _, p := range pairs {
+		if p.legacy != p.canonical {
+			t.Errorf("%s: legacy %q != canonical %q — deprecated aliases must equal their replacement", p.name, p.legacy, p.canonical)
+		}
+	}
+}
+
+// TestNormalizeSeverity covers the on-read shim that maps legacy "P0".."P3"
+// strings (and any case-variant of the canonical names) to the canonical
+// lowercase form. The DB store and the verdict-schema unmarshaller call
+// this so old payloads transparently flow into the new ladder.
+func TestNormalizeSeverity(t *testing.T) {
+	cases := []struct {
+		in   Severity
+		want Severity
+	}{
+		// legacy -> canonical
+		{"P0", SeverityCritical},
+		{"P1", SeverityHigh},
+		{"P2", SeverityMedium},
+		{"P3", SeverityLow},
+		// case variants of legacy
+		{"p0", SeverityCritical},
+		{"p3", SeverityLow},
+		// canonical passes through
+		{"critical", SeverityCritical},
+		{"high", SeverityHigh},
+		{"medium", SeverityMedium},
+		{"low", SeverityLow},
+		// case variants of canonical
+		{"Critical", SeverityCritical},
+		{"HIGH", SeverityHigh},
+		// unknown values pass through unchanged so callers can flag them
+		{"bogus", "bogus"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := NormalizeSeverity(c.in)
+		if got != c.want {
+			t.Errorf("NormalizeSeverity(%q): want %q, got %q", c.in, c.want, got)
+		}
+	}
+}
+
+// TestSeverityIsBlocking encodes the new gate semantics: Critical and High
+// block; Medium and Low do not. This replaces the implicit "P0/P1 are
+// blocking" rule scattered across judges with a single source of truth.
+func TestSeverityIsBlocking(t *testing.T) {
+	cases := []struct {
+		s    Severity
+		want bool
+	}{
+		{SeverityCritical, true},
+		{SeverityHigh, true},
+		{SeverityMedium, false},
+		{SeverityLow, false},
+		// legacy strings normalize to the same answer
+		{"P0", true},
+		{"P1", true},
+		{"P2", false},
+		{"P3", false},
+		// unknown severities are not blocking; the post-processor flags them
+		{"bogus", false},
+	}
+	for _, c := range cases {
+		if got := c.s.IsBlocking(); got != c.want {
+			t.Errorf("Severity(%q).IsBlocking() = %v, want %v", c.s, got, c.want)
+		}
+	}
+}
+
+// TestSeverityDisplay covers the user-facing rendering of a severity.
+// Stored values are lowercase ("critical"); rendered output uses Title
+// Case ("Critical") so PR comment tables and inline comments read as
+// English words rather than enum identifiers. Legacy "P0".."P3" inputs
+// render under their canonical names so old DB rows display correctly.
+func TestSeverityDisplay(t *testing.T) {
+	cases := []struct {
+		s    Severity
+		want string
+	}{
+		{SeverityCritical, "Critical"},
+		{SeverityHigh, "High"},
+		{SeverityMedium, "Medium"},
+		{SeverityLow, "Low"},
+		// legacy
+		{"P0", "Critical"},
+		{"P1", "High"},
+		{"P2", "Medium"},
+		{"P3", "Low"},
+		// case variants
+		{"critical", "Critical"},
+		{"HIGH", "High"},
+		// unknown severities pass through unchanged so renderers can
+		// surface whatever the judge produced rather than silently
+		// substituting a real severity word.
+		{"weird", "weird"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := c.s.Display(); got != c.want {
+			t.Errorf("Severity(%q).Display() = %q, want %q", c.s, got, c.want)
+		}
+	}
+}
+
+// TestSeverityRank pins the ordering used when sorting gaps for display.
+// Critical first, then High, Medium, Low. The notes section uses this to
+// surface Medium above Low; the inline section uses it implicitly because
+// only Critical and High are eligible.
+func TestSeverityRank(t *testing.T) {
+	cases := []struct {
+		s    Severity
+		rank int
+	}{
+		{SeverityCritical, 0},
+		{SeverityHigh, 1},
+		{SeverityMedium, 2},
+		{SeverityLow, 3},
+		// legacy normalizes
+		{"P0", 0},
+		{"P3", 3},
+		// unknown severities sort last
+		{"bogus", 99},
+	}
+	for _, c := range cases {
+		if got := c.s.Rank(); got != c.rank {
+			t.Errorf("Severity(%q).Rank() = %d, want %d", c.s, got, c.rank)
+		}
+	}
+}

--- a/internal/state/severity_test.go
+++ b/internal/state/severity_test.go
@@ -195,7 +195,7 @@ func TestSeverityRank(t *testing.T) {
 		{"P0", 0},
 		{"P3", 3},
 		// unknown severities sort last
-		{"bogus", 99},
+		{"bogus", UnknownSeverityRank},
 	}
 	for _, c := range cases {
 		if got := c.s.Rank(); got != c.rank {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -83,14 +83,100 @@ var phaseForState = map[TaskState]Phase{
 }
 
 // Severity represents the severity level of a gap or assumption.
+//
+// Canonical values are lowercase words: "critical" / "high" / "medium" /
+// "low". Legacy "P0".."P3" payloads (older DB rows, older judge prompts)
+// flow through NormalizeSeverity at the seams (DB read, schema unmarshal)
+// so internal code only ever compares against the canonical constants.
+//
+// The deprecated SeverityP0..P3 constants below remain as aliases pointing
+// at the canonical strings so existing call sites keep compiling during
+// the migration; new code should reference SeverityCritical/High/Medium/Low.
 type Severity string
 
 const (
-	SeverityP0 Severity = "P0"
-	SeverityP1 Severity = "P1"
-	SeverityP2 Severity = "P2"
-	SeverityP3 Severity = "P3"
+	SeverityCritical Severity = "critical"
+	SeverityHigh     Severity = "high"
+	SeverityMedium   Severity = "medium"
+	SeverityLow      Severity = "low"
+
+	// Deprecated: use SeverityCritical. Alias kept so existing call sites
+	// compile; resolves to the same canonical string.
+	SeverityP0 = SeverityCritical
+	// Deprecated: use SeverityHigh.
+	SeverityP1 = SeverityHigh
+	// Deprecated: use SeverityMedium.
+	SeverityP2 = SeverityMedium
+	// Deprecated: use SeverityLow.
+	SeverityP3 = SeverityLow
 )
+
+// NormalizeSeverity maps any accepted spelling — legacy "P0".."P3", any
+// case variant of the canonical names — to the canonical lowercase form.
+// Unknown values pass through unchanged so callers can detect and flag
+// them rather than silently coercing to a real severity.
+func NormalizeSeverity(s Severity) Severity {
+	switch strings.ToLower(string(s)) {
+	case "p0", "critical":
+		return SeverityCritical
+	case "p1", "high":
+		return SeverityHigh
+	case "p2", "medium":
+		return SeverityMedium
+	case "p3", "low":
+		return SeverityLow
+	}
+	return s
+}
+
+// IsBlocking reports whether a severity blocks the verdict gate. Critical
+// and High block; Medium and Low do not. Standards findings have their
+// own blocking semantics (config-driven) and are not modelled as a
+// Severity — see the standards package.
+func (s Severity) IsBlocking() bool {
+	switch NormalizeSeverity(s) {
+	case SeverityCritical, SeverityHigh:
+		return true
+	}
+	return false
+}
+
+// Display returns the user-facing string for a severity (Title Case,
+// English word). Used by the PR comment renderer and the CLI verdict
+// printer so a stored "critical" surfaces as "Critical" in output.
+// Unknown values pass through unchanged so the renderer can faithfully
+// surface whatever the judge produced rather than silently substituting
+// a real severity word.
+func (s Severity) Display() string {
+	switch NormalizeSeverity(s) {
+	case SeverityCritical:
+		return "Critical"
+	case SeverityHigh:
+		return "High"
+	case SeverityMedium:
+		return "Medium"
+	case SeverityLow:
+		return "Low"
+	}
+	return string(s)
+}
+
+// Rank returns the display-order rank of a severity: 0 (Critical) is
+// shown first, 3 (Low) last. Unknown severities sort to the end (99).
+// Used by the verdict renderer to order the notes section.
+func (s Severity) Rank() int {
+	switch NormalizeSeverity(s) {
+	case SeverityCritical:
+		return 0
+	case SeverityHigh:
+		return 1
+	case SeverityMedium:
+		return 2
+	case SeverityLow:
+		return 3
+	}
+	return 99
+}
 
 // Assumption records a decision made under uncertainty during a phase.
 type Assumption struct {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -178,8 +178,15 @@ func (s Severity) Display() string {
 	return string(s)
 }
 
+// UnknownSeverityRank is the sort rank used for severities outside
+// the canonical Critical/High/Medium/Low ladder. Sorts last so any
+// surprise value the judge produces ends up at the bottom of the
+// notes section rather than mixed in with real findings.
+const UnknownSeverityRank = 99
+
 // Rank returns the display-order rank of a severity: 0 (Critical) is
-// shown first, 3 (Low) last. Unknown severities sort to the end (99).
+// shown first, 3 (Low) last. Unknown severities sort to the end
+// (UnknownSeverityRank).
 // Used by the verdict renderer to order the notes section.
 func (s Severity) Rank() int {
 	switch NormalizeSeverity(s) {
@@ -192,7 +199,7 @@ func (s Severity) Rank() int {
 	case SeverityLow:
 		return 3
 	}
-	return 99
+	return UnknownSeverityRank
 }
 
 // Assumption records a decision made under uncertainty during a phase.

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -141,6 +141,23 @@ func (s Severity) IsBlocking() bool {
 	return false
 }
 
+// InlineEligible reports whether a gap of this severity is eligible
+// to surface as an inline review comment on the PR diff. Critical and
+// High block and must be visible at the line they touch, so they're
+// inline. Medium and Low don't block and would only clutter the
+// inline surface with non-blocking nits — they go to the summary
+// "Notes" section instead. Unknown severities default to false so the
+// renderer never silently surfaces something the dispatch table
+// doesn't know about. Standards findings have their own inline
+// rule — always eligible — and are not modeled on Severity.
+func (s Severity) InlineEligible() bool {
+	switch NormalizeSeverity(s) {
+	case SeverityCritical, SeverityHigh:
+		return true
+	}
+	return false
+}
+
 // Display returns the user-facing string for a severity (Title Case,
 // English word). Used by the PR comment renderer and the CLI verdict
 // printer so a stored "critical" surfaces as "Critical" in output.

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -112,7 +112,7 @@ func TestJSONRendererEmitsValidJSON(t *testing.T) {
 	r := New(Options{Out: &buf, Mode: ModeJSON})
 	r.RunStart("abc", "intent", "/tmp/x.log")
 	r.PhaseLoop(state.PhaseCode, 2, 3, 75.5, false)
-	r.PhaseDone(state.PhaseCode, OutcomeFail, 75.5, 2, "", []state.Gap{{Severity: state.SeverityP1, Description: "oops"}})
+	r.PhaseDone(state.PhaseCode, OutcomeFail, 75.5, 2, "", []state.Gap{{Severity: state.SeverityHigh, Description: "oops"}})
 	r.Error(errors.New("boom"))
 
 	dec := json.NewDecoder(&buf)


### PR DESCRIPTION
Renames the user-facing severity ladder from P0..P3 to Critical/High/
Medium/Low without breaking existing call sites. SeverityCritical/High/
Medium/Low are the new canonical constants; their string values are
lowercase ("critical", "high", "medium", "low") so DB rows and JSON
payloads carry the new wording. SeverityP0..P3 remain as deprecated
aliases pointing at the canonical values, so vairdict.yaml configs and
existing code that still references them keep compiling unchanged.

NormalizeSeverity is the on-read shim — it accepts legacy "P0".."P3"
strings, any case variant of the new names, and unknown values pass
through unchanged so the post-processor can flag them rather than
silently coercing. ApplyBlocking now normalises both its map keys and
each gap's stored severity, so a config still spelling BlockOn as
["P0","P1"] continues to gate the new "critical"/"high" gaps with no
user-visible change.

Severity gains three accessors used by every renderer:
- IsBlocking — single source of truth for the gate (Critical and High
  block; Medium and Low do not).
- Display — Title-Case rendering for PR comments, escalation output,
  feedback summaries, and hard constraints. Stored "critical" surfaces
  as "Critical" so reviewers read English words rather than enum tokens.
- Rank — display ordering (Critical first, Low last) for the notes
  section in upcoming dispatch work.

PR comment, escalation, plan-phase feedback, and rewind-context
constraint renderers all switch to Severity.Display(). Existing tests
that hardcoded "[P0]"/"[P3]" substrings move to "[Critical]"/"[Low]";
the verdictschema ApplyBlocking test that passed a literal "P0" map
key now relies on normalisation to keep working.

Severity tests (internal/state/severity_test.go) pin canonical values,
legacy alias equality, normalisation matrix, blocking semantics, rank
ordering, and Display rendering — including the round-trip from legacy
"P0".."P3" inputs so old DB rows surface under the new wording.

First commit in the rethink-of-severity-and-scoring sequence; later
commits add Standards as a separate category, swap the score-as-gate
for a checklist + PASS/NEEDS_WORK verdict, fix the duplicate-comment
cascade in PostVerdictWithDiff, and tighten judge prompts with a
before-flagging rubric and cross-push awareness.