### PR TITLE
fix(cmd): unbreak Windows cross-build by splitting Setsid into per-OS files

### DIFF
--- a/cmd/vairdict/background.go
+++ b/cmd/vairdict/background.go
@@ -1,76 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strconv"
-	"syscall"
 )
-
-// spawnBackground re-executes the current binary with the given args
-// in a detached session and returns the child's PID. The child's
-// stdout/stderr are redirected to the per-task log file at
-// ~/.vairdict/logs/<taskID>.log so the work proceeds identically to
-// a foreground run.
-//
-// The parent then writes a short "started in background" banner to
-// `banner` (os.Stdout for humans) and returns — the child keeps
-// running after the parent exits.
-//
-// Not supported on non-unix platforms: `setsid` is a unix concept.
-// Windows users can still run vairdict in the foreground.
-func spawnBackground(taskID string, passthroughArgs []string, banner io.Writer) error {
-	self, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("resolving own binary: %w", err)
-	}
-
-	logPath, err := logPathForTask(taskID)
-	if err != nil {
-		return fmt.Errorf("resolving log path: %w", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
-		return fmt.Errorf("creating log dir: %w", err)
-	}
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		return fmt.Errorf("opening log file for background run: %w", err)
-	}
-
-	cmd := exec.Command(self, passthroughArgs...)
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-	cmd.Stdin = nil
-	// Detach: new session so the child outlives the controlling terminal.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	// Inherit VAIRDICT_FOREGROUND=1 into the child so it bypasses the
-	// --background re-exec and runs the real work.
-	cmd.Env = append(os.Environ(), "VAIRDICT_FOREGROUND=1")
-
-	if err := cmd.Start(); err != nil {
-		_ = logFile.Close()
-		return fmt.Errorf("starting background process: %w", err)
-	}
-
-	// The parent keeps the file descriptor to the log just long enough
-	// to finish Start — the child has its own copy via fork. Close ours
-	// so the parent doesn't hold the file open unnecessarily.
-	_ = logFile.Close()
-
-	_, _ = fmt.Fprintf(banner, "task %s running in background (pid %d)\n", taskID, cmd.Process.Pid)
-	_, _ = fmt.Fprintf(banner, "  status: vairdict status %s\n", taskID)
-	_, _ = fmt.Fprintf(banner, "  logs:   vairdict logs %s -f\n", taskID)
-	_, _ = fmt.Fprintf(banner, "  resume: vairdict resume %s\n", taskID)
-
-	// Release the child so the parent can exit cleanly without waiting.
-	if err := cmd.Process.Release(); err != nil {
-		return fmt.Errorf("releasing background process: %w", err)
-	}
-	return nil
-}
 
 // shouldRunForeground reports whether the current invocation is either
 // the re-exec child of a --background spawn, or a user-invoked
@@ -111,4 +45,18 @@ func backgroundArgsForResume(taskID, envName string) []string {
 	}
 	args = append(args, taskID)
 	return args
+}
+
+// spawnBackground re-executes the current binary with the given args
+// in a detached session and returns the child's PID. The child's
+// stdout/stderr are redirected to the per-task log file at
+// ~/.vairdict/logs/<taskID>.log so the work proceeds identically to
+// a foreground run.
+//
+// The platform-specific bits (how to detach the child from the
+// controlling terminal / process group) live in background_unix.go and
+// background_windows.go. spawnBackground itself dispatches to
+// spawnBackgroundOS, which is defined per platform.
+func spawnBackground(taskID string, passthroughArgs []string, banner io.Writer) error {
+	return spawnBackgroundOS(taskID, passthroughArgs, banner)
 }

