### PR TITLE
feat(quality): thread prior gaps into judge so cross-push framing fires

### DIFF
--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -90,9 +90,13 @@ type reviewGH interface {
 
 // reviewJudge is the narrow judge surface; *quality.QualityJudge satisfies
 // it. Plan is always empty for review mode (per #48 acceptance criteria);
-// the third argument is the unified diff fetched from the PR.
+// the third argument is the unified diff fetched from the PR. The fourth
+// argument is the previous review's gap list, used to prepend the cross-
+// push framing block; `vairdict review` is one-shot so it always passes
+// nil — cross-push memory across CLI invocations would need a separate
+// state store and is out of scope for the subcommand.
 type reviewJudge interface {
-	Judge(ctx context.Context, intent string, plan string, diff string) (*state.Verdict, error)
+	Judge(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap) (*state.Verdict, error)
 }
 
 // runReview is the production entry point: it loads the config, builds
@@ -161,8 +165,9 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 	}
 
 	// Review mode has no plan — pass empty. The diff is what the judge
-	// actually evaluates.
-	verdict, err := deps.judge.Judge(ctx, intent, "", diff)
+	// actually evaluates. priorGaps is nil because `vairdict review` is
+	// a one-shot CLI invocation with no persisted prior verdict.
+	verdict, err := deps.judge.Judge(ctx, intent, "", diff, nil)
 	if err != nil {
 		return fmt.Errorf("running quality judge: %w", err)
 	}

--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -66,7 +66,7 @@ type fakeReviewJudge struct {
 	diff    string
 }
 
