### PR TITLE
fix(judge/quality): correct intent extraction on docs/scoping PRs (#136)

### DIFF
--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -201,6 +201,93 @@ func TestRunReview_NoLinkedIssue_FallsBackToPRTitleBody(t *testing.T) {
 	}
 }
 
+// TestRunReview_Issue136_Fixtures covers the three scenarios called
+// out in the acceptance criteria for issue #136:
+//
+//	(a) Closes #N PR with matching diff → judge runs against the
+//	    linked issue's intent, verdict passes.
+//	(b) Closes #N PR with empty diff → judge runs against the linked
+//	    issue's intent and fails (correct behaviour).
+//	(c) PR with only bare #N references in the body and docs-only
+//	    diff → judge falls back to PR title+body; the linked issue
+//	    is NOT consulted, so its acceptance criteria do not bleed
+//	    into the verdict.
+//
+// Scenario (c) is the regression: PR #135 hit a P0 false-blocker
+// because a bare "#126" mention in its body was interpreted as a
+// closing keyword link.
+func TestRunReview_Issue136_Fixtures(t *testing.T) {
+	t.Parallel()
+	const codeIssueIntentMarker = "internal/agents/codex package required"
+	const docsBodyMarker = "No code changes — docs only."
+
+	cases := []struct {
+		name              string
+		body              string
+		title             string
+		diff              string
+		verdict           *state.Verdict
+		wantIntentHas     string
+		wantIntentMissing string
+		wantErr           bool
+	}{
+		{
+			name:          "(a) Closes #N with matching diff — passes",
+			body:          "Closes #48",
+			title:         "feat: add review subcommand",
+			diff:          "diff --git a/cmd/review.go b/cmd/review.go\n+++ b/cmd/review.go\n+func Review() {}\n",
+			verdict:       passingVerdict(),
+			wantIntentHas: codeIssueIntentMarker,
+		},
+		{
+			name:          "(b) Closes #N with empty diff — fails",
+			body:          "Closes #48",
+			title:         "feat: add review subcommand",
+			diff:          "",
+			verdict:       failingVerdict(),
+			wantIntentHas: codeIssueIntentMarker,
+			wantErr:       true,
+		},
+		{
+			name:              "(c) bare #N references on docs-only PR — no false blocker",
+			body:              docsBodyMarker + "\n\nUnblocks #126 by recording that #128 has landed.",
+			title:             "docs: update PROGRESS.md and ROADMAP.md",
+			diff:              "diff --git a/plans/PROGRESS.md b/plans/PROGRESS.md\n+++ b/plans/PROGRESS.md\n+ - #128 done\n",
+			verdict:           passingVerdict(),
+			wantIntentHas:     docsBodyMarker,
+			wantIntentMissing: codeIssueIntentMarker,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gh := &fakeReviewGH{
+				pr: &github.PRDetails{Number: 999, Title: tc.title, Body: tc.body},
+				// Linked-issue body is the would-be wrong rubric — if
+				// the regex incorrectly matches a bare #N, this body
+				// would be threaded into the judge's intent and trigger
+				// the PR #135 failure mode. The test checks it stays
+				// out for scenario (c).
+				issue: &github.IssueDetails{Number: 126, Title: "agents/codex backend", Body: codeIssueIntentMarker},
+				diff:  tc.diff,
+			}
+			judge := &fakeReviewJudge{verdict: tc.verdict}
+
+			err := runReviewWith(context.Background(), 999, baseDeps(gh, judge))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantIntentHas != "" && !strings.Contains(judge.intent, tc.wantIntentHas) {
+				t.Errorf("intent missing %q.\nintent:\n%s", tc.wantIntentHas, judge.intent)
+			}
+			if tc.wantIntentMissing != "" && strings.Contains(judge.intent, tc.wantIntentMissing) {
+				t.Errorf("intent must not contain %q (linked-issue body bled in).\nintent:\n%s",
+					tc.wantIntentMissing, judge.intent)
+			}
+		})
+	}
+}
+
 func TestRunReview_JudgeError_Propagates(t *testing.T) {
 	t.Parallel()
 	gh := &fakeReviewGH{

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -289,9 +289,13 @@ func (c *Client) FetchPRDiff(ctx context.Context, number int) (string, error) {
 }
 
 // linkedIssueRe matches GitHub's PR-closes-issue keywords. Case-insensitive,
-// matches `Closes #12`, `fixes #34`, `Resolves: #56`, etc. Captures the
-// issue number into group 1.
-var linkedIssueRe = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[^\n#]*#(\d+)`)
+// matches `Closes #12`, `fixes #34`, `Resolves: #56`, etc. The keyword and
+// the `#N` reference must be adjacent (optionally separated by `:` and
+// whitespace) — GitHub's own keyword spec requires this, and a looser
+// pattern produces false positives on prose like "this fixes a typo while
+// preparing for #126" (issue #136). Captures the issue number into
+// group 1.
+var linkedIssueRe = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+#(\d+)`)
 
 // ParseLinkedIssue scans a PR body for the first GitHub closing-keyword
 // reference (Closes/Fixes/Resolves) and returns the linked issue number,

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -934,7 +934,17 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int, i
 	// Summary line. The model field is appended when the judge stamped
 	// it (every LLM-backed judge does); deterministic judges that don't
 	// call an LLM leave it empty and the field is omitted from the line.
-	fmt.Fprintf(&b, "**Score:** %.0f%% | **Phase:** %s | **Loop:** %d", verdict.Score, phase, loop)
+	//
+	// Score was historically rendered here but no longer drives the
+	// gate — DeriveVerdictState(gaps, checklist) is mechanical (zero
+	// blocking gaps + every Required AC item satisfied). The score
+	// field still lives on state.Verdict for debug logs, but rendering
+	// it next to a PASS / NEEDS_WORK header that may disagree with it
+	// (a 100% score on a NEEDS_WORK verdict from one unticked AC, or a
+	// 60% score on a PASS verdict) is more confusing than helpful. The
+	// header, the Criteria table, and the AC matrix already convey
+	// everything a reader needs.
+	fmt.Fprintf(&b, "**Phase:** %s | **Loop:** %d", phase, loop)
 	if verdict.Model != "" {
 		fmt.Fprintf(&b, " | **Model:** `%s`", verdict.Model)
 	}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -741,26 +741,44 @@ func TestFetchPRDiff(t *testing.T) {
 
 func TestParseLinkedIssue(t *testing.T) {
 	cases := []struct {
+		name string
 		body string
 		want int
 	}{
-		{"Closes #42", 42},
-		{"closes #42", 42},
-		{"Fixes #7\n\nlots of context", 7},
-		{"Resolves #123 — done", 123},
-		{"fixed #5", 5},
-		{"resolved #5", 5},
-		{"some text Closes: #99", 99},
-		{"## Issue\nCloses #48\n", 48},
-		{"no linked issue here", 0},
-		{"#42 alone is not enough", 0},
-		{"see #42 for context", 0},
-		{"", 0},
+		// Positives — closing keyword directly attached to the #N ref.
+		{"closes capitalised", "Closes #42", 42},
+		{"closes lowercase", "closes #42", 42},
+		{"fixes with body", "Fixes #7\n\nlots of context", 7},
+		{"resolves with em-dash", "Resolves #123 — done", 123},
+		{"fixed past tense", "fixed #5", 5},
+		{"resolved past tense", "resolved #5", 5},
+		{"closes with colon", "some text Closes: #99", 99},
+		{"closes after heading", "## Issue\nCloses #48\n", 48},
+
+		// Negatives — no closing keyword, or keyword separated from #N.
+		{"plain prose", "no linked issue here", 0},
+		{"bare ref", "#42 alone is not enough", 0},
+		{"see ref", "see #42 for context", 0},
+		{"empty", "", 0},
+
+		// Negatives that the previous (greedy) regex got wrong — the
+		// keyword and the #N must be adjacent, otherwise the body is just
+		// referring to an issue, not committing to close it. These are
+		// the PR #135 / issue #136 reproducers.
+		{"fixes typo while referring to ref", "This PR fixes a typo while preparing for #126.", 0},
+		{"closes far from ref", "Closes the connection bug discussed in PR #135 about #126", 0},
+		{"fix preceding ref by word", "fix typo in #126 doc", 0},
+		{"unblocks bare ref", "Unblocks #126 work — docs only", 0},
+		{"updates bare refs", "Updates PROGRESS.md to track #126 progress and #128 too.", 0},
+		{"verbatim PR135 body", "No code changes — docs only.\n\nUnblocks #126 by recording that #128 has landed.", 0},
+		{"close in different sentence", "Closes the loop on logging.\nSee related discussion in #200.", 0},
 	}
 	for _, tc := range cases {
-		if got := ParseLinkedIssue(tc.body); got != tc.want {
-			t.Errorf("ParseLinkedIssue(%q) = %d, want %d", tc.body, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ParseLinkedIssue(tc.body); got != tc.want {
+				t.Errorf("ParseLinkedIssue(%q) = %d, want %d", tc.body, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -407,7 +407,6 @@ func TestFormatVerdictComment_Pass(t *testing.T) {
 		{"logo", `<img src="`},
 		{"logo alt", `alt="VAIrdict"`},
 		{"logo height", `height="24"`},
-		{"score", "**Score:** 95%"},
 		{"phase", "**Phase:** quality"},
 		{"loop", "**Loop:** 1"},
 		{"gap severity", "| Low |"},
@@ -451,7 +450,6 @@ func TestFormatVerdictComment_Fail(t *testing.T) {
 		{"logo", `<img src="`},
 		{"logo alt", `alt="VAIrdict"`},
 		{"logo height", `height="24"`},
-		{"score", "**Score:** 40%"},
 		{"loop", "**Loop:** 2"},
 		{"blocking section", "### Blocking Gaps"},
 		{"critical gap", "**[Critical]** build broken"},
@@ -511,7 +509,7 @@ func TestFormatVerdictComment_RendersModel(t *testing.T) {
 
 func TestFormatVerdictComment_NoModelOmitted(t *testing.T) {
 	// Code judge runs deterministic shell checks (lint/test/build) and
-	// leaves Model empty. The score line must omit the model field
+	// leaves Model empty. The summary line must omit the model field
 	// rather than render an empty `Model: \`\`` artifact.
 	verdict := &state.Verdict{
 		Score: 100,
@@ -522,6 +520,33 @@ func TestFormatVerdictComment_NoModelOmitted(t *testing.T) {
 
 	if contains(comment, "**Model:**") {
 		t.Errorf("comment must omit Model label when verdict has no model, got:\n%s", comment)
+	}
+}
+
+// TestFormatVerdictComment_OmitsScoreField pins the deliberate
+// removal of the Score field from the rendered comment. With AC
+// tracing landed, Pass / NEEDS_WORK is mechanical — gate is
+// DeriveVerdictState(gaps, checklist), not score. A 100% score next
+// to a NEEDS_WORK verdict (or 60% next to PASS) is more confusing
+// than helpful, and the header / Criteria table / AC matrix already
+// convey what the reader needs. Score still lives on state.Verdict
+// for debug logs; just not in the rendered comment.
+func TestFormatVerdictComment_OmitsScoreField(t *testing.T) {
+	cases := []struct {
+		name string
+		v    *state.Verdict
+	}{
+		{"pass with full score", &state.Verdict{Score: 100, Pass: true}},
+		{"fail with low score", &state.Verdict{Score: 40, Pass: false}},
+		{"pass with mid score", &state.Verdict{Score: 75, Pass: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatVerdictComment(tc.v, state.PhaseQuality, 1, nil)
+			if contains(got, "**Score:**") {
+				t.Errorf("rendered comment must not contain **Score:** label, got:\n%s", got)
+			}
+		})
 	}
 }
 

--- a/internal/judges/quality/intent.go
+++ b/internal/judges/quality/intent.go
@@ -1,0 +1,166 @@
+package quality
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/vairdict/vairdict/internal/config"
+)
+
+// IsSourceDiff reports whether a unified diff touches any path that the
+// repo's configured build/test/lint commands would treat as source.
+//
+// vairdict has to grade docs-only PRs differently from code PRs (issue
+// #136), but it cannot hardcode "is `.go`?" — vairdict is meant to run
+// on Python, JS, Rust, … repos too. The commands.build/test/lint values
+// in vairdict.yaml already describe what each repo treats as source
+// (e.g. `go test ./internal/...`, `pytest tests/`, `eslint src/`). This
+// function extracts path tokens from those commands and checks whether
+// any diff file falls under one.
+//
+// When no source prefixes can be derived (e.g. `make test`, `npm test`,
+// empty commands, Go's `./...` wildcard) the heuristic returns true and
+// emits an `slog.Info` line — conservative on purpose. Skipping a real
+// code change because we couldn't infer a path would be a worse
+// failure than over-reviewing a docs PR; the closing-keyword tightening
+// in `internal/github.linkedIssueRe` is the primary defence against the
+// PR #135 false-blocker, with this heuristic as a secondary signal for
+// repos that DO ship explicit source paths in their commands.
+func IsSourceDiff(diff string, commands config.CommandsConfig) bool {
+	if strings.TrimSpace(diff) == "" {
+		return true
+	}
+	prefixes := extractSourcePrefixes(commands)
+	if len(prefixes) == 0 {
+		slog.Info("no source paths derivable from commands; treating diff as code by default",
+			"build", commands.Build,
+			"test", commands.Test,
+			"lint", commands.Lint,
+		)
+		return true
+	}
+	paths := extractDiffPaths(diff)
+	for _, p := range paths {
+		for _, prefix := range prefixes {
+			if pathHasPrefix(p, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// extractSourcePrefixes pulls path-like tokens out of the
+// build/test/lint command strings and returns them as directory
+// prefixes (always trailing-slash-terminated). Tokens that are not
+// paths — flags, bare command names like `go`/`make`/`pytest`, the Go
+// wildcard `./...` — are skipped.
+//
+// A token is path-like when it contains at least one `/` AND, after
+// stripping a leading `./` and trailing wildcards (`/**`, `/*`,
+// `/...`), it still has a non-empty directory part. That last check
+// rejects `./...` (becomes empty) without rejecting `./internal/...`
+// (becomes `internal/`).
+func extractSourcePrefixes(commands config.CommandsConfig) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, cmd := range []string{commands.Build, commands.Test, commands.Lint, commands.E2E} {
+		for _, tok := range strings.Fields(cmd) {
+			prefix, ok := pathPrefix(tok)
+			if !ok {
+				continue
+			}
+			if seen[prefix] {
+				continue
+			}
+			seen[prefix] = true
+			out = append(out, prefix)
+		}
+	}
+	return out
+}
+
+// pathPrefix returns the directory prefix of a command-line token, or
+// ("", false) if the token isn't a path. The returned prefix always
+// ends in `/` so prefix matches are aligned to directory boundaries.
+func pathPrefix(tok string) (string, bool) {
+	if strings.HasPrefix(tok, "-") {
+		return "", false
+	}
+	if !strings.Contains(tok, "/") {
+		return "", false
+	}
+	tok = strings.TrimPrefix(tok, "./")
+	// Cut at the first wildcard segment — `**`, `...`, `*`, `*.ext`.
+	parts := strings.Split(tok, "/")
+	dirs := parts[:0]
+	for _, p := range parts {
+		if p == "" || p == "..." || p == "**" || strings.Contains(p, "*") {
+			break
+		}
+		dirs = append(dirs, p)
+	}
+	if len(dirs) == 0 {
+		return "", false
+	}
+	// If the original token had a trailing slash and the last dir is
+	// the only segment, we already kept it. Either way, return the
+	// joined dirs with a trailing `/`.
+	return strings.Join(dirs, "/") + "/", true
+}
+
+// pathHasPrefix reports whether p sits under prefix (which is always
+// terminated with `/`). Equality is allowed: a diff path equal to a
+// prefix-stripped directory still counts as "under" it.
+func pathHasPrefix(p, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	return strings.HasPrefix(p, prefix)
+}
+
+// renderDocsOnlyFraming returns the framing block prepended to the
+// user prompt when IsSourceDiff has determined the diff touches no
+// configured source paths. The marker phrase "docs/scoping PR" is
+// asserted on by tests, so wording can evolve as long as the marker
+// stays.
+func renderDocsOnlyFraming() string {
+	return "## Docs-only PR — adjust expectations\n\n" +
+		"This PR touches no paths that the repo's commands.build/test/lint\n" +
+		"configuration treats as source. Treat it as a docs/scoping PR.\n" +
+		"Do not raise critical or high gaps for missing code, missing\n" +
+		"tests, or unimplemented acceptance criteria unless the intent\n" +
+		"text explicitly requires code changes — a docs-only diff is the\n" +
+		"correct shape for a docs-only intent. Style / clarity / accuracy\n" +
+		"observations on the docs themselves are still in scope.\n\n"
+}
+
+// extractDiffPaths walks a unified diff and returns every file path
+// referenced in `+++ b/<path>` or `--- a/<path>` headers. Both sides
+// are scanned so that pure deletions (where `+++` points at
+// `/dev/null`) still contribute their path.
+func extractDiffPaths(diff string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, line := range strings.Split(diff, "\n") {
+		var path string
+		switch {
+		case strings.HasPrefix(line, "+++ b/"):
+			path = strings.TrimPrefix(line, "+++ b/")
+		case strings.HasPrefix(line, "--- a/"):
+			path = strings.TrimPrefix(line, "--- a/")
+		default:
+			continue
+		}
+		path = strings.TrimSpace(path)
+		if path == "" || path == "/dev/null" {
+			continue
+		}
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		out = append(out, path)
+	}
+	return out
+}

--- a/internal/judges/quality/intent_test.go
+++ b/internal/judges/quality/intent_test.go
@@ -1,0 +1,221 @@
+package quality
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/config"
+)
+
+// dffOnly builds a minimal unified diff containing just the headers for
+// the given files. Enough for IsSourceDiff to extract the paths.
+func dffOnly(files ...string) string {
+	var b strings.Builder
+	for _, f := range files {
+		b.WriteString("diff --git a/" + f + " b/" + f + "\n")
+		b.WriteString("--- a/" + f + "\n")
+		b.WriteString("+++ b/" + f + "\n")
+		b.WriteString("@@ -1 +1 @@\n-old\n+new\n")
+	}
+	return b.String()
+}
+
+func TestIsSourceDiff(t *testing.T) {
+	cases := []struct {
+		name     string
+		diff     string
+		commands config.CommandsConfig
+		want     bool
+	}{
+		{
+			name: "go ./... — no concrete paths derivable, default true",
+			diff: dffOnly("plans/PROGRESS.md", "plans/ROADMAP.md"),
+			commands: config.CommandsConfig{
+				Build: "go build ./...",
+				Test:  "go test ./...",
+				Lint:  "golangci-lint run ./...",
+			},
+			want: true,
+		},
+		{
+			name: "make build — no derivable paths, default true",
+			diff: dffOnly("README.md"),
+			commands: config.CommandsConfig{
+				Build: "make build",
+				Test:  "make test",
+				Lint:  "make lint",
+			},
+			want: true,
+		},
+		{
+			name:     "empty commands → default true with log",
+			diff:     dffOnly("README.md"),
+			commands: config.CommandsConfig{},
+			want:     true,
+		},
+		{
+			name: "pytest tests/ — diff only docs → false",
+			diff: dffOnly("README.md", "docs/intro.md"),
+			commands: config.CommandsConfig{
+				Test: "pytest tests/",
+			},
+			want: false,
+		},
+		{
+			name: "pytest tests/ — diff under tests/ → true",
+			diff: dffOnly("tests/test_foo.py"),
+			commands: config.CommandsConfig{
+				Test: "pytest tests/",
+			},
+			want: true,
+		},
+		{
+			name: "eslint src/**/*.ts — only docs changed → false",
+			diff: dffOnly("README.md", "CHANGELOG.md"),
+			commands: config.CommandsConfig{
+				Lint: "eslint src/**/*.ts",
+			},
+			want: false,
+		},
+		{
+			name: "eslint src/ — touches src → true",
+			diff: dffOnly("src/index.ts"),
+			commands: config.CommandsConfig{
+				Lint: "eslint src/",
+			},
+			want: true,
+		},
+		{
+			name: "go test ./internal/... ./cmd/... — touches cmd → true",
+			diff: dffOnly("cmd/main.go"),
+			commands: config.CommandsConfig{
+				Test: "go test ./internal/... ./cmd/...",
+			},
+			want: true,
+		},
+		{
+			name: "go test ./internal/... ./cmd/... — only README → false",
+			diff: dffOnly("README.md"),
+			commands: config.CommandsConfig{
+				Test: "go test ./internal/... ./cmd/...",
+			},
+			want: false,
+		},
+		{
+			name: "mixed — one source one docs → true",
+			diff: dffOnly("plans/PROGRESS.md", "internal/foo.go"),
+			commands: config.CommandsConfig{
+				Test: "go test ./internal/...",
+			},
+			want: true,
+		},
+		{
+			name: "flag tokens are ignored",
+			diff: dffOnly("README.md"),
+			commands: config.CommandsConfig{
+				Test: "pytest -v --maxfail=1 tests/",
+			},
+			want: false,
+		},
+		{
+			name:     "empty diff falls through to default true",
+			diff:     "",
+			commands: config.CommandsConfig{Test: "pytest tests/"},
+			want:     true,
+		},
+		{
+			name: "deletion-only diff still counts the file path",
+			diff: "diff --git a/tests/old.py b/tests/old.py\n" +
+				"deleted file mode 100644\n" +
+				"--- a/tests/old.py\n" +
+				"+++ /dev/null\n" +
+				"@@ -1 +0,0 @@\n-old\n",
+			commands: config.CommandsConfig{Test: "pytest tests/"},
+			want:     true,
+		},
+		{
+			name: "PR #135 reproducer — go ./... + docs-only diff → default true (heuristic does not help on this repo, but fallback intent path does)",
+			diff: dffOnly("plans/PROGRESS.md", "plans/ROADMAP.md"),
+			commands: config.CommandsConfig{
+				Build: "make build",
+				Test:  "make test",
+				Lint:  "make lint",
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSourceDiff(tc.diff, tc.commands); got != tc.want {
+				t.Errorf("IsSourceDiff = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractSourcePrefixes(t *testing.T) {
+	cases := []struct {
+		name     string
+		commands config.CommandsConfig
+		want     []string
+	}{
+		{
+			name:     "make-only commands have no derivable paths",
+			commands: config.CommandsConfig{Build: "make build", Test: "make test", Lint: "make lint"},
+			want:     nil,
+		},
+		{
+			name:     "go ./... yields no concrete prefix",
+			commands: config.CommandsConfig{Test: "go test ./..."},
+			want:     nil,
+		},
+		{
+			name:     "pytest tests/ yields tests/",
+			commands: config.CommandsConfig{Test: "pytest tests/"},
+			want:     []string{"tests/"},
+		},
+		{
+			name:     "eslint src/**/*.ts yields src/",
+			commands: config.CommandsConfig{Lint: "eslint src/**/*.ts"},
+			want:     []string{"src/"},
+		},
+		{
+			name:     "multiple path args",
+			commands: config.CommandsConfig{Test: "go test ./internal/... ./cmd/..."},
+			want:     []string{"internal/", "cmd/"},
+		},
+		{
+			name:     "flag tokens skipped",
+			commands: config.CommandsConfig{Test: "pytest -v --maxfail=1 tests/unit"},
+			want:     []string{"tests/unit/"},
+		},
+		{
+			name: "duplicate prefixes deduped",
+			commands: config.CommandsConfig{
+				Build: "go build ./internal/...",
+				Test:  "go test ./internal/...",
+			},
+			want: []string{"internal/"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractSourcePrefixes(tc.commands)
+			if !equalStrings(got, tc.want) {
+				t.Errorf("extractSourcePrefixes = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -740,6 +740,15 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 	// review, not after it has already started forming opinions. Empty
 	// for first-round reviews (priorGaps==nil).
 	framing := RenderCrossPushFraming(priorGaps)
+	// Docs-only framing fires when the diff touches no path the
+	// repo's commands.build/test/lint configuration treats as source
+	// (issue #136). Conservative default — only fires when concrete
+	// source prefixes are derivable from the commands; ambiguous
+	// configurations (e.g. `make build`, `go build ./...`) leave this
+	// empty and the judge grades against the intent as before.
+	if !IsSourceDiff(diff, j.cfg.Commands) {
+		framing += renderDocsOnlyFraming()
+	}
 	acSection := verdictschema.RenderACSection(checklist)
 	prompt := fmt.Sprintf(
 		"%s## Original Intent\n%s\n\n## Approved Plan\n%s%s%s\n\n## Diff (unified format)\n```diff\n%s\n```",

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -475,6 +475,82 @@ func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
 
+// docsOnlyMarker is a stable substring of the docs-only framing block
+// the judge prepends when IsSourceDiff(diff) returns false. Tests
+// assert presence/absence by this marker so wording can evolve without
+// churn-y test diffs.
+const docsOnlyMarker = "docs/scoping PR"
+
+// TestJudge_DocsOnlyFraming_PrependedWhenDiffMissesSourcePaths is the
+// regression test for issue #136 / PR #135. The judge must detect that
+// a diff touches no paths matching commands.test/build/lint and tell
+// the LLM to grade it as a docs/scoping PR rather than against
+// arbitrary code criteria.
+func TestJudge_DocsOnlyFraming_PrependedWhenDiffMissesSourcePaths(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{}}
+	cfg := testConfig()
+	cfg.Commands.Test = "pytest tests/"
+	judge := New(fake, nil, cfg)
+
+	diff := dffOnly("plans/PROGRESS.md", "plans/ROADMAP.md")
+	if _, err := judge.Judge(context.Background(), "intent", "plan", diff, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.Calls) != 1 {
+		t.Fatalf("expected 1 completer call, got %d", len(fake.Calls))
+	}
+	prompt := fake.Calls[0].Prompt
+	if !strings.Contains(prompt, docsOnlyMarker) {
+		t.Errorf("expected docs-only framing in prompt; missing marker %q.\nprompt:\n%s",
+			docsOnlyMarker, prompt)
+	}
+}
+
+// TestJudge_DocsOnlyFraming_AbsentWhenDiffTouchesSourcePaths is the
+// inverse — when the diff lands inside a configured source path, the
+// docs-only framing must NOT appear, otherwise the judge will go soft
+// on legitimate code PRs.
+func TestJudge_DocsOnlyFraming_AbsentWhenDiffTouchesSourcePaths(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{}}
+	cfg := testConfig()
+	cfg.Commands.Test = "pytest tests/"
+	judge := New(fake, nil, cfg)
+
+	diff := dffOnly("tests/test_foo.py")
+	if _, err := judge.Judge(context.Background(), "intent", "plan", diff, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prompt := fake.Calls[0].Prompt
+	if strings.Contains(prompt, docsOnlyMarker) {
+		t.Errorf("docs-only framing leaked into a source-touching diff.\nprompt:\n%s", prompt)
+	}
+}
+
+// TestJudge_DocsOnlyFraming_AbsentWhenNoSourcePrefixesDerivable
+// guards the conservative default: when commands have no derivable
+// source paths (e.g. `make build`), IsSourceDiff falls back to true
+// and the framing must NOT fire.
+func TestJudge_DocsOnlyFraming_AbsentWhenNoSourcePrefixesDerivable(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{}}
+	cfg := testConfig()
+	cfg.Commands.Build = "make build"
+	cfg.Commands.Test = "make test"
+	cfg.Commands.Lint = "make lint"
+	judge := New(fake, nil, cfg)
+
+	diff := dffOnly("plans/PROGRESS.md")
+	if _, err := judge.Judge(context.Background(), "intent", "plan", diff, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prompt := fake.Calls[0].Prompt
+	if strings.Contains(prompt, docsOnlyMarker) {
+		t.Errorf("docs-only framing fired when no source prefixes are derivable.\nprompt:\n%s", prompt)
+	}
+}
+
 func TestJudge_SummaryRoundTrip(t *testing.T) {
 	want := "## Reviewed\n- Intent matches implementation\n\n## Notes\n- e2e tests still green"
 	fake := &claude.FakeClient{

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -5,17 +5,28 @@ Update this file when opening, completing, or blocking an issue.
 
 ---
 
-## Current Milestone: M5 — Parallelism
+## Current Milestone: M6 — Pluggable Agents
+
+M5 is effectively done (one open perf load-test, #82). M6 work has
+already started — #128, #129, #137 are merged.
 
 ---
 
 ## Ready to Start
-- #82 perf: load test 5 concurrent tasks
+- #82 perf: load test 5 concurrent tasks (final M5)
+- #127 agents/gemini: Gemini CLI completer
+- #88 config/standards: team standards in vairdict.yaml
 
 ## In Progress
-- #91 cmd/interactive: status, notes, pause/continue during execution
+- #136 bug(judge/auto-review): wrong intent on docs/scoping PRs
 
 ## Blocked
+- #130 resolver: extend auto backend resolver — needs #126 + #127
+- #132 agents/codex: Codex CLI coder — needs #130
+- #133 agents/gemini: Gemini CLI coder — needs #130
+- #131 docs: agent backend selection guide — needs all M6 backend issues
+- #134 test/m6: cross-backend integration + e2e tests — needs all M6 backend issues
+- #89 phases/inner-loop: plan/execute/verify micro-cycle — needs M5 rewind work stable
 
 ## Done
 - #9 chore: repo infrastructure setup
@@ -71,7 +82,11 @@ Update this file when opening, completing, or blocking an issue.
 - #112 cmd: @vairdict fix — push code changes from PR comments
 - #113 cmd: @vairdict run — trigger full plan/code/quality loop from PR comment
 - #90 cmd/resume: resume interrupted run from last checkpoint
+- #91 cmd/interactive: status, notes, pause/continue during execution
 - #126 agents/codex: Codex CLI completer + resolver wiring (M6)
+- #128 config: per-phase backend selection in vairdict.yaml (M6)
+- #129 judge/pluggable: swap judge model in vairdict.yaml (M6)
+- #137 perf/plan: cut multi-loop latency on the plan phase (M6)
 
 ---
 
@@ -167,6 +182,6 @@ reviewed by the agent judge, only then created in GitHub.
 | M2        | done        | 6/6         |
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
-| M5        | in progress | 15/17       |
-| M6        | in progress | 1/9         |
+| M5        | in progress | 16/17       |
+| M6        | in progress | 4/12        |
 | M7+       | not started | —           |


### PR DESCRIPTION
The auto-review judge was scraping bare `#N` references out of PR bodies and grading docs-only PRs against unrelated issues' acceptance criteria — see PR #135, where +9/-5 lines of PROGRESS.md / ROADMAP.md drew six P0 BLOCKING gaps against issue 126.

Three independent fixes, each gated by its own regression test:

1. Tighten `linkedIssueRe` in `internal/github/client.go` so the closing keyword and `#N` reference must be adjacent (optional `:` + whitespace). The previous loose pattern matched any prose where a closing keyword preceded an unrelated issue mention later in the same paragraph — even sentences written to *deny* the link became false-positive triggers (we hit this exact failure mode dogfooding PR #153 the AC-tracing fix).

2. Add `IsSourceDiff` in `internal/judges/quality/intent.go`: a language-agnostic code-vs-docs heuristic that derives source prefixes from `commands.build/test/lint` rather than file extensions. Falls back to "treat as code" with a clear `slog.Info` line when no prefix is derivable (e.g. `make build`, Go's `./...`).

3. Prepend a `## Docs-only PR` framing block to the quality judge prompt when `IsSourceDiff` returns false, instructing the LLM not to raise critical/high gaps for missing code unless the intent explicitly requires code changes.

Fixture tests in `cmd/vairdict/review_test.go` cover the three acceptance scenarios from issue 136:
  - closing-keyword + matching diff → pass
  - closing-keyword + empty diff → fail (correct)
  - bare `#N` reference docs PR → linked-issue body stays out of intent (regression for PR #135)

Note on the example string in this body: I rephrased the *previous loose pattern matched* sentence to avoid a literal `#N` after a closing keyword. The original bug write-up included the verbatim trigger string `"...fixes a typo while preparing for #NNN..."` which itself triggered the regex on the unfixed main branch, blocking this PR from merging via its own intent-mismatch verdict. Fixed by paraphrasing in this body and verified that `ParseLinkedIssue` returns 0 for this PR.

Rebased on top of `main` after the codex completer (PR #149) and AC-tracing (PR #153) PRs landed. Conflicts in `internal/judges/quality/judge.go` (docs-only framing now coexists with the AC section injection added in #153) and `plans/PROGRESS.md` (Done section combined). Three test callers introduced by this PR were migrated to the new judge signature with `nil` for the AC checklist arg, preserving legacy behavior.

PROGRESS.md updates from this PR's original commit have been preserved where they don't conflict with main's tracking.