--- a/cmd/vairdict/background_unix.go
+++ b/cmd/vairdict/background_unix.go
@@ -1,0 +1,67 @@
+//go:build unix
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+// spawnBackgroundOS is the unix implementation: re-exec the binary in
+// a new session (Setsid) so the child outlives the controlling
+// terminal and the parent. Stdout/stderr go to the per-task log file
+// so the detached run produces the same telemetry as a foreground
+// run.
+func spawnBackgroundOS(taskID string, passthroughArgs []string, banner io.Writer) error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving own binary: %w", err)
+	}
+
+	logPath, err := logPathForTask(taskID)
+	if err != nil {
+		return fmt.Errorf("resolving log path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		return fmt.Errorf("creating log dir: %w", err)
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening log file for background run: %w", err)
+	}
+
+	cmd := exec.Command(self, passthroughArgs...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Stdin = nil
+	// Detach: new session so the child outlives the controlling terminal.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// Inherit VAIRDICT_FOREGROUND=1 into the child so it bypasses the
+	// --background re-exec and runs the real work.
+	cmd.Env = append(os.Environ(), "VAIRDICT_FOREGROUND=1")
+
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("starting background process: %w", err)
+	}
+
+	// The parent keeps the file descriptor to the log just long enough
+	// to finish Start — the child has its own copy via fork. Close ours
+	// so the parent doesn't hold the file open unnecessarily.
+	_ = logFile.Close()
+
+	_, _ = fmt.Fprintf(banner, "task %s running in background (pid %d)\n", taskID, cmd.Process.Pid)
+	_, _ = fmt.Fprintf(banner, "  status: vairdict status %s\n", taskID)
+	_, _ = fmt.Fprintf(banner, "  logs:   vairdict logs %s -f\n", taskID)
+	_, _ = fmt.Fprintf(banner, "  resume: vairdict resume %s\n", taskID)
+
+	// Release the child so the parent can exit cleanly without waiting.
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("releasing background process: %w", err)
+	}
+	return nil
+}

--- a/cmd/vairdict/background_windows.go
+++ b/cmd/vairdict/background_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"io"
+)
+
+// spawnBackgroundOS on Windows returns an explicit error: the unix
+// implementation relies on syscall.SysProcAttr.Setsid (a new
+// process-session primitive) to detach the child from the controlling
+// terminal. Windows uses different process-group / console-detach
+// primitives and the existing background flow has not been adapted to
+// them. Until that work happens, the --background flag is unsupported
+// on Windows and surfaces with a clear actionable message rather than
+// silently doing the wrong thing.
+//
+// Windows users can still run vairdict in the foreground; only
+// detached background spawning is unavailable.
+func spawnBackgroundOS(_ string, _ []string, _ io.Writer) error {
+	return errors.New("--background is not supported on Windows; run vairdict in the foreground instead")
+}


### PR DESCRIPTION
## What broke

The v0.0.7 release workflow ([run 25271919574](https://github.com/vairdict/vairdict/actions/runs/25271919574)) failed at the GoReleaser step:

```
unknown field Setsid in struct literal of type syscall.SysProcAttr
```

`cmd/vairdict/background.go:48` references `syscall.SysProcAttr.Setsid` unconditionally. `Setsid` is unix-only — it does not exist on the Windows build of the `syscall` package — so cross-compiling the `windows/amd64` target fails the GoReleaser run before any binaries land. The release exists on GitHub but with **no assets** (compare v0.0.6 which has 6 archives + `checksums.txt` uploaded by `github-actions[bot]`). This regression has been latent since #124 (v0.0.6 didn't include the affected file).

Local dev on linux/darwin never tripped over this because the windows target is only built at release time.

## Fix

Standard split-by-build-tag pattern:

- **`background.go`** — keeps the portable helpers (`shouldRunForeground`, `backgroundArgsForRun`, `backgroundArgsForResume`) + a thin `spawnBackground` wrapper that delegates to `spawnBackgroundOS`.
- **`background_unix.go`** (`//go:build unix`) — existing `Setsid`-based detach implementation byte-for-byte; only the function name changed from `spawnBackground` to `spawnBackgroundOS`.
- **`background_windows.go`** (`//go:build windows`) — Windows stub that returns `"--background is not supported on Windows; run vairdict in the foreground instead"`. Matches the original file's comment intent ("Windows users can still run vairdict in the foreground").

## Test plan

- [x] `go build ./...` (linux) — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — clean (was failing before this PR)
- [x] `go test ./...` — green except the two pre-existing sandbox-only failures (`internal/workspace`, `internal/conflicts`)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Tag a fresh `v0.0.8` after merge and confirm the Release workflow's GoReleaser step succeeds with the expected 6 archives + `checksums.txt` uploaded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGnXoo85bATDYVudNvJjpz)_