-func (f *fakeReviewJudge) Judge(_ context.Context, intent, plan, diff string) (*state.Verdict, error) {
+func (f *fakeReviewJudge) Judge(_ context.Context, intent, plan, diff string, _ []state.Gap) (*state.Verdict, error) {
 	f.intent = intent
 	f.plan = plan
 	f.diff = diff

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -633,9 +633,17 @@ func RenderCrossPushFraming(priorGaps []state.Gap) string {
 // (the quality phase orchestrator and `vairdict review`) compute it via
 // git before invoking the judge. An empty diff is allowed but will
 // produce a low score because the LLM has nothing concrete to evaluate.
-func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, diff string) (*state.Verdict, error) {
+//
+// `priorGaps` is the gap list from the previous review round (the
+// previous phase loop, or the previous push on the same PR). When
+// non-empty, the judge prepends the cross-push framing block to the
+// user prompt so the model verifies each prior gap is still applicable
+// instead of inventing fresh findings for code that pre-dated the
+// prior review. nil/empty disables the framing — used for first-round
+// reviews and one-shot calls (e.g. `vairdict review`).
+func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap) (*state.Verdict, error) {
 	// Step 1: AI intent verification.
-	verdict, err := j.evaluateIntent(ctx, intent, plan, diff)
+	verdict, err := j.evaluateIntent(ctx, intent, plan, diff, priorGaps)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating intent: %w", err)
 	}
@@ -676,7 +684,7 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 }
 
 // evaluateIntent uses the Claude API to assess whether the diff matches the intent.
-func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan string, diff string) (*state.Verdict, error) {
+func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap) (*state.Verdict, error) {
 	diffSection := diff
 	if strings.TrimSpace(diffSection) == "" {
 		diffSection = "(no diff provided — judge cannot evaluate code changes)"
@@ -689,9 +697,15 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 		facts = fmt.Sprintf("\n\n## Facts (from code judge)\n%s", strings.TrimSpace(j.codeFacts))
 	}
 
+	// Cross-push framing comes BEFORE the intent/plan/diff so the model
+	// reads the "verify prior gaps, do not invent old findings"
+	// instructions while it's still building its mental model of the
+	// review, not after it has already started forming opinions. Empty
+	// for first-round reviews (priorGaps==nil).
+	framing := RenderCrossPushFraming(priorGaps)
 	prompt := fmt.Sprintf(
-		"## Original Intent\n%s\n\n## Approved Plan\n%s%s\n\n## Diff (unified format)\n```diff\n%s\n```",
-		intent, plan, facts, diffSection,
+		"%s## Original Intent\n%s\n\n## Approved Plan\n%s%s\n\n## Diff (unified format)\n```diff\n%s\n```",
+		framing, intent, plan, facts, diffSection,
 	)
 
 	var verdict state.Verdict

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -44,7 +44,7 @@ func TestQualityJudge_BaselineMarkerForcesBlocking(t *testing.T) {
 	}
 	judge := New(fake, nil, testConfig())
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestQualityJudge_VerdictStampedWithModel(t *testing.T) {
 	}
 	judge := New(fake, nil, testConfig())
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "diff --git a/x.go b/x.go\n+func H() {}")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "diff --git a/x.go b/x.go\n+func H() {}", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestJudge_Pass_NoGapsScoresFull(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes", "diff --git a/x.go b/x.go\n+func H() {}")
+	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes", "diff --git a/x.go b/x.go\n+func H() {}", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestJudge_IntentMismatch_P0Blocks(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "build auth system", "1. Implement auth", "diff --git a/x.go b/x.go\n+func crud() {}")
+	verdict, err := judge.Judge(context.Background(), "build auth system", "1. Implement auth", "diff --git a/x.go b/x.go\n+func crud() {}", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestJudge_E2EPass(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestJudge_E2EFail_AddsBlockingGap(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestJudge_E2ENotRequired(t *testing.T) {
 	// E2ERequired is false by default.
 
 	judge := New(fake, nil, cfg)
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestJudge_E2ERequiredNoCommand(t *testing.T) {
 	// Commands.E2E is empty.
 
 	judge := New(fake, nil, cfg)
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestJudge_AccumulatedP2sDragBelowThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestJudge_PassAtExactThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestJudge_ClientError(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err == nil {
 		t.Fatal("expected error when client fails")
 	}
@@ -374,7 +374,7 @@ func TestJudge_MixedGapsWithE2E(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -416,7 +416,7 @@ func TestJudge_ScoreFloorAtZero(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -436,7 +436,7 @@ func TestJudge_PromptContainsDiff(t *testing.T) {
 
 	judge := New(fake, nil, testConfig())
 	const diff = "diff --git a/foo.go b/foo.go\n+++ b/foo.go\n+func Foo() {}"
-	_, err := judge.Judge(context.Background(), "intent", "plan", diff)
+	_, err := judge.Judge(context.Background(), "intent", "plan", diff, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestJudge_EmptyDiffPlaceholder(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	_, err := judge.Judge(context.Background(), "intent", "plan", "")
+	_, err := judge.Judge(context.Background(), "intent", "plan", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -486,7 +486,7 @@ func TestJudge_SummaryRoundTrip(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Phases.Quality.E2ERequired = false
 	judge := New(fake, &FakeRunner{}, cfg)
-	verdict, err := judge.Judge(context.Background(), "build it", "the plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "build it", "the plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -694,7 +694,7 @@ func TestJudge_GapWithFileAndLine(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -719,7 +719,7 @@ func TestJudge_CodeFactsInjectedIntoPrompt(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig()).WithCodeFacts("Score: 100%\nAll checks passed (lint, test, build)")
-	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -785,7 +785,7 @@ func TestJudge_BlockingGapFailsEvenWithHighScore(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -810,7 +810,7 @@ func TestJudge_NonBlockingGapsAllowPass(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -907,7 +907,7 @@ func TestJudge_ReturnTo_ClearedOnPass(t *testing.T) {
 		},
 	}
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -939,7 +939,7 @@ func TestJudge_ReturnTo_Propagated(t *testing.T) {
 				},
 			}
 			judge := New(fake, nil, testConfig())
-			verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+			verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -966,7 +966,7 @@ func TestJudge_ReturnTo_DefaultsToCodeOnBlockingFailure(t *testing.T) {
 		},
 	}
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -993,7 +993,7 @@ func TestJudge_ReturnTo_EmptyForNonBlockingFailure(t *testing.T) {
 		},
 	}
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1019,7 +1019,7 @@ func TestJudge_ReturnTo_UnknownValueCollapsesToCode(t *testing.T) {
 		},
 	}
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1051,7 +1051,7 @@ func TestJudge_UsesCompleteWithTools(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff")
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1153,5 +1153,56 @@ func TestRenderCrossPushFraming_IncludesPriorGapsAndInstructions(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("RenderCrossPushFraming missing %q\n--- got ---\n%s", want, got)
 		}
+	}
+}
+
+// TestJudge_PrependsCrossPushFramingWhenPriorGapsPresent encodes the
+// orchestrator wiring: when the caller passes a non-empty priorGaps
+// slice, the judge prepends the cross-push framing block to the user
+// prompt so the model sees both the framing AND the diff in the same
+// turn. Without this, the helper added in commit 5 would never reach
+// the model — the prompt would still look identical to a first-review
+// prompt and the nagging-comment failure mode would persist.
+func TestJudge_PrependsCrossPushFramingWhenPriorGapsPresent(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{Gaps: []state.Gap{}}}
+	judge := New(fake, nil, testConfig())
+
+	prior := []state.Gap{
+		{Severity: state.SeverityCritical, Description: "auth missing on /admin"},
+	}
+	if _, err := judge.Judge(context.Background(), "intent", "plan", "diff", prior); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.Calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
+	}
+	prompt := fake.Calls[0].Prompt
+	if !strings.Contains(prompt, "Cross-push awareness") {
+		t.Errorf("prompt missing cross-push framing header\n--- prompt ---\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "auth missing on /admin") {
+		t.Errorf("prompt missing the prior gap description\n--- prompt ---\n%s", prompt)
+	}
+	// The original sections still come through after the framing.
+	if !strings.Contains(prompt, "## Original Intent") {
+		t.Error("prompt missing original intent section after framing")
+	}
+}
+
+// TestJudge_OmitsCrossPushFramingOnFirstReview — first review of a PR
+// (no prior gaps) must NOT include the framing, otherwise an empty
+// "you reviewed this before" block would mislead the model.
+func TestJudge_OmitsCrossPushFramingOnFirstReview(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{Gaps: []state.Gap{}}}
+	judge := New(fake, nil, testConfig())
+
+	if _, err := judge.Judge(context.Background(), "intent", "plan", "diff", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.Calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
+	}
+	if strings.Contains(fake.Calls[0].Prompt, "Cross-push awareness") {
+		t.Error("first-review prompt should not contain cross-push framing")
 	}
 }

--- a/internal/phases/quality/phase.go
+++ b/internal/phases/quality/phase.go
@@ -39,8 +39,12 @@ type PhaseResult struct {
 // Judge is the interface for the quality judge. The real implementation lives
 // in internal/judges/quality. The third argument is the unified diff of the
 // code under review — the judge no longer reads the working directory itself.
+// The fourth argument is the gap list from the previous review round (the
+// previous in-phase loop, or empty on the first round); the judge prepends
+// the cross-push framing block when this is non-empty so it doesn't re-flag
+// concerns already raised.
 type Judge interface {
-	Judge(ctx context.Context, intent, plan, diff string) (*state.Verdict, error)
+	Judge(ctx context.Context, intent, plan, diff string, priorGaps []state.Gap) (*state.Verdict, error)
 }
 
 // QualityPhase orchestrates the quality phase: judge loop on already-coded work.
@@ -83,6 +87,10 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 
 	var lastFeedback string
 	var lastScore float64
+	// priorGaps carries the previous loop's gaps into the next judge
+	// call so the cross-push framing block lands on every retry. nil
+	// on the first iteration (no prior round), populated thereafter.
+	var priorGaps []state.Gap
 
 	for loop := 0; loop < p.cfg.MaxLoops; loop++ {
 		slog.Info("quality phase loop",
@@ -96,10 +104,14 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 		}
 
 		p.notify(loop+1, p.cfg.MaxLoops, "reviewing", 0, false, nil)
-		verdict, err := p.judge.Judge(ctx, task.Intent, plan, p.diff)
+		verdict, err := p.judge.Judge(ctx, task.Intent, plan, p.diff, priorGaps)
 		if err != nil {
 			return nil, fmt.Errorf("running quality judge: %w", err)
 		}
+		// Carry this round's gaps forward so the next loop's judge call
+		// sees them via the cross-push framing — closes the "judge keeps
+		// inventing new findings on the same diff" failure mode.
+		priorGaps = verdict.Gaps
 
 		p.notify(loop+1, p.cfg.MaxLoops, "done", verdict.Score, verdict.Pass, verdict.Gaps)
 

--- a/internal/phases/quality/phase_test.go
+++ b/internal/phases/quality/phase_test.go
@@ -10,14 +10,18 @@ import (
 	"github.com/vairdict/vairdict/internal/state"
 )
 
-// fakeJudge returns configurable verdicts in order.
+// fakeJudge returns configurable verdicts in order. priorGapsByCall
+// captures the priorGaps passed on each call so tests can assert that
+// loop N+1 receives loop N's gaps as cross-push context.
 type fakeJudge struct {
-	verdicts []*state.Verdict
-	err      error
-	calls    int
+	verdicts        []*state.Verdict
+	err             error
+	calls           int
+	priorGapsByCall [][]state.Gap
 }
 
-func (f *fakeJudge) Judge(_ context.Context, _, _, _ string) (*state.Verdict, error) {
+func (f *fakeJudge) Judge(_ context.Context, _, _, _ string, priorGaps []state.Gap) (*state.Verdict, error) {
+	f.priorGapsByCall = append(f.priorGapsByCall, priorGaps)
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -346,5 +350,46 @@ func TestBuildQualityFeedback(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("feedback missing %q\ngot:\n%s", want, out)
 		}
+	}
+}
+
+// TestQualityPhase_PriorGapsThreadAcrossLoops pins the orchestrator
+// wiring of cross-push framing within a single phase invocation: the
+// first judge call receives nil priorGaps (no prior round); each
+// subsequent loop receives the immediately preceding loop's gaps so
+// the judge has the cross-push framing material it needs to avoid
+// re-flagging concerns it already raised.
+func TestQualityPhase_PriorGapsThreadAcrossLoops(t *testing.T) {
+	gapsLoop1 := []state.Gap{
+		{Severity: state.SeverityCritical, Description: "missing auth", Blocking: true},
+	}
+	gapsLoop2 := []state.Gap{
+		{Severity: state.SeverityHigh, Description: "still missing auth", Blocking: true},
+	}
+	judge := &fakeJudge{verdicts: []*state.Verdict{
+		{Score: 50, Pass: false, Gaps: gapsLoop1},
+		{Score: 60, Pass: false, Gaps: gapsLoop2},
+		{Score: 100, Pass: true},
+	}}
+	phase := New(judge, defaultCfg(), "diff")
+	task := state.NewTask("t-prior", "intent")
+	task.State = state.StateQuality
+	task.LoopCount = map[state.Phase]int{}
+
+	if _, err := phase.Run(context.Background(), task, "plan"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(judge.priorGapsByCall) != 3 {
+		t.Fatalf("expected 3 judge calls, got %d", len(judge.priorGapsByCall))
+	}
+	if judge.priorGapsByCall[0] != nil {
+		t.Errorf("first call must receive nil priorGaps (no prior round), got %+v", judge.priorGapsByCall[0])
+	}
+	if len(judge.priorGapsByCall[1]) != 1 || judge.priorGapsByCall[1][0].Description != "missing auth" {
+		t.Errorf("second call must receive loop 1's gaps, got %+v", judge.priorGapsByCall[1])
+	}
+	if len(judge.priorGapsByCall[2]) != 1 || judge.priorGapsByCall[2][0].Description != "still missing auth" {
+		t.Errorf("third call must receive loop 2's gaps, got %+v", judge.priorGapsByCall[2])
 	}
 }


### PR DESCRIPTION
## Summary

Wires the `RenderCrossPushFraming` helper added in #143 into the quality judge call path. Without this commit the helper exists, returns the right text under unit test, but is never called — so the nagging-comment failure mode (judge "discovers" findings on push N that were already there on push N−1) keeps surfacing.

## Changes

- `QualityJudge.Judge` gains a `priorGaps []state.Gap` parameter; passes it to `evaluateIntent` which prepends `RenderCrossPushFraming(priorGaps)` to the user prompt before the intent / plan / diff sections so the framing is read while the model is still building its mental model of the review. Empty / nil priorGaps → no framing (first-round behaviour preserved).
- `QualityPhase` `Judge` interface signature mirrors the new parameter. The Run loop tracks priorGaps locally: nil on the first iteration, set to the previous loop's `verdict.Gaps` after each judge call. So a three-loop in-phase retry feeds loop 2 with loop 1's gaps and loop 3 with loop 2's gaps — the judge sees what it already raised and verifies-or-drops rather than starting fresh each time.
- `vairdict review` subcommand passes nil because it's a one-shot CLI invocation with no persisted prior verdict; cross-PR-push memory across CLI invocations would need a separate state store and is out of scope.

## Test plan

- [x] `TestJudge_PrependsCrossPushFramingWhenPriorGapsPresent` — judge call with non-empty priorGaps produces a prompt containing the framing header and the prior gap descriptions.
- [x] `TestJudge_OmitsCrossPushFramingOnFirstReview` — nil priorGaps produces a prompt with no framing header (no misleading "you reviewed this before" block on first reviews).
- [x] `TestQualityPhase_PriorGapsThreadAcrossLoops` — three-loop fake judge captures priorGaps per call; first call gets nil, second gets loop 1's gaps, third gets loop 2's gaps.
- [x] `go build ./...` and `go test ./...` green except the pre-existing sandbox-only failures (`internal/workspace`, `internal/conflicts`).
- [x] `golangci-lint run ./...` reports 0 issues.

## Out of scope (follow-up)

Cross-PR-push wiring (loading prior verdict gaps from `task.Attempts` across separate orchestrator invocations / pushes to the same PR) is left for a future commit. The cross-LOOP wiring here is the direct user-facing win because in-phase retries are the most common case where the judge re-flags concerns it already raised.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGnXoo85bATDYVudNvJjpz)_