### PR TITLE
fix(install): resolve latest version via github.com redirect, not API

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,12 +45,6 @@ runs:
       shell: bash
       env:
         VAIRDICT_VERSION: ${{ inputs.version }}
-        # Authenticate the `releases/latest` probe so we don't share
-        # the 60/hour anonymous rate-limit bucket with every other
-        # runner on the same IP. install.sh reads $GITHUB_TOKEN.
-        # Falls back to github.token (job-default GITHUB_TOKEN);
-        # any caller-set GH_TOKEN env (eg. the App token) still wins.
-        GITHUB_TOKEN: ${{ env.GH_TOKEN || github.token }}
       run: |
         if [ "$VAIRDICT_VERSION" = "latest" ]; then
           curl -fsSL https://raw.githubusercontent.com/vairdict/vairdict/main/scripts/install.sh | INSTALL_DIR="${{ runner.temp }}" sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,11 +7,13 @@
 # Respects:
 #   INSTALL_DIR  — where to put the binary (default: /usr/local/bin)
 #   VERSION      — specific version to install (default: latest)
-#   GITHUB_TOKEN — bearer token for the releases API call. When set,
-#                  the latest-version probe is authenticated, raising
-#                  the rate limit from 60/hour (anon) to 5000/hour
-#                  and avoiding the "Failed to detect latest version"
-#                  exit that hits CI runner pools sharing IP space.
+#
+# Version resolution: this script follows the github.com /releases/latest
+# 302 redirect rather than calling the api.github.com REST endpoint.
+# The web redirect is not auth-rate-limited (the API path is — 60/hour
+# per anonymous IP, easily exhausted by CI runner pools sharing IPs,
+# which produced the recurring exit-22 failures the auto-review action
+# was hitting). No GITHUB_TOKEN needed.
 
 set -e
 # pipefail makes a curl failure inside a `curl | grep | sed` pipeline
@@ -49,41 +51,41 @@ esac
 # --- Resolve version ---
 
 if [ -z "$VERSION" ]; then
-  # fetch_latest queries the releases/latest API. When GITHUB_TOKEN is
-  # set, sends Authorization so the request is authenticated (5000/hour
-  # rate limit) instead of anonymous (60/hour shared by IP across the
-  # runner pool — easy to exhaust on busy days). Two branches keep the
-  # quoting clean: building one with a header injected via shell
-  # variable would word-split badly.
+  # fetch_latest follows the github.com /releases/latest redirect and
+  # returns the version from the Location header (e.g.
+  # `https://github.com/.../releases/tag/v0.0.8` -> `0.0.8`). Curl's
+  # `-I` issues a HEAD request so the body is never downloaded; `-f`
+  # makes 4xx/5xx return non-zero so this falls into the retry loop
+  # instead of producing empty output downstream.
   fetch_latest() {
-    if [ -n "$GITHUB_TOKEN" ]; then
-      curl -fsSL \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github+json" \
-        -H "User-Agent: vairdict-install.sh" \
-        "https://api.github.com/repos/${REPO}/releases/latest"
-    else
-      curl -fsSL \
-        -H "Accept: application/vnd.github+json" \
-        -H "User-Agent: vairdict-install.sh" \
-        "https://api.github.com/repos/${REPO}/releases/latest"
-    fi
+    curl -fsSI \
+      -H "User-Agent: vairdict-install.sh" \
+      "https://github.com/${REPO}/releases/latest" \
+      | awk 'tolower($1) == "location:" {
+                sub(/\r$/, "", $2)
+                n = split($2, a, "/")
+                v = a[n]
+                sub(/^v/, "", v)
+                print v
+                exit
+              }'
   }
 
-  # Retry on transient API failures (rate-limit blips, network jitter,
-  # transient 5xx). Without retry the latest-version probe is a single
-  # point of failure on every PR's review check.
+  # Retry on transient network blips. The redirect endpoint is the
+  # same path the tarball download will hit moments later, so a
+  # persistent failure here is a strong signal the rest will fail
+  # too — bail with a clear message rather than retrying forever.
   attempt=1
   while [ "$attempt" -le 3 ]; do
-    if VERSION="$(fetch_latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')" && [ -n "$VERSION" ]; then
+    if VERSION="$(fetch_latest)" && [ -n "$VERSION" ]; then
       break
     fi
-    echo "Attempt ${attempt}: failed to fetch latest version, retrying..." >&2
+    echo "Attempt ${attempt}: failed to resolve latest version, retrying..." >&2
     attempt=$((attempt + 1))
     sleep 2
   done
   if [ -z "$VERSION" ]; then
-    echo "Failed to detect latest version after 3 attempts. Set VERSION explicitly." >&2
+    echo "Failed to resolve latest version after 3 attempts. Set VERSION explicitly." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

`install.sh` was hitting GitHub's anonymous-API rate limit (60/hour
per IP, shared across CI runner pools), failing every PR's
auto-review with `curl: (22) The requested URL returned error: 403`
in ~5–8 seconds.

Reproduced locally:
```
$ INSTALL_DIR=/tmp/x sh scripts/install.sh
curl: (22) The requested URL returned error: 403
Attempt 1: failed to fetch latest version, retrying...
... (3 attempts) ...
Failed to detect latest version after 3 attempts.
```

The previous design tried to dodge the limit with `GITHUB_TOKEN`,
but the auth chain through the composite-action env context is
fragile — if it breaks for any reason (App secret rotation, env
scoping in composite actions, permission tightening) every PR
review job dies before vairdict even starts.

## Fix

Switch the version probe from the API to the github.com web
endpoint, which 302-redirects:

```
GET https://github.com/<owner>/<repo>/releases/latest
→ 302 Location: https://github.com/<owner>/<repo>/releases/tag/v0.0.8
```

The web endpoint is **not API-rate-limited** and **needs no token**.
We extract the version from the `Location` header via `curl -fsSI` +
`awk`. End-to-end verified locally: `INSTALL_DIR=/tmp/x sh
scripts/install.sh` resolves `0.0.8`, downloads, verifies checksum,
installs, exit 0, binary runs.

Side benefit: kills the brittle `grep '"tag_name"' | sed -E
's/.*"v([^"]+)".*/\1/'` JSON parse, which only worked by accident
when the greedy regex landed on `"name":"v..."` (would have silently
flipped the installed version if the JSON field order or release
body content shifted).

Drops the now-unused `GITHUB_TOKEN` env from the action's install
step — install.sh no longer reads it.

## Why a separate PR

Discovered while working on #136 (PR #146). The auto-review action
on #146 cannot dogfood the fix from #146 itself because both
`install.sh` and `action.yml` are pulled from `main`. Landing this
small fix to `main` first lets every subsequent PR (including the
rebase of #146) see a working auto-review.

## Test plan

- [x] Local repro of the 403 failure mode against api.github.com
- [x] Local end-to-end install with the new redirect-based probe → exit 0, v0.0.8 installs
- [x] `VERSION=v0.0.X` pinning still works (errors with exit 22 on missing artifact, as expected)
- [ ] After merge: re-trigger PR #146 auto-review → expect the install step to succeed and vairdict to actually run

https://claude.ai/code/session_011xP5zsqSVPtV3i5UXaHrXd

---
_Generated by [Claude Code](https://claude.ai/code/session_011xP5zsqSVPtV3i5UXaHrXd)_