### PR TITLE
fix(review): scope pre-flight validation to the quality judge

### DIFF
--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -112,7 +112,18 @@ func runReview(prNumber int) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	if err := validateBackends(cfg, defaultBackendProbes()); err != nil {
+	// `vairdict review` only ever runs the quality judge — never the
+	// planner, the code judge, or the coder. Validating the full agent
+	// matrix would reject the run on a stock CI runner that has no
+	// `claude` binary installed (the coder probe in `validateBackends`
+	// is unconditional). Scope the pre-flight to the role we actually
+	// invoke so review-mode auto-review works on any runner with just
+	// an Anthropic API key.
+	if err := validateCompleterBackend(
+		"agents.quality_judge",
+		cfg.Agents.QualityJudgeBackend(),
+		defaultBackendProbes(),
+	); err != nil {
 		return fmt.Errorf("backend validation: %w", err)
 	}
 

--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -8,9 +8,47 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/github"
 	"github.com/vairdict/vairdict/internal/state"
 )
+
+// TestRunReview_ValidatesOnlyQualityJudge guards the regression where
+// `vairdict review` was rejecting the dogfood config in CI because
+// validateBackends insists on a `claude` binary on PATH for the
+// agents.coder slot — even though `vairdict review` never invokes the
+// coder. The review subcommand only ever runs the quality judge, so
+// it must validate that one role and nothing else.
+//
+// The scenario we reproduce is the exact one the auto-review action
+// hits: a stock CI runner with no `claude` CLI installed and an
+// Anthropic API key in env, against the in-repo vairdict.yaml where
+// `agents.judge: claude` (smart default).
+func TestRunReview_ValidatesOnlyQualityJudge(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code", // would fail validateCoderBackend with no CLI
+		Judge:   "claude",      // smart default — no binary required
+	}}
+	probes := backendProbes{
+		cliAvailable:  func(string) bool { return false },
+		apiKeyPresent: func() bool { return true },
+	}
+
+	// Sanity: the full validateBackends would reject this config.
+	if err := validateBackends(cfg, probes); err == nil {
+		t.Fatal("test setup is wrong: validateBackends must reject when claude binary is missing")
+	}
+
+	// What review.go now does: validate only the quality judge slot.
+	if err := validateCompleterBackend(
+		"agents.quality_judge",
+		cfg.Agents.QualityJudgeBackend(),
+		probes,
+	); err != nil {
+		t.Errorf("review-scoped validation must accept smart-default judge with no binary: %v", err)
+	}
+}
 
 // fakeReviewGH is a hand-rolled fake covering only the surface that
 // runReviewWith uses. Records every PostVerdict call so tests can assert


### PR DESCRIPTION
## Summary

`vairdict review` was rejecting the dogfood config in CI with:

```
agents.coder: claude-code requires the `claude` binary on PATH
```

…even though `vairdict review` only ever runs the **quality judge**
— never the planner, code judge, or coder. The broad
`validateBackends` call was probing the coder slot
unconditionally, and stock CI runners don't ship the Claude CLI.

This was masked for a while by the `install.sh` exit-22 failure
fixed in #147; once install started succeeding, `vairdict review`
fell over here instead.

## Fix

Replace the broad `validateBackends(cfg, probes)` call in
`cmd/vairdict/review.go` with a single
`validateCompleterBackend("agents.quality_judge",
cfg.Agents.QualityJudgeBackend(), probes)`.

The smart-default `"claude"` value still falls through to the
runtime resolver, which probes for the CLI and falls back to
`claude-api` when `ANTHROPIC_API_KEY` is set — exactly the path
the action needs on a stock runner.

`vairdict run` (full plan→code→quality loop) keeps the broad
`validateBackends` because it actually does invoke the coder.

## Why a separate PR

Discovered while working on PR #146 (issue #136). The auto-review
on #146 cannot dogfood the fix from #146 itself because the
action installs `vairdict` from the latest release — the fix has
to live in the binary, not in the PR branch source. Landing this
small fix to `main` and cutting v0.0.10 lets the next push to
#146 actually get a real verdict.

## Test plan

- [x] New regression test `TestRunReview_ValidatesOnlyQualityJudge`
      reproduces the CI scenario (no `claude` binary, API key
      present, dogfood config) and asserts the new scoped
      validation accepts it while the old broad
      `validateBackends` rejects it (the test asserts both
      directions to keep the diff honest).
- [x] Existing review tests unchanged and still passing.
- [ ] After merge + v0.0.10 release: re-trigger PR #146
      auto-review → expect `vairdict review 146` to actually run
      and post a verdict.

https://claude.ai/code/session_011xP5zsqSVPtV3i5UXaHrXd

---
_Generated by [Claude Code](https://claude.ai/code/session_011xP5zsqSVPtV3i5UXaHrXd)_