### PR TITLE
test(agents/codex): add red-phase test suite for Codex CLI completer (#126)

### DIFF
--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -2,17 +2,20 @@
 // planner and judges (the "completer" roles, distinct from the "coder" role
 // in internal/agents/claudecode which uses tools and edits the filesystem).
 //
-// Three values are accepted in vairdict.yaml under agents.planner /
+// Four values are accepted in vairdict.yaml under agents.planner /
 // agents.judge (and the per-phase overrides agents.plan_judge,
 // agents.code_judge, agents.quality_judge):
 //
 //	claude      — smart default: try claude-cli, fall back to claude-api
 //	claude-cli  — strict local subprocess (errors if `claude` not on PATH)
 //	claude-api  — strict HTTP API client (errors if no API key configured)
+//	codex       — OpenAI Codex CLI (errors if `codex` not on PATH)
 //
-// The bare value `claude` exists so future families (gpt, gemini, …) can
+// The bare value `claude` exists so future families (gemini, …) can
 // follow the same convention: bare = smart default for the family, suffixed
-// = explicit transport.
+// = explicit transport. `codex` is single-transport today (no
+// codex-cli/codex-api distinction); when an OpenAI HTTP client lands the
+// same suffix pattern applies.
 package main
 
 import (
@@ -22,6 +25,7 @@ import (
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/agents/claudecli"
+	"github.com/vairdict/vairdict/internal/agents/codex"
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/state"
 )
@@ -65,6 +69,7 @@ type backendKind string
 const (
 	backendClaudeCLI backendKind = "claude-cli" // local `claude -p`
 	backendClaudeAPI backendKind = "claude-api" // HTTP API
+	backendCodex     backendKind = "codex"      // OpenAI Codex CLI (`codex exec`)
 )
 
 // backendForRole reads the configured backend string for the given role
@@ -134,8 +139,14 @@ func chooseBackendForRole(roleName, setting string, cliAvailable bool) (backendK
 		return backendClaudeCLI, nil
 	case "claude-api":
 		return backendClaudeAPI, nil
+	case "codex":
+		// Codex is single-transport today — there is no codex-api
+		// fallback because we don't have an OpenAI HTTP client. The
+		// caller errors later if `codex` isn't on PATH (handled in
+		// validateCompleterBackend).
+		return backendCodex, nil
 	default:
-		return "", fmt.Errorf("unknown %s backend %q (want claude|claude-cli|claude-api)", roleName, setting)
+		return "", fmt.Errorf("unknown %s backend %q (want claude|claude-cli|claude-api|codex)", roleName, setting)
 	}
 }
 
@@ -186,6 +197,18 @@ func resolveCompleter(cfg *config.Config, role completerRole) (completer, backen
 			return nil, "", fmt.Errorf("creating claude client: %w", err)
 		}
 		return c, kind, nil
+	case backendCodex:
+		// --dangerously-bypass-approvals-and-sandbox lets the
+		// subprocess complete tool-style operations without
+		// interactive prompts. --skip-git-repo-check covers calls
+		// outside a git working tree (review/comment handlers).
+		opts := []codex.Option{
+			codex.WithExtraArgs("--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check"),
+		}
+		if model != "" {
+			opts = append(opts, codex.WithModel(model))
+		}
+		return codex.New(opts...), kind, nil
 	default:
 		return nil, "", fmt.Errorf("unreachable backend kind: %s", kind)
 	}
@@ -262,8 +285,13 @@ func validateCompleterBackend(roleName, setting string, probes backendProbes) er
 			return fmt.Errorf("%s: claude-api requires ANTHROPIC_API_KEY (env var or ~/.config/vairdict/config.yaml)", roleName)
 		}
 		return nil
+	case "codex":
+		if !probes.cliAvailable("codex") {
+			return fmt.Errorf("%s: codex requires the `codex` binary on PATH", roleName)
+		}
+		return nil
 	default:
-		return fmt.Errorf("%s: unknown backend %q (want claude|claude-cli|claude-api)", roleName, setting)
+		return fmt.Errorf("%s: unknown backend %q (want claude|claude-cli|claude-api|codex)", roleName, setting)
 	}
 }
 

--- a/cmd/vairdict/completer_test.go
+++ b/cmd/vairdict/completer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/agents/claudecli"
+	"github.com/vairdict/vairdict/internal/agents/codex"
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/state"
 )
@@ -33,6 +34,11 @@ func TestChooseBackend(t *testing.T) {
 		{"strict cli with cli", "claude-cli", true, backendClaudeCLI, false},
 		{"strict api", "claude-api", true, backendClaudeAPI, false},
 		{"strict api no cli", "claude-api", false, backendClaudeAPI, false},
+		// Codex pinned — explicit choice, no smart fall-through to claude.
+		// cliAvailable here refers to the *claude* CLI; it must not
+		// influence codex resolution either way.
+		{"codex no claude cli", "codex", false, backendCodex, false},
+		{"codex with claude cli", "codex", true, backendCodex, false},
 		// Typos surface as a hard error so users don't silently get the
 		// wrong backend.
 		{"unknown value", "openai", true, "", true},
@@ -414,6 +420,98 @@ func TestValidateBackends_AutoDoesNotErrorWhenFamilyUnavailable(t *testing.T) {
 	}
 	if err := validateBackends(cfg, probes); err != nil {
 		t.Errorf("smart-default config should not error, got: %v", err)
+	}
+}
+
+// TestResolveCompleter_CodexBackend: agents.judge: codex must construct a
+// codex.Client (not a claude one) and route through resolveCompleter
+// without touching the claude API path. AC item from #126: the new
+// client is reachable from the resolver.
+func TestResolveCompleter_CodexBackend(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "codex",
+		Judge:   "codex",
+		Model:   "gpt-5-codex",
+	}}
+
+	for _, role := range []completerRole{rolePlanner, rolePlanJudge, roleCodeJudge, roleQualityJudge} {
+		c, kind, err := resolveCompleter(cfg, role)
+		if err != nil {
+			t.Fatalf("resolveCompleter(%s): %v", role, err)
+		}
+		if kind != backendCodex {
+			t.Errorf("%s kind = %q, want %q", role, kind, backendCodex)
+		}
+		cc, ok := c.(*codex.Client)
+		if !ok {
+			t.Fatalf("expected *codex.Client for %s, got %T", role, c)
+		}
+		if got := cc.Model(); got != "gpt-5-codex" {
+			t.Errorf("%s codex client model = %q, want gpt-5-codex", role, got)
+		}
+	}
+}
+
+// TestValidateBackends_CodexNeedsBinary: codex pinned but `codex` not
+// on PATH must error and name both the role and the missing binary.
+// Mirrors the claude-cli missing-binary check.
+func TestValidateBackends_CodexNeedsBinary(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code",
+		Judge:   "claude",
+		// QualityJudge is the explicit pinned slot that should fail.
+		QualityJudge: "codex",
+	}}
+	probes := backendProbes{
+		// claude available (so coder + smart-default judges validate),
+		// codex absent.
+		cliAvailable:  func(name string) bool { return name == "claude" },
+		apiKeyPresent: func() bool { return true },
+	}
+	err := validateBackends(cfg, probes)
+	if err == nil {
+		t.Fatal("expected error for missing codex binary")
+	}
+	if !strings.Contains(err.Error(), "quality_judge") {
+		t.Errorf("error should name the role (quality_judge), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "codex") {
+		t.Errorf("error should name the missing binary (codex), got: %v", err)
+	}
+}
+
+// TestValidateBackends_CodexAvailable: codex pinned and the binary is
+// on PATH validates without error.
+func TestValidateBackends_CodexAvailable(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "codex",
+		Coder:   "claude-code",
+		Judge:   "codex",
+	}}
+	probes := backendProbes{
+		// Both binaries present — claude for the coder, codex for the
+		// completers.
+		cliAvailable:  func(string) bool { return true },
+		apiKeyPresent: func() bool { return false },
+	}
+	if err := validateBackends(cfg, probes); err != nil {
+		t.Errorf("codex pinned with binary present should validate, got: %v", err)
+	}
+}
+
+// TestSeedCLISession_NoOpForCodexClient: codex has no session-resume
+// concept (no --resume in our wrapper). seed/capture must be safe
+// no-ops so the orchestrator's existing wiring keeps working.
+func TestSeedCLISession_NoOpForCodexClient(t *testing.T) {
+	codexClient := codex.New()
+	task := state.NewTask("t", "i")
+	task.CLISessionIDs = map[string]string{string(rolePlanner): "ignored"}
+	// Must not panic; codex client doesn't have a session concept.
+	seedCLISession(codexClient, task, rolePlanner)
+	captureCLISession(codexClient, task, rolePlanner)
+	if task.CLISessionIDs[string(rolePlanner)] != "ignored" {
+		t.Errorf("codex client should not affect task session ids, got %v", task.CLISessionIDs)
 	}
 }
 

--- a/internal/agents/codex/client.go
+++ b/internal/agents/codex/client.go
@@ -338,16 +338,16 @@ func writeTempFile(pattern string, content []byte) (string, func(), error) {
 	path := f.Name()
 	if content != nil {
 		if _, err := f.Write(content); err != nil {
-			f.Close()
-			os.Remove(path)
+			_ = f.Close()
+			_ = os.Remove(path)
 			return "", func() {}, err
 		}
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(path)
+		_ = os.Remove(path)
 		return "", func() {}, err
 	}
-	return path, func() { os.Remove(path) }, nil
+	return path, func() { _ = os.Remove(path) }, nil
 }
 
 // truncate returns the first n characters of s.

--- a/internal/agents/codex/client.go
+++ b/internal/agents/codex/client.go
@@ -1,16 +1,39 @@
 // Package codex implements a Completer that shells out to the local
-// OpenAI Codex CLI (`codex exec --json`) instead of calling an Anthropic
+// OpenAI Codex CLI (`codex exec`) instead of calling an Anthropic
 // HTTP API.
 //
-// This is the first non-Anthropic completer for VAIrdict — it lets users
-// with the Codex CLI installed run vairdict end-to-end without an
-// Anthropic key, and proves the completer interface generalises across
-// CLI families. Mirrors internal/agents/claudecli in shape so the
-// follow-up registry work (#130) can register both behind a single
-// resolver path.
+// This is the first non-Anthropic completer for VAIrdict — it lets
+// users with the Codex CLI installed run vairdict end-to-end without
+// an Anthropic key, and proves the completer interface generalises
+// across CLI families.
 //
-// The Client is safe to share across goroutines. Each CompleteWithSystem
-// call spawns a fresh `codex` subprocess and blocks until it finishes.
+// Wire shape (verified against codex-rs/exec/src/cli.rs in
+// github.com/openai/codex):
+//
+//	codex exec [--model <m>] [--output-schema <schemafile>] \
+//	    --output-last-message <tmpfile> [<extras>...] <prompt>
+//
+// We deliberately do NOT pass `--json`. That flag emits a stream of
+// JSONL telemetry events (one per state change) — useful for
+// observability, not for getting back a single structured result.
+// Instead `--output-last-message` writes only the agent's final
+// message to a file, which is exactly the shape the planner and
+// judges consume.
+//
+// Tool use uses native enforcement via `--output-schema <file>`: the
+// tool's InputSchema is written to a tempfile and codex constrains
+// the model to a JSON response conforming to it. Falls back to a
+// single recovery round-trip if the model returns prose anyway.
+//
+// System prompt handling is deliberately simple: the system text is
+// prepended to the prompt arg with a blank-line separator. Codex's
+// non-interactive mode has no `--system` flag; the proper alternative
+// (`-c base_instructions=<toml-escaped>`) needs verification against a
+// real binary before we commit to it. Tracking that as a follow-up.
+//
+// The Client is safe to share across goroutines. Each
+// CompleteWithSystem call spawns a fresh `codex` subprocess and blocks
+// until it finishes.
 package codex
 
 import (
@@ -19,6 +42,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -26,8 +50,8 @@ import (
 	"github.com/vairdict/vairdict/internal/agents/claude"
 )
 
-// NotInstalledError is returned when the `codex` binary cannot be found
-// on PATH. Callers can use errors.As to surface a friendlier
+// NotInstalledError is returned when the `codex` binary cannot be
+// found on PATH. Callers can use errors.As to surface a friendlier
 // install-me message.
 type NotInstalledError struct {
 	Err error
@@ -39,10 +63,10 @@ func (e *NotInstalledError) Error() string {
 
 func (e *NotInstalledError) Unwrap() error { return e.Err }
 
-// ParseError is returned when the CLI produced output that could not be
-// decoded into the envelope or the caller's target struct. Raw carries
-// the original (truncated) stdout so operators can see what Codex
-// actually said.
+// ParseError is returned when codex's output file was missing, empty,
+// or could not be decoded into the caller's target struct. Raw
+// carries the original (truncated) file content so operators can see
+// what codex actually said.
 type ParseError struct {
 	Raw string
 	Err error
@@ -55,8 +79,6 @@ func (e *ParseError) Error() string {
 func (e *ParseError) Unwrap() error { return e.Err }
 
 // ExitError is returned when `codex` exits with a non-zero status.
-// Stderr carries the truncated stderr output so callers don't see a
-// bare "exit status 1".
 type ExitError struct {
 	ExitCode int
 	Stderr   string
@@ -75,7 +97,7 @@ func (e *ExitError) Unwrap() error { return e.Err }
 
 // CommandFactory constructs exec.Cmd instances. The production default
 // is exec.CommandContext; tests inject a factory that returns a fake
-// binary (typically `sh -c`).
+// binary.
 type CommandFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
 
 // Client is a Completer backed by the Codex CLI.
@@ -89,8 +111,7 @@ type Client struct {
 // Option configures a Client.
 type Option func(*Client)
 
-// WithTimeout caps how long a single Codex CLI call may run. Defaults
-// to 5 minutes to mirror the claudecli client.
+// WithTimeout caps how long a single Codex CLI call may run.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Client) { c.timeout = d }
 }
@@ -102,14 +123,16 @@ func WithCommandFactory(f CommandFactory) Option {
 }
 
 // WithExtraArgs appends additional flags before the prompt. Useful for
-// `--dangerously-bypass-approvals-and-sandbox`, etc. The core flags
-// (`exec`, `--json`) are always set.
+// `--dangerously-bypass-approvals-and-sandbox`,
+// `--skip-git-repo-check`, etc. The core flags (`exec`,
+// `--output-last-message`) are always set.
 func WithExtraArgs(args ...string) Option {
 	return func(c *Client) { c.extraArgs = append(c.extraArgs, args...) }
 }
 
 // WithModel pins the Codex CLI subprocess to a specific model via the
-// `--model` flag. Empty string is a no-op (the CLI picks its default).
+// `--model` flag (`SharedCliOptions.model` upstream). Empty string is a
+// no-op.
 func WithModel(model string) Option {
 	return func(c *Client) { c.model = model }
 }
@@ -126,15 +149,13 @@ func New(opts ...Option) *Client {
 	return c
 }
 
-// IsAvailable reports whether the `codex` binary is on PATH. Callers
-// use this for auto-detect logic. Cheap and safe to call repeatedly.
+// IsAvailable reports whether the `codex` binary is on PATH.
 func IsAvailable() bool {
 	_, err := exec.LookPath("codex")
 	return err == nil
 }
 
-// Model returns the model the client is pinned to via WithModel, or
-// empty string when the client uses the CLI's default.
+// Model returns the model the client is pinned to via WithModel.
 func (c *Client) Model() string { return c.model }
 
 // Complete is a convenience wrapper for CompleteWithSystem with an
@@ -143,37 +164,26 @@ func (c *Client) Complete(ctx context.Context, prompt string, target any) error 
 	return c.CompleteWithSystem(ctx, "", prompt, target)
 }
 
-// CompleteWithSystem runs `codex exec --json` and unmarshals the
-// assistant's JSON output into target. The Codex CLI has no separate
-// system-prompt flag in non-interactive mode, so when system is set it
-// is bundled into the prompt arg with a delimiter. Errors are typed:
-// NotInstalledError when the binary is missing, ExitError on non-zero
-// exit, ParseError for any JSON decode failure.
+// CompleteWithSystem runs `codex exec` and unmarshals the agent's
+// final message into target. The system prompt is bundled into the
+// prompt arg; codex non-interactive mode has no separate
+// system-prompt flag.
 func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, target any) error {
-	return c.runAndDecode(ctx, system, prompt, target)
+	return c.run(ctx, system, prompt, "", target)
 }
 
-// CompleteWithTool injects the tool's JSON Schema into the system
-// prompt and reuses the prose-to-JSON parser. The Codex CLI does not
-// expose native tool-use with a forced schema, so this falls back to
-// the same approach as claudecli. On parse failure a single recovery
-// call re-prompts Codex with its own raw output and asks for just the
-// JSON.
+// CompleteWithTool runs `codex exec --output-schema <schemafile>` so
+// codex enforces the agent's final message conforms to the tool's
+// InputSchema. On parse failure the client makes a single recovery
+// call asking the model to reformat the original prose as JSON.
 func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error {
-	augmented := system
-	if augmented != "" {
-		augmented += "\n\n"
+	schemaPath, cleanup, err := writeTempFile("codex-schema-*.json", tool.InputSchema)
+	if err != nil {
+		return fmt.Errorf("writing schema tempfile: %w", err)
 	}
-	augmented += fmt.Sprintf(
-		"## Response tool: %s\n%s\n\n"+
-			"CRITICAL INSTRUCTION — OUTPUT FORMAT:\n"+
-			"Respond with ONLY a single JSON object that conforms to this JSON Schema.\n"+
-			"No prose before or after. No markdown fences. No explanation. Just the raw JSON object.\n\n"+
-			"Schema:\n%s",
-		tool.Name, tool.Description, string(tool.InputSchema),
-	)
+	defer cleanup()
 
-	err := c.runAndDecode(ctx, augmented, prompt, target)
+	err = c.run(ctx, system, prompt, schemaPath, target)
 	if err == nil {
 		return nil
 	}
@@ -192,7 +202,7 @@ func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, to
 			"Original text:\n%s",
 		string(tool.InputSchema), truncate(parseErr.Raw, 4000),
 	)
-	return c.runAndDecode(ctx, "", recoveryPrompt, target)
+	return c.run(ctx, "", recoveryPrompt, schemaPath, target)
 }
 
 // CompleteWithTools falls back to single-turn CompleteWithTool using
@@ -207,47 +217,55 @@ func (c *Client) CompleteWithTools(ctx context.Context, system, prompt string, t
 	return fmt.Errorf("final tool %q not found in tools list", finalTool)
 }
 
-// envelope is the subset of Codex's `--json` result we care about.
-// Mirrors claudecli's shape so the parser is identical.
-type envelope struct {
-	Type    string `json:"type"`
-	Subtype string `json:"subtype"`
-	IsError bool   `json:"is_error"`
-	Result  string `json:"result"`
-}
-
-// runAndDecode executes the subprocess, decodes the envelope, and
-// unmarshals the extracted result into target.
-func (c *Client) runAndDecode(ctx context.Context, system, prompt string, target any) error {
-	env, err := c.runOnce(ctx, system, prompt)
+// run is the core invocation path. Creates an output tempfile, runs
+// codex, reads the tempfile, extracts JSON from the model's final
+// message, and unmarshals into target. schemaPath is optional — when
+// non-empty it's passed via --output-schema for native shape
+// enforcement.
+func (c *Client) run(ctx context.Context, system, prompt, schemaPath string, target any) error {
+	outputPath, cleanup, err := writeTempFile("codex-output-*.txt", nil)
 	if err != nil {
+		return fmt.Errorf("creating output tempfile: %w", err)
+	}
+	defer cleanup()
+
+	if err := c.runOnce(ctx, system, prompt, outputPath, schemaPath); err != nil {
 		return err
 	}
 
-	cleaned := extractJSON(env.Result)
+	raw, err := os.ReadFile(outputPath)
+	if err != nil {
+		return &ParseError{Raw: "", Err: fmt.Errorf("reading output file: %w", err)}
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return &ParseError{Raw: string(raw), Err: fmt.Errorf("codex wrote empty output file")}
+	}
+
+	cleaned := extractJSON(string(raw))
 	if err := json.Unmarshal([]byte(cleaned), target); err != nil {
 		slog.Debug("codex cli parse failed",
 			"err", err,
-			"raw_len", len(env.Result),
+			"raw_len", len(raw),
 			"cleaned_len", len(cleaned),
-			"raw_head", truncate(env.Result, 500),
+			"raw_head", truncate(string(raw), 500),
 			"cleaned_head", truncate(cleaned, 500),
 		)
-		return &ParseError{Raw: env.Result, Err: fmt.Errorf("decoding result into target: %w", err)}
+		return &ParseError{Raw: string(raw), Err: fmt.Errorf("decoding output into target: %w", err)}
 	}
 	return nil
 }
 
-// runOnce executes a single CLI subprocess attempt. Returns the decoded
-// envelope on success; typed errors on failure.
-func (c *Client) runOnce(ctx context.Context, system, prompt string) (envelope, error) {
+// runOnce executes a single codex subprocess. Returns typed errors
+// (NotInstalledError, ExitError) on failure. Side effect on success:
+// codex writes the agent's final message to outputPath.
+func (c *Client) runOnce(ctx context.Context, system, prompt, outputPath, schemaPath string) error {
 	start := time.Now()
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
 	bundled := bundlePrompt(system, prompt)
-	args := buildArgs(c.model, c.extraArgs, bundled)
+	args := buildArgs(c.model, outputPath, schemaPath, c.extraArgs, bundled)
 	cmd := c.cmdFactory(ctx, "codex", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -257,65 +275,82 @@ func (c *Client) runOnce(ctx context.Context, system, prompt string) (envelope, 
 
 	if err := cmd.Run(); err != nil {
 		if execErr, ok := err.(*exec.Error); ok {
-			return envelope{}, &NotInstalledError{Err: execErr}
+			return &NotInstalledError{Err: execErr}
 		}
 		if ctx.Err() != nil {
-			return envelope{}, fmt.Errorf("codex cli cancelled: %w", ctx.Err())
+			return fmt.Errorf("codex cli cancelled: %w", ctx.Err())
 		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return envelope{}, &ExitError{
+			return &ExitError{
 				ExitCode: exitErr.ExitCode(),
 				Stderr:   stderr.String(),
 				Err:      err,
 			}
 		}
-		return envelope{}, fmt.Errorf("running codex cli: %w", err)
+		return fmt.Errorf("running codex cli: %w", err)
 	}
 
 	slog.Debug("codex cli completed", "duration", time.Since(start))
-
-	var env envelope
-	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
-		return envelope{}, &ParseError{Raw: stdout.String(), Err: fmt.Errorf("decoding envelope: %w", err)}
-	}
-	if env.IsError {
-		return envelope{}, &ParseError{Raw: env.Result, Err: fmt.Errorf("codex cli returned is_error=true (subtype=%s)", env.Subtype)}
-	}
-	if env.Result == "" {
-		return envelope{}, &ParseError{Raw: stdout.String(), Err: fmt.Errorf("empty result field in envelope")}
-	}
-
-	return env, nil
+	return nil
 }
 
-// bundlePrompt produces the single positional prompt arg passed to
-// `codex exec`. When system is empty the user prompt is returned
-// verbatim; otherwise the two are joined with a labelled delimiter so
-// the model can tell them apart. Codex's non-interactive mode has no
-// separate system-prompt flag.
+// bundlePrompt prepends the system prompt to the user prompt with a
+// blank-line separator. No role markers — codex has no convention for
+// parsing them, and inventing `[system]/[user]` would be cargo-culting
+// from chat formats the model wasn't trained to honor.
 func bundlePrompt(system, prompt string) string {
 	if system == "" {
 		return prompt
 	}
-	return fmt.Sprintf("[system]\n%s\n\n[user]\n%s", system, prompt)
+	return system + "\n\n" + prompt
 }
 
 // buildArgs returns the argv after the binary name for one
-// `codex exec --json` invocation. Pulled out as a free function so
-// it's trivially unit-testable.
-func buildArgs(model string, extra []string, prompt string) []string {
-	args := make([]string, 0, 6+len(extra))
-	args = append(args, "exec", "--json")
+// `codex exec` invocation. Pulled out as a free function so it's
+// trivially unit-testable.
+//
+// outputPath is required. schemaPath is optional ("" = omit
+// --output-schema). model is optional ("" = omit --model). extras and
+// prompt are appended last so the prompt always lands as the final
+// positional arg.
+func buildArgs(model, outputPath, schemaPath string, extra []string, prompt string) []string {
+	args := make([]string, 0, 8+len(extra))
+	args = append(args, "exec", "--output-last-message", outputPath)
 	if model != "" {
 		args = append(args, "--model", model)
+	}
+	if schemaPath != "" {
+		args = append(args, "--output-schema", schemaPath)
 	}
 	args = append(args, extra...)
 	args = append(args, prompt)
 	return args
 }
 
-// truncate returns the first n characters of s (never panics on short
-// strings). Used purely for bounded debug logging of raw Codex output.
+// writeTempFile creates a temp file with the given pattern, writes
+// content to it (when non-nil), closes it, and returns its path plus a
+// cleanup func. Cleanup is safe to call multiple times.
+func writeTempFile(pattern string, content []byte) (string, func(), error) {
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", func() {}, err
+	}
+	path := f.Name()
+	if content != nil {
+		if _, err := f.Write(content); err != nil {
+			f.Close()
+			os.Remove(path)
+			return "", func() {}, err
+		}
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(path)
+		return "", func() {}, err
+	}
+	return path, func() { os.Remove(path) }, nil
+}
+
+// truncate returns the first n characters of s.
 func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s
@@ -323,12 +358,11 @@ func truncate(s string, n int) string {
 	return s[:n]
 }
 
-// extractJSON pulls a JSON object out of Codex's result string,
-// tolerating prose preambles and markdown fences. Strategy: prefer
-// string-aware brace matching from the first `{` to its balanced `}`,
-// which handles bare objects, prose-wrapped objects, AND fenced
-// objects in one pass. Fenced extraction is a last-resort fallback
-// for non-object payloads.
+// extractJSON pulls a JSON object out of codex's output text,
+// tolerating prose preambles and markdown fences. Even with
+// --output-schema active, models occasionally still wrap their final
+// response in ```json fences; this lets us recover instead of
+// failing parse.
 func extractJSON(text string) string {
 	if obj := extractBraceObject(text); obj != "" {
 		return obj
@@ -351,17 +385,16 @@ func extractFencedBlock(text string) string {
 	if nl := strings.IndexByte(text[bodyStart:], '\n'); nl != -1 {
 		bodyStart += nl + 1
 	}
-	close := strings.Index(text[bodyStart:], fence)
-	if close == -1 {
+	end := strings.Index(text[bodyStart:], fence)
+	if end == -1 {
 		return ""
 	}
-	return text[bodyStart : bodyStart+close]
+	return text[bodyStart : bodyStart+end]
 }
 
 // extractBraceObject scans for the first `{` and walks forward
 // counting braces (respecting JSON string literals) until it finds the
-// matching closing `}`. Returns the balanced slice, or empty string if
-// no match.
+// matching closing `}`.
 func extractBraceObject(text string) string {
 	start := strings.IndexByte(text, '{')
 	if start == -1 {

--- a/internal/agents/codex/client.go
+++ b/internal/agents/codex/client.go
@@ -1,0 +1,401 @@
+// Package codex implements a Completer that shells out to the local
+// OpenAI Codex CLI (`codex exec --json`) instead of calling an Anthropic
+// HTTP API.
+//
+// This is the first non-Anthropic completer for VAIrdict — it lets users
+// with the Codex CLI installed run vairdict end-to-end without an
+// Anthropic key, and proves the completer interface generalises across
+// CLI families. Mirrors internal/agents/claudecli in shape so the
+// follow-up registry work (#130) can register both behind a single
+// resolver path.
+//
+// The Client is safe to share across goroutines. Each CompleteWithSystem
+// call spawns a fresh `codex` subprocess and blocks until it finishes.
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/vairdict/vairdict/internal/agents/claude"
+)
+
+// NotInstalledError is returned when the `codex` binary cannot be found
+// on PATH. Callers can use errors.As to surface a friendlier
+// install-me message.
+type NotInstalledError struct {
+	Err error
+}
+
+func (e *NotInstalledError) Error() string {
+	return fmt.Sprintf("codex CLI not installed: %v", e.Err)
+}
+
+func (e *NotInstalledError) Unwrap() error { return e.Err }
+
+// ParseError is returned when the CLI produced output that could not be
+// decoded into the envelope or the caller's target struct. Raw carries
+// the original (truncated) stdout so operators can see what Codex
+// actually said.
+type ParseError struct {
+	Raw string
+	Err error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("codex cli parse error: %v (raw: %.200s)", e.Err, e.Raw)
+}
+
+func (e *ParseError) Unwrap() error { return e.Err }
+
+// ExitError is returned when `codex` exits with a non-zero status.
+// Stderr carries the truncated stderr output so callers don't see a
+// bare "exit status 1".
+type ExitError struct {
+	ExitCode int
+	Stderr   string
+	Err      error
+}
+
+func (e *ExitError) Error() string {
+	stderr := strings.TrimRight(e.Stderr, "\n")
+	if stderr == "" {
+		return fmt.Sprintf("codex cli exited with status %d", e.ExitCode)
+	}
+	return fmt.Sprintf("codex cli exited with status %d: %s", e.ExitCode, stderr)
+}
+
+func (e *ExitError) Unwrap() error { return e.Err }
+
+// CommandFactory constructs exec.Cmd instances. The production default
+// is exec.CommandContext; tests inject a factory that returns a fake
+// binary (typically `sh -c`).
+type CommandFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+// Client is a Completer backed by the Codex CLI.
+type Client struct {
+	timeout    time.Duration
+	cmdFactory CommandFactory
+	extraArgs  []string
+	model      string
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithTimeout caps how long a single Codex CLI call may run. Defaults
+// to 5 minutes to mirror the claudecli client.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) { c.timeout = d }
+}
+
+// WithCommandFactory overrides how subprocesses are constructed. Tests
+// use this to intercept exec without touching the real `codex` binary.
+func WithCommandFactory(f CommandFactory) Option {
+	return func(c *Client) { c.cmdFactory = f }
+}
+
+// WithExtraArgs appends additional flags before the prompt. Useful for
+// `--dangerously-bypass-approvals-and-sandbox`, etc. The core flags
+// (`exec`, `--json`) are always set.
+func WithExtraArgs(args ...string) Option {
+	return func(c *Client) { c.extraArgs = append(c.extraArgs, args...) }
+}
+
+// WithModel pins the Codex CLI subprocess to a specific model via the
+// `--model` flag. Empty string is a no-op (the CLI picks its default).
+func WithModel(model string) Option {
+	return func(c *Client) { c.model = model }
+}
+
+// New constructs a Client with the given options.
+func New(opts ...Option) *Client {
+	c := &Client{
+		timeout:    5 * time.Minute,
+		cmdFactory: exec.CommandContext,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// IsAvailable reports whether the `codex` binary is on PATH. Callers
+// use this for auto-detect logic. Cheap and safe to call repeatedly.
+func IsAvailable() bool {
+	_, err := exec.LookPath("codex")
+	return err == nil
+}
+
+// Model returns the model the client is pinned to via WithModel, or
+// empty string when the client uses the CLI's default.
+func (c *Client) Model() string { return c.model }
+
+// Complete is a convenience wrapper for CompleteWithSystem with an
+// empty system prompt.
+func (c *Client) Complete(ctx context.Context, prompt string, target any) error {
+	return c.CompleteWithSystem(ctx, "", prompt, target)
+}
+
+// CompleteWithSystem runs `codex exec --json` and unmarshals the
+// assistant's JSON output into target. The Codex CLI has no separate
+// system-prompt flag in non-interactive mode, so when system is set it
+// is bundled into the prompt arg with a delimiter. Errors are typed:
+// NotInstalledError when the binary is missing, ExitError on non-zero
+// exit, ParseError for any JSON decode failure.
+func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, target any) error {
+	return c.runAndDecode(ctx, system, prompt, target)
+}
+
+// CompleteWithTool injects the tool's JSON Schema into the system
+// prompt and reuses the prose-to-JSON parser. The Codex CLI does not
+// expose native tool-use with a forced schema, so this falls back to
+// the same approach as claudecli. On parse failure a single recovery
+// call re-prompts Codex with its own raw output and asks for just the
+// JSON.
+func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error {
+	augmented := system
+	if augmented != "" {
+		augmented += "\n\n"
+	}
+	augmented += fmt.Sprintf(
+		"## Response tool: %s\n%s\n\n"+
+			"CRITICAL INSTRUCTION — OUTPUT FORMAT:\n"+
+			"Respond with ONLY a single JSON object that conforms to this JSON Schema.\n"+
+			"No prose before or after. No markdown fences. No explanation. Just the raw JSON object.\n\n"+
+			"Schema:\n%s",
+		tool.Name, tool.Description, string(tool.InputSchema),
+	)
+
+	err := c.runAndDecode(ctx, augmented, prompt, target)
+	if err == nil {
+		return nil
+	}
+
+	parseErr, ok := err.(*ParseError)
+	if !ok || parseErr.Raw == "" {
+		return err
+	}
+
+	slog.Info("codex cli tool call failed, attempting recovery", "original_err", err)
+
+	recoveryPrompt := fmt.Sprintf(
+		"The following text was supposed to be a JSON object conforming to this schema:\n%s\n\n"+
+			"But it was returned as prose. Extract the information and return ONLY the JSON object. "+
+			"No markdown, no explanation, no fences — just the JSON.\n\n"+
+			"Original text:\n%s",
+		string(tool.InputSchema), truncate(parseErr.Raw, 4000),
+	)
+	return c.runAndDecode(ctx, "", recoveryPrompt, target)
+}
+
+// CompleteWithTools falls back to single-turn CompleteWithTool using
+// only the final tool. The CLI backend cannot do multi-turn tool use,
+// so auxiliary tools like check_path are silently unavailable.
+func (c *Client) CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, _ map[string]claude.ToolHandler, target any) error {
+	for _, t := range tools {
+		if t.Name == finalTool {
+			return c.CompleteWithTool(ctx, system, prompt, t, target)
+		}
+	}
+	return fmt.Errorf("final tool %q not found in tools list", finalTool)
+}
+
+// envelope is the subset of Codex's `--json` result we care about.
+// Mirrors claudecli's shape so the parser is identical.
+type envelope struct {
+	Type    string `json:"type"`
+	Subtype string `json:"subtype"`
+	IsError bool   `json:"is_error"`
+	Result  string `json:"result"`
+}
+
+// runAndDecode executes the subprocess, decodes the envelope, and
+// unmarshals the extracted result into target.
+func (c *Client) runAndDecode(ctx context.Context, system, prompt string, target any) error {
+	env, err := c.runOnce(ctx, system, prompt)
+	if err != nil {
+		return err
+	}
+
+	cleaned := extractJSON(env.Result)
+	if err := json.Unmarshal([]byte(cleaned), target); err != nil {
+		slog.Debug("codex cli parse failed",
+			"err", err,
+			"raw_len", len(env.Result),
+			"cleaned_len", len(cleaned),
+			"raw_head", truncate(env.Result, 500),
+			"cleaned_head", truncate(cleaned, 500),
+		)
+		return &ParseError{Raw: env.Result, Err: fmt.Errorf("decoding result into target: %w", err)}
+	}
+	return nil
+}
+
+// runOnce executes a single CLI subprocess attempt. Returns the decoded
+// envelope on success; typed errors on failure.
+func (c *Client) runOnce(ctx context.Context, system, prompt string) (envelope, error) {
+	start := time.Now()
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	bundled := bundlePrompt(system, prompt)
+	args := buildArgs(c.model, c.extraArgs, bundled)
+	cmd := c.cmdFactory(ctx, "codex", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	slog.Debug("running codex cli", "args", args, "timeout", c.timeout)
+
+	if err := cmd.Run(); err != nil {
+		if execErr, ok := err.(*exec.Error); ok {
+			return envelope{}, &NotInstalledError{Err: execErr}
+		}
+		if ctx.Err() != nil {
+			return envelope{}, fmt.Errorf("codex cli cancelled: %w", ctx.Err())
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return envelope{}, &ExitError{
+				ExitCode: exitErr.ExitCode(),
+				Stderr:   stderr.String(),
+				Err:      err,
+			}
+		}
+		return envelope{}, fmt.Errorf("running codex cli: %w", err)
+	}
+
+	slog.Debug("codex cli completed", "duration", time.Since(start))
+
+	var env envelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		return envelope{}, &ParseError{Raw: stdout.String(), Err: fmt.Errorf("decoding envelope: %w", err)}
+	}
+	if env.IsError {
+		return envelope{}, &ParseError{Raw: env.Result, Err: fmt.Errorf("codex cli returned is_error=true (subtype=%s)", env.Subtype)}
+	}
+	if env.Result == "" {
+		return envelope{}, &ParseError{Raw: stdout.String(), Err: fmt.Errorf("empty result field in envelope")}
+	}
+
+	return env, nil
+}
+
+// bundlePrompt produces the single positional prompt arg passed to
+// `codex exec`. When system is empty the user prompt is returned
+// verbatim; otherwise the two are joined with a labelled delimiter so
+// the model can tell them apart. Codex's non-interactive mode has no
+// separate system-prompt flag.
+func bundlePrompt(system, prompt string) string {
+	if system == "" {
+		return prompt
+	}
+	return fmt.Sprintf("[system]\n%s\n\n[user]\n%s", system, prompt)
+}
+
+// buildArgs returns the argv after the binary name for one
+// `codex exec --json` invocation. Pulled out as a free function so
+// it's trivially unit-testable.
+func buildArgs(model string, extra []string, prompt string) []string {
+	args := make([]string, 0, 6+len(extra))
+	args = append(args, "exec", "--json")
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	args = append(args, extra...)
+	args = append(args, prompt)
+	return args
+}
+
+// truncate returns the first n characters of s (never panics on short
+// strings). Used purely for bounded debug logging of raw Codex output.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// extractJSON pulls a JSON object out of Codex's result string,
+// tolerating prose preambles and markdown fences. Strategy: prefer
+// string-aware brace matching from the first `{` to its balanced `}`,
+// which handles bare objects, prose-wrapped objects, AND fenced
+// objects in one pass. Fenced extraction is a last-resort fallback
+// for non-object payloads.
+func extractJSON(text string) string {
+	if obj := extractBraceObject(text); obj != "" {
+		return obj
+	}
+	if fenced := extractFencedBlock(text); fenced != "" {
+		return fenced
+	}
+	return strings.TrimSpace(text)
+}
+
+// extractFencedBlock returns the content between the first pair of ```
+// fences, or empty string if no complete pair is found.
+func extractFencedBlock(text string) string {
+	const fence = "```"
+	open := strings.Index(text, fence)
+	if open == -1 {
+		return ""
+	}
+	bodyStart := open + len(fence)
+	if nl := strings.IndexByte(text[bodyStart:], '\n'); nl != -1 {
+		bodyStart += nl + 1
+	}
+	close := strings.Index(text[bodyStart:], fence)
+	if close == -1 {
+		return ""
+	}
+	return text[bodyStart : bodyStart+close]
+}
+
+// extractBraceObject scans for the first `{` and walks forward
+// counting braces (respecting JSON string literals) until it finds the
+// matching closing `}`. Returns the balanced slice, or empty string if
+// no match.
+func extractBraceObject(text string) string {
+	start := strings.IndexByte(text, '{')
+	if start == -1 {
+		return ""
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(text); i++ {
+		c := text[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch c {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return text[start : i+1]
+			}
+		}
+	}
+	return ""
+}

--- a/internal/agents/codex/client_test.go
+++ b/internal/agents/codex/client_test.go
@@ -1,0 +1,562 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vairdict/vairdict/internal/agents/claude"
+)
+
+// fakeCmd builds an exec.Cmd that runs `sh -c script` via the given ctx so
+// each test can script stdout/stderr/exit-code precisely without touching
+// the real codex binary.
+func fakeCmd(ctx context.Context, script string) *exec.Cmd {
+	return exec.CommandContext(ctx, "sh", "-c", script)
+}
+
+// stdoutCmd returns a fake exec.Cmd that prints the given bytes verbatim
+// on stdout. Bytes are passed through an env var to sidestep shell quoting.
+func stdoutCmd(ctx context.Context, stdout string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "sh", "-c", `printf '%s' "$FAKE_STDOUT"`)
+	cmd.Env = append(os.Environ(), "FAKE_STDOUT="+stdout)
+	return cmd
+}
+
+// stdoutCmdWithStderr is a fake exec.Cmd that prints stdout AND stderr
+// and exits with the given code. Used for non-zero-exit error tests.
+func stdoutCmdWithStderr(ctx context.Context, stdout, stderr string, exit int) *exec.Cmd {
+	script := `printf '%s' "$FAKE_STDOUT"; printf '%s' "$FAKE_STDERR" >&2; exit ${FAKE_EXIT:-0}`
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"FAKE_STDOUT="+stdout,
+		"FAKE_STDERR="+stderr,
+		"FAKE_EXIT="+itoa(exit),
+	)
+	return cmd
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}
+
+// --- Core CompleteWithSystem behaviour ---
+
+func TestCompleteWithSystem_HappyPath(t *testing.T) {
+	envelope := `{"type":"result","is_error":false,"result":"{\"answer\":42,\"label\":\"ok\"}"}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got struct {
+		Answer int    `json:"answer"`
+		Label  string `json:"label"`
+	}
+	if err := c.CompleteWithSystem(context.Background(), "sys", "hi", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Answer != 42 || got.Label != "ok" {
+		t.Errorf("got %+v, want {42 ok}", got)
+	}
+}
+
+func TestCompleteWithSystem_FencedResult(t *testing.T) {
+	// Codex sometimes wraps the result in ```json … ``` fences.
+	envelope := "{\"type\":\"result\",\"is_error\":false,\"result\":\"```json\\n{\\\"x\\\":1}\\n```\"}"
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got struct {
+		X int `json:"x"`
+	}
+	if err := c.Complete(context.Background(), "hi", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.X != 1 {
+		t.Errorf("got %+v, want {1}", got)
+	}
+}
+
+func TestCompleteWithSystem_EnvelopeParseError(t *testing.T) {
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return stdoutCmd(ctx, "not json at all")
+	}))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(parseErr.Raw, "not json") {
+		t.Errorf("expected raw to contain stdout, got %q", parseErr.Raw)
+	}
+}
+
+func TestCompleteWithSystem_IsErrorEnvelope(t *testing.T) {
+	envelope := `{"type":"result","subtype":"error_during_execution","is_error":true,"result":"oh no"}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(parseErr.Err.Error(), "is_error=true") {
+		t.Errorf("expected is_error message, got %v", parseErr.Err)
+	}
+}
+
+func TestCompleteWithSystem_EmptyResult(t *testing.T) {
+	envelope := `{"type":"result","is_error":false,"result":""}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestCompleteWithSystem_TargetDecodeFailure(t *testing.T) {
+	// Envelope ok, result ok JSON but not an object — decoding into a
+	// struct target should surface as ParseError.
+	envelope := `{"type":"result","is_error":false,"result":"\"a string\""}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got struct{ X int }
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestCompleteWithSystem_NonZeroExit(t *testing.T) {
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeCmd(ctx, "echo 'boom' >&2; exit 2")
+	}))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+	if exitErr.ExitCode != 2 {
+		t.Errorf("exit code = %d, want 2", exitErr.ExitCode)
+	}
+	if !strings.Contains(exitErr.Stderr, "boom") {
+		t.Errorf("stderr = %q, want to contain 'boom'", exitErr.Stderr)
+	}
+}
+
+func TestCompleteWithSystem_NotInstalled(t *testing.T) {
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "nonexistent-binary-xyz-12345")
+	}))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var ni *NotInstalledError
+	if !errors.As(err, &ni) {
+		t.Fatalf("expected NotInstalledError, got %T: %v", err, err)
+	}
+}
+
+func TestCompleteWithSystem_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeCmd(ctx, "sleep 30")
+	}))
+
+	var got map[string]any
+	err := c.CompleteWithSystem(ctx, "", "hi", &got)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+	if !strings.Contains(err.Error(), "cancelled") && !strings.Contains(err.Error(), "context") {
+		t.Errorf("expected cancellation error, got %v", err)
+	}
+}
+
+func TestCompleteWithSystem_Timeout(t *testing.T) {
+	c := New(
+		WithTimeout(50*time.Millisecond),
+		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			return fakeCmd(ctx, "sleep 30")
+		}),
+	)
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+// --- Argv shape ---
+
+func TestCompleteWithSystem_ArgsIncludeSubcommandJSONAndExtras(t *testing.T) {
+	// Production argv shape: codex exec --json [--model M] [<extra>...] <prompt>.
+	// System prompt is bundled into the prompt arg (codex has no separate
+	// --system flag in non-interactive mode), so the prompt arg must
+	// contain the system text when system is set.
+	var captured []string
+	envelope := `{"type":"result","is_error":false,"result":"{}"}`
+	c := New(
+		WithExtraArgs("--dangerously-bypass-approvals-and-sandbox"),
+		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			captured = append([]string{name}, args...)
+			return stdoutCmd(ctx, envelope)
+		}),
+	)
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "you are a judge", "do the thing", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(captured) == 0 {
+		t.Fatalf("nothing captured")
+	}
+	if captured[0] != "codex" {
+		t.Errorf("binary = %q, want codex", captured[0])
+	}
+	joined := strings.Join(captured, " ")
+	for _, w := range []string{"exec", "--json", "--dangerously-bypass-approvals-and-sandbox"} {
+		if !strings.Contains(joined, w) {
+			t.Errorf("captured args %q missing %q", joined, w)
+		}
+	}
+	// Prompt must be last and must contain both the system prompt and
+	// the user prompt.
+	last := captured[len(captured)-1]
+	if !strings.Contains(last, "you are a judge") {
+		t.Errorf("prompt arg %q must contain system prompt", last)
+	}
+	if !strings.Contains(last, "do the thing") {
+		t.Errorf("prompt arg %q must contain user prompt", last)
+	}
+}
+
+func TestCompleteWithSystem_WithModelAddsFlag(t *testing.T) {
+	var captured []string
+	envelope := `{"type":"result","is_error":false,"result":"{}"}`
+	c := New(
+		WithModel("gpt-5-codex"),
+		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			captured = append([]string{name}, args...)
+			return stdoutCmd(ctx, envelope)
+		}),
+	)
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "", "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Model() != "gpt-5-codex" {
+		t.Errorf("client Model() = %q, want gpt-5-codex", c.Model())
+	}
+	joined := strings.Join(captured, " ")
+	if !strings.Contains(joined, "--model gpt-5-codex") {
+		t.Errorf("captured args missing --model gpt-5-codex: %v", captured)
+	}
+}
+
+func TestCompleteWithSystem_NoModelSkipsFlag(t *testing.T) {
+	var captured []string
+	envelope := `{"type":"result","is_error":false,"result":"{}"}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		captured = append([]string{name}, args...)
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "", "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, a := range captured {
+		if a == "--model" {
+			t.Errorf("client without WithModel must not add --model flag: %v", captured)
+		}
+	}
+}
+
+func TestCompleteWithSystem_NoSystemPromptKeepsPromptClean(t *testing.T) {
+	// When system is empty, the prompt arg is the user prompt verbatim —
+	// no bundled-in system fragment, no prefix.
+	var captured []string
+	envelope := `{"type":"result","is_error":false,"result":"{}"}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		captured = append([]string{name}, args...)
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "", "just the prompt", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if captured[len(captured)-1] != "just the prompt" {
+		t.Errorf("expected last arg to equal user prompt verbatim when system empty, got %q", captured[len(captured)-1])
+	}
+}
+
+// --- Tool use ---
+
+func TestCompleteWithTool_InjectsSchemaAndParsesResult(t *testing.T) {
+	// CompleteWithTool must (a) inject the tool's JSON Schema into the
+	// system prompt the subprocess sees, and (b) parse the envelope's
+	// result back into the target as plain JSON.
+	var captured []string
+	envelope := `{"type":"result","is_error":false,"result":"{\"verdict\":\"pass\",\"score\":0.9}"}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		captured = append([]string{name}, args...)
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	tool := claude.Tool{
+		Name:        "verdict",
+		Description: "judge verdict",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"verdict":{"type":"string"},"score":{"type":"number"}}}`),
+	}
+
+	var got struct {
+		Verdict string  `json:"verdict"`
+		Score   float64 `json:"score"`
+	}
+	if err := c.CompleteWithTool(context.Background(), "you are a judge", "judge it", tool, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Verdict != "pass" || got.Score != 0.9 {
+		t.Errorf("got %+v, want {pass 0.9}", got)
+	}
+
+	// The schema must reach the subprocess somewhere in the prompt arg.
+	last := captured[len(captured)-1]
+	if !strings.Contains(last, "verdict") {
+		t.Errorf("prompt arg must mention tool name, got %q", last)
+	}
+	if !strings.Contains(last, `"score"`) {
+		t.Errorf("prompt arg must include schema fragment, got %q", last)
+	}
+}
+
+func TestCompleteWithTool_RecoveryOnProseResult(t *testing.T) {
+	// First subprocess call returns prose that won't parse as JSON.
+	// Client must retry once with a recovery prompt and parse the
+	// second response. The recovery call's prompt arg must reference
+	// the schema and contain the original prose.
+	proseEnvelope := `{"type":"result","is_error":false,"result":"sure thing! the answer is x=7"}`
+	recoveryEnvelope := `{"type":"result","is_error":false,"result":"{\"x\":7}"}`
+
+	calls := 0
+	var capturedRuns [][]string
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		capturedRuns = append(capturedRuns, append([]string{name}, args...))
+		calls++
+		switch calls {
+		case 1:
+			return stdoutCmd(ctx, proseEnvelope)
+		default:
+			return stdoutCmd(ctx, recoveryEnvelope)
+		}
+	}))
+
+	tool := claude.Tool{
+		Name:        "answer",
+		Description: "give answer",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"x":{"type":"integer"}}}`),
+	}
+
+	var got struct {
+		X int `json:"x"`
+	}
+	if err := c.CompleteWithTool(context.Background(), "", "what is x?", tool, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.X != 7 {
+		t.Errorf("got %+v, want {7}", got)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 subprocess calls (initial + recovery), got %d", calls)
+	}
+
+	// Recovery prompt must include the prose that failed to parse.
+	recoveryPromptArg := capturedRuns[1][len(capturedRuns[1])-1]
+	if !strings.Contains(recoveryPromptArg, "x=7") {
+		t.Errorf("recovery prompt should include original prose, got %q", recoveryPromptArg)
+	}
+}
+
+func TestCompleteWithTools_RoutesToFinalTool(t *testing.T) {
+	envelope := `{"type":"result","is_error":false,"result":"{\"verdict\":\"pass\"}"}`
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return stdoutCmd(ctx, envelope)
+	}))
+
+	tools := []claude.Tool{
+		{
+			Name:        "check_path",
+			Description: "auxiliary",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		{
+			Name:        "verdict",
+			Description: "final",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"verdict":{"type":"string"}}}`),
+		},
+	}
+
+	var got struct {
+		Verdict string `json:"verdict"`
+	}
+	if err := c.CompleteWithTools(context.Background(), "", "p", tools, "verdict", nil, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Verdict != "pass" {
+		t.Errorf("got %+v, want {pass}", got)
+	}
+}
+
+func TestCompleteWithTools_UnknownFinalToolErrors(t *testing.T) {
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return stdoutCmd(ctx, `{"type":"result","is_error":false,"result":"{}"}`)
+	}))
+
+	tools := []claude.Tool{{Name: "verdict", InputSchema: json.RawMessage(`{}`)}}
+
+	var got map[string]any
+	err := c.CompleteWithTools(context.Background(), "", "p", tools, "missing_tool", nil, &got)
+	if err == nil {
+		t.Fatalf("expected error for unknown final tool")
+	}
+	if !strings.Contains(err.Error(), "missing_tool") {
+		t.Errorf("error should name the missing tool, got %v", err)
+	}
+}
+
+// --- Availability + helpers ---
+
+func TestIsAvailable_SmokeTest(t *testing.T) {
+	// Just ensure it doesn't panic and returns a bool — we can't assume
+	// the test host has codex installed or not.
+	_ = IsAvailable()
+}
+
+func TestExtractJSON(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"bare", `{"x":1}`, `{"x":1}`},
+		{"fenced_json", "```json\n{\"x\":1}\n```", `{"x":1}`},
+		{"fenced_plain", "```\n{\"x\":2}\n```", `{"x":2}`},
+		{"padded", "   {\"x\":3}   ", `{"x":3}`},
+		{
+			"preamble_then_fence",
+			"Here is the answer.\n\n```json\n{\"x\":4}\n```",
+			`{"x":4}`,
+		},
+		{
+			"prose_then_bare_object",
+			"Here is the result: {\"x\":6} done.",
+			`{"x":6}`,
+		},
+		{
+			"string_with_braces",
+			`{"msg":"a{b}c","n":7}`,
+			`{"msg":"a{b}c","n":7}`,
+		},
+		{
+			"escaped_quote_in_string",
+			`{"msg":"he said \"hi\"","n":8}`,
+			`{"msg":"he said \"hi\"","n":8}`,
+		},
+		{
+			"nested_object",
+			`prefix {"a":{"b":{"c":9}}} suffix`,
+			`{"a":{"b":{"c":9}}}`,
+		},
+		{
+			// Brace matching ignores braces and fences inside string
+			// literals — same regression coverage as claudecli.
+			"fenced_with_embedded_fence_in_string",
+			"```json\n{\"requirements\":\"see ```html\\nfoo\\n``` for an example\",\"n\":10}\n```",
+			"{\"requirements\":\"see ```html\\nfoo\\n``` for an example\",\"n\":10}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractJSON(tc.in)
+			if got != tc.want {
+				t.Errorf("extractJSON(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildArgs_Shape(t *testing.T) {
+	t.Run("base_no_model_no_extra", func(t *testing.T) {
+		args := buildArgs("", nil, "user prompt")
+		if args[0] != "exec" {
+			t.Errorf("first arg must be subcommand exec, got %q", args[0])
+		}
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "--json") {
+			t.Errorf("missing --json: %s", joined)
+		}
+		if strings.Contains(joined, "--model") {
+			t.Errorf("must not include --model when empty: %s", joined)
+		}
+		if args[len(args)-1] != "user prompt" {
+			t.Errorf("prompt must be last: %v", args)
+		}
+	})
+
+	t.Run("with_model_and_extra", func(t *testing.T) {
+		args := buildArgs("gpt-5-codex", []string{"--dangerously-bypass-approvals-and-sandbox"}, "p")
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "--model gpt-5-codex") {
+			t.Errorf("missing --model gpt-5-codex: %s", joined)
+		}
+		if !strings.Contains(joined, "--dangerously-bypass-approvals-and-sandbox") {
+			t.Errorf("missing extra arg: %s", joined)
+		}
+		if args[len(args)-1] != "p" {
+			t.Errorf("prompt must be last: %v", args)
+		}
+	})
+}

--- a/internal/agents/codex/client_test.go
+++ b/internal/agents/codex/client_test.go
@@ -199,7 +199,12 @@ func TestCompleteWithSystem_ContextCancelled(t *testing.T) {
 	cancel() // cancel immediately
 
 	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return fakeCmd(ctx, "sleep 30")
+		// `exec sleep 1` makes sh replace itself with sleep so the
+		// kill on ctx cancel reaps the actual sleeper and unblocks
+		// cmd.Run immediately. Bare `sh -c "sleep 1"` leaves an
+		// orphaned sleep holding the stdout pipe, which makes the
+		// test wait the full sleep duration.
+		return fakeCmd(ctx, "exec sleep 1")
 	}))
 
 	var got map[string]any
@@ -216,7 +221,7 @@ func TestCompleteWithSystem_Timeout(t *testing.T) {
 	c := New(
 		WithTimeout(50*time.Millisecond),
 		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-			return fakeCmd(ctx, "sleep 30")
+			return fakeCmd(ctx, "exec sleep 5")
 		}),
 	)
 

--- a/internal/agents/codex/client_test.go
+++ b/internal/agents/codex/client_test.go
@@ -13,32 +13,53 @@ import (
 	"github.com/vairdict/vairdict/internal/agents/claude"
 )
 
-// fakeCmd builds an exec.Cmd that runs `sh -c script` via the given ctx so
-// each test can script stdout/stderr/exit-code precisely without touching
-// the real codex binary.
+// --- Test helpers ---
+
+// fakeCmd builds an exec.Cmd that runs `sh -c script` via the given ctx
+// so each test can script stdout/stderr/exit-code precisely without
+// touching the real codex binary.
 func fakeCmd(ctx context.Context, script string) *exec.Cmd {
 	return exec.CommandContext(ctx, "sh", "-c", script)
 }
 
-// stdoutCmd returns a fake exec.Cmd that prints the given bytes verbatim
-// on stdout. Bytes are passed through an env var to sidestep shell quoting.
-func stdoutCmd(ctx context.Context, stdout string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "sh", "-c", `printf '%s' "$FAKE_STDOUT"`)
-	cmd.Env = append(os.Environ(), "FAKE_STDOUT="+stdout)
-	return cmd
+// flagValue returns the value following the named flag in args, or "" if
+// the flag is not present or has no value following it.
+func flagValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
 }
 
-// stdoutCmdWithStderr is a fake exec.Cmd that prints stdout AND stderr
-// and exits with the given code. Used for non-zero-exit error tests.
-func stdoutCmdWithStderr(ctx context.Context, stdout, stderr string, exit int) *exec.Cmd {
-	script := `printf '%s' "$FAKE_STDOUT"; printf '%s' "$FAKE_STDERR" >&2; exit ${FAKE_EXIT:-0}`
+// writeAndExitCmd returns a sh -c command that writes content to path
+// (when path is non-empty) and exits with the given code. Used by the
+// fake command factory to simulate codex writing the final agent
+// message to the file passed via --output-last-message.
+func writeAndExitCmd(ctx context.Context, path, content, stderr string, exit int) *exec.Cmd {
+	script := `if [ -n "$FAKE_PATH" ]; then printf '%s' "$FAKE_CONTENT" > "$FAKE_PATH"; fi; if [ -n "$FAKE_STDERR" ]; then printf '%s' "$FAKE_STDERR" >&2; fi; exit ${FAKE_EXIT:-0}`
 	cmd := exec.CommandContext(ctx, "sh", "-c", script)
 	cmd.Env = append(os.Environ(),
-		"FAKE_STDOUT="+stdout,
+		"FAKE_CONTENT="+content,
+		"FAKE_PATH="+path,
 		"FAKE_STDERR="+stderr,
 		"FAKE_EXIT="+itoa(exit),
 	)
 	return cmd
+}
+
+// writingFactory returns a CommandFactory that captures argv into
+// captured (if non-nil) and writes content to whatever path follows
+// --output-last-message in the args.
+func writingFactory(content string, captured *[][]string) CommandFactory {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if captured != nil {
+			*captured = append(*captured, append([]string{name}, args...))
+		}
+		path := flagValue(args, "--output-last-message")
+		return writeAndExitCmd(ctx, path, content, "", 0)
+	}
 }
 
 func itoa(n int) string {
@@ -64,10 +85,7 @@ func itoa(n int) string {
 // --- Core CompleteWithSystem behaviour ---
 
 func TestCompleteWithSystem_HappyPath(t *testing.T) {
-	envelope := `{"type":"result","is_error":false,"result":"{\"answer\":42,\"label\":\"ok\"}"}`
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return stdoutCmd(ctx, envelope)
-	}))
+	c := New(WithCommandFactory(writingFactory(`{"answer":42,"label":"ok"}`, nil)))
 
 	var got struct {
 		Answer int    `json:"answer"`
@@ -82,11 +100,9 @@ func TestCompleteWithSystem_HappyPath(t *testing.T) {
 }
 
 func TestCompleteWithSystem_FencedResult(t *testing.T) {
-	// Codex sometimes wraps the result in ```json … ``` fences.
-	envelope := "{\"type\":\"result\",\"is_error\":false,\"result\":\"```json\\n{\\\"x\\\":1}\\n```\"}"
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return stdoutCmd(ctx, envelope)
-	}))
+	// Even with --output-schema available, models sometimes still wrap
+	// output in ```json … ``` fences. extractJSON tolerates that.
+	c := New(WithCommandFactory(writingFactory("```json\n{\"x\":1}\n```", nil)))
 
 	var got struct {
 		X int `json:"x"`
@@ -99,9 +115,13 @@ func TestCompleteWithSystem_FencedResult(t *testing.T) {
 	}
 }
 
-func TestCompleteWithSystem_EnvelopeParseError(t *testing.T) {
+func TestCompleteWithSystem_OutputFileMissing(t *testing.T) {
+	// Process exits 0 but never writes the output file. Real failure
+	// mode if codex crashed silently or was killed mid-flight.
 	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return stdoutCmd(ctx, "not json at all")
+		// Empty FAKE_PATH means the script does not write the file,
+		// even though the actual --output-last-message path was real.
+		return exec.CommandContext(ctx, "sh", "-c", "exit 0")
 	}))
 
 	var got map[string]any
@@ -110,33 +130,10 @@ func TestCompleteWithSystem_EnvelopeParseError(t *testing.T) {
 	if !errors.As(err, &parseErr) {
 		t.Fatalf("expected ParseError, got %T: %v", err, err)
 	}
-	if !strings.Contains(parseErr.Raw, "not json") {
-		t.Errorf("expected raw to contain stdout, got %q", parseErr.Raw)
-	}
 }
 
-func TestCompleteWithSystem_IsErrorEnvelope(t *testing.T) {
-	envelope := `{"type":"result","subtype":"error_during_execution","is_error":true,"result":"oh no"}`
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return stdoutCmd(ctx, envelope)
-	}))
-
-	var got map[string]any
-	err := c.Complete(context.Background(), "hi", &got)
-	var parseErr *ParseError
-	if !errors.As(err, &parseErr) {
-		t.Fatalf("expected ParseError, got %T: %v", err, err)
-	}
-	if !strings.Contains(parseErr.Err.Error(), "is_error=true") {
-		t.Errorf("expected is_error message, got %v", parseErr.Err)
-	}
-}
-
-func TestCompleteWithSystem_EmptyResult(t *testing.T) {
-	envelope := `{"type":"result","is_error":false,"result":""}`
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return stdoutCmd(ctx, envelope)
-	}))
+func TestCompleteWithSystem_OutputFileEmpty(t *testing.T) {
+	c := New(WithCommandFactory(writingFactory("", nil)))
 
 	var got map[string]any
 	err := c.Complete(context.Background(), "hi", &got)
@@ -147,18 +144,19 @@ func TestCompleteWithSystem_EmptyResult(t *testing.T) {
 }
 
 func TestCompleteWithSystem_TargetDecodeFailure(t *testing.T) {
-	// Envelope ok, result ok JSON but not an object — decoding into a
-	// struct target should surface as ParseError.
-	envelope := `{"type":"result","is_error":false,"result":"\"a string\""}`
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return stdoutCmd(ctx, envelope)
-	}))
+	// Output is valid JSON but not an object — decoding into a struct
+	// target should surface as ParseError with the raw content
+	// preserved.
+	c := New(WithCommandFactory(writingFactory(`"a string"`, nil)))
 
 	var got struct{ X int }
 	err := c.Complete(context.Background(), "hi", &got)
 	var parseErr *ParseError
 	if !errors.As(err, &parseErr) {
 		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(parseErr.Raw, "a string") {
+		t.Errorf("expected raw to preserve output, got %q", parseErr.Raw)
 	}
 }
 
@@ -199,11 +197,6 @@ func TestCompleteWithSystem_ContextCancelled(t *testing.T) {
 	cancel() // cancel immediately
 
 	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		// `exec sleep 1` makes sh replace itself with sleep so the
-		// kill on ctx cancel reaps the actual sleeper and unblocks
-		// cmd.Run immediately. Bare `sh -c "sleep 1"` leaves an
-		// orphaned sleep holding the stdout pipe, which makes the
-		// test wait the full sleep duration.
 		return fakeCmd(ctx, "exec sleep 1")
 	}))
 
@@ -232,21 +225,18 @@ func TestCompleteWithSystem_Timeout(t *testing.T) {
 	}
 }
 
-// --- Argv shape ---
+// --- Argv shape (verified against codex-rs/exec/src/cli.rs) ---
 
-func TestCompleteWithSystem_ArgsIncludeSubcommandJSONAndExtras(t *testing.T) {
-	// Production argv shape: codex exec --json [--model M] [<extra>...] <prompt>.
-	// System prompt is bundled into the prompt arg (codex has no separate
-	// --system flag in non-interactive mode), so the prompt arg must
-	// contain the system text when system is set.
-	var captured []string
-	envelope := `{"type":"result","is_error":false,"result":"{}"}`
+func TestCompleteWithSystem_ArgvShape(t *testing.T) {
+	// Production argv shape against the real codex-exec binary:
+	//   codex exec --output-last-message <tmpfile> [--model M] [extras...] <prompt>
+	// Critically, --json is NOT used: that flag emits streaming JSONL
+	// telemetry events, not a single structured result. The structured
+	// final response comes from --output-last-message reading.
+	var captured [][]string
 	c := New(
 		WithExtraArgs("--dangerously-bypass-approvals-and-sandbox"),
-		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-			captured = append([]string{name}, args...)
-			return stdoutCmd(ctx, envelope)
-		}),
+		WithCommandFactory(writingFactory(`{}`, &captured)),
 	)
 
 	var got map[string]any
@@ -254,21 +244,35 @@ func TestCompleteWithSystem_ArgsIncludeSubcommandJSONAndExtras(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(captured) == 0 {
-		t.Fatalf("nothing captured")
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 invocation, got %d", len(captured))
 	}
-	if captured[0] != "codex" {
-		t.Errorf("binary = %q, want codex", captured[0])
+	run := captured[0]
+	if run[0] != "codex" {
+		t.Errorf("binary = %q, want codex", run[0])
 	}
-	joined := strings.Join(captured, " ")
-	for _, w := range []string{"exec", "--json", "--dangerously-bypass-approvals-and-sandbox"} {
-		if !strings.Contains(joined, w) {
-			t.Errorf("captured args %q missing %q", joined, w)
-		}
+	if run[1] != "exec" {
+		t.Errorf("first arg must be subcommand `exec`, got %q", run[1])
 	}
-	// Prompt must be last and must contain both the system prompt and
-	// the user prompt.
-	last := captured[len(captured)-1]
+	joined := strings.Join(run, " ")
+	if strings.Contains(joined, "--json") {
+		t.Errorf("argv must NOT contain --json (it streams JSONL telemetry, not structured output): %s", joined)
+	}
+	if !strings.Contains(joined, "--output-last-message") {
+		t.Errorf("argv must contain --output-last-message: %s", joined)
+	}
+	if !strings.Contains(joined, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Errorf("argv missing extra arg: %s", joined)
+	}
+	// Output file path must be a real path string after the flag.
+	outPath := flagValue(run[1:], "--output-last-message")
+	if outPath == "" {
+		t.Errorf("--output-last-message has no value: %v", run)
+	}
+	// Prompt is the last arg and contains both system + user prompt
+	// (bundled, no markers — codex exec has no separate
+	// system-prompt flag in non-interactive mode).
+	last := run[len(run)-1]
 	if !strings.Contains(last, "you are a judge") {
 		t.Errorf("prompt arg %q must contain system prompt", last)
 	}
@@ -277,15 +281,34 @@ func TestCompleteWithSystem_ArgsIncludeSubcommandJSONAndExtras(t *testing.T) {
 	}
 }
 
+func TestCompleteWithSystem_TempFilesCleanedUp(t *testing.T) {
+	// The output file the client passes to codex must be removed after
+	// the call returns. Otherwise long-running judge loops leak temp
+	// files into /tmp.
+	var captured [][]string
+	c := New(WithCommandFactory(writingFactory(`{}`, &captured)))
+
+	var got map[string]any
+	if err := c.Complete(context.Background(), "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 invocation, got %d", len(captured))
+	}
+	outPath := flagValue(captured[0][1:], "--output-last-message")
+	if outPath == "" {
+		t.Fatal("--output-last-message path missing")
+	}
+	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+		t.Errorf("output tempfile %q must be cleaned up after call (stat err = %v)", outPath, err)
+	}
+}
+
 func TestCompleteWithSystem_WithModelAddsFlag(t *testing.T) {
-	var captured []string
-	envelope := `{"type":"result","is_error":false,"result":"{}"}`
+	var captured [][]string
 	c := New(
 		WithModel("gpt-5-codex"),
-		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-			captured = append([]string{name}, args...)
-			return stdoutCmd(ctx, envelope)
-		}),
+		WithCommandFactory(writingFactory(`{}`, &captured)),
 	)
 
 	var got map[string]any
@@ -295,69 +318,72 @@ func TestCompleteWithSystem_WithModelAddsFlag(t *testing.T) {
 	if c.Model() != "gpt-5-codex" {
 		t.Errorf("client Model() = %q, want gpt-5-codex", c.Model())
 	}
-	joined := strings.Join(captured, " ")
+	joined := strings.Join(captured[0], " ")
 	if !strings.Contains(joined, "--model gpt-5-codex") {
-		t.Errorf("captured args missing --model gpt-5-codex: %v", captured)
+		t.Errorf("captured args missing --model gpt-5-codex: %v", captured[0])
 	}
 }
 
 func TestCompleteWithSystem_NoModelSkipsFlag(t *testing.T) {
-	var captured []string
-	envelope := `{"type":"result","is_error":false,"result":"{}"}`
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		captured = append([]string{name}, args...)
-		return stdoutCmd(ctx, envelope)
-	}))
+	var captured [][]string
+	c := New(WithCommandFactory(writingFactory(`{}`, &captured)))
 
 	var got map[string]any
 	if err := c.CompleteWithSystem(context.Background(), "", "p", &got); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	for _, a := range captured {
+	for _, a := range captured[0] {
 		if a == "--model" {
-			t.Errorf("client without WithModel must not add --model flag: %v", captured)
+			t.Errorf("client without WithModel must not add --model flag: %v", captured[0])
 		}
 	}
 }
 
 func TestCompleteWithSystem_NoSystemPromptKeepsPromptClean(t *testing.T) {
-	// When system is empty, the prompt arg is the user prompt verbatim —
-	// no bundled-in system fragment, no prefix.
-	var captured []string
-	envelope := `{"type":"result","is_error":false,"result":"{}"}`
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		captured = append([]string{name}, args...)
-		return stdoutCmd(ctx, envelope)
-	}))
+	// When system is empty, the prompt arg is the user prompt verbatim.
+	var captured [][]string
+	c := New(WithCommandFactory(writingFactory(`{}`, &captured)))
 
 	var got map[string]any
 	if err := c.CompleteWithSystem(context.Background(), "", "just the prompt", &got); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	if captured[len(captured)-1] != "just the prompt" {
-		t.Errorf("expected last arg to equal user prompt verbatim when system empty, got %q", captured[len(captured)-1])
+	if captured[0][len(captured[0])-1] != "just the prompt" {
+		t.Errorf("expected last arg to equal user prompt verbatim when system empty, got %q", captured[0][len(captured[0])-1])
 	}
 }
 
-// --- Tool use ---
+// --- Tool use (uses --output-schema for native structured output) ---
 
-func TestCompleteWithTool_InjectsSchemaAndParsesResult(t *testing.T) {
-	// CompleteWithTool must (a) inject the tool's JSON Schema into the
-	// system prompt the subprocess sees, and (b) parse the envelope's
-	// result back into the target as plain JSON.
-	var captured []string
-	envelope := `{"type":"result","is_error":false,"result":"{\"verdict\":\"pass\",\"score\":0.9}"}`
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		captured = append([]string{name}, args...)
-		return stdoutCmd(ctx, envelope)
-	}))
+func TestCompleteWithTool_PassesOutputSchemaFile(t *testing.T) {
+	// CompleteWithTool must (a) write the tool's InputSchema to a
+	// tempfile, (b) pass it via --output-schema, and (c) parse the
+	// agent's final message file into the target. The schema file
+	// content must match the InputSchema verbatim — that's how codex
+	// enforces the response shape.
+	var captured [][]string
+	var capturedSchemaContent string
 
+	schemaJSON := `{"type":"object","properties":{"verdict":{"type":"string"},"score":{"type":"number"}},"required":["verdict","score"]}`
 	tool := claude.Tool{
 		Name:        "verdict",
 		Description: "judge verdict",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"verdict":{"type":"string"},"score":{"type":"number"}}}`),
+		InputSchema: json.RawMessage(schemaJSON),
 	}
+
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		captured = append(captured, append([]string{name}, args...))
+		// Capture schema file content before codex would consume it.
+		schemaPath := flagValue(args, "--output-schema")
+		if schemaPath != "" {
+			b, err := os.ReadFile(schemaPath)
+			if err == nil {
+				capturedSchemaContent = string(b)
+			}
+		}
+		path := flagValue(args, "--output-last-message")
+		return writeAndExitCmd(ctx, path, `{"verdict":"pass","score":0.9}`, "", 0)
+	}))
 
 	var got struct {
 		Verdict string  `json:"verdict"`
@@ -369,43 +395,62 @@ func TestCompleteWithTool_InjectsSchemaAndParsesResult(t *testing.T) {
 	if got.Verdict != "pass" || got.Score != 0.9 {
 		t.Errorf("got %+v, want {pass 0.9}", got)
 	}
-
-	// The schema must reach the subprocess somewhere in the prompt arg.
-	last := captured[len(captured)-1]
-	if !strings.Contains(last, "verdict") {
-		t.Errorf("prompt arg must mention tool name, got %q", last)
+	if !strings.Contains(strings.Join(captured[0], " "), "--output-schema") {
+		t.Errorf("argv must include --output-schema for tool use: %v", captured[0])
 	}
-	if !strings.Contains(last, `"score"`) {
-		t.Errorf("prompt arg must include schema fragment, got %q", last)
+	if capturedSchemaContent != schemaJSON {
+		t.Errorf("schema file content mismatch:\n got: %s\nwant: %s", capturedSchemaContent, schemaJSON)
 	}
 }
 
-func TestCompleteWithTool_RecoveryOnProseResult(t *testing.T) {
-	// First subprocess call returns prose that won't parse as JSON.
-	// Client must retry once with a recovery prompt and parse the
-	// second response. The recovery call's prompt arg must reference
-	// the schema and contain the original prose.
-	proseEnvelope := `{"type":"result","is_error":false,"result":"sure thing! the answer is x=7"}`
-	recoveryEnvelope := `{"type":"result","is_error":false,"result":"{\"x\":7}"}`
+func TestCompleteWithTool_SchemaFileCleanedUp(t *testing.T) {
+	tool := claude.Tool{
+		Name:        "x",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}
 
-	calls := 0
-	var capturedRuns [][]string
+	var capturedSchemaPath string
 	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		capturedRuns = append(capturedRuns, append([]string{name}, args...))
-		calls++
-		switch calls {
-		case 1:
-			return stdoutCmd(ctx, proseEnvelope)
-		default:
-			return stdoutCmd(ctx, recoveryEnvelope)
-		}
+		capturedSchemaPath = flagValue(args, "--output-schema")
+		path := flagValue(args, "--output-last-message")
+		return writeAndExitCmd(ctx, path, `{}`, "", 0)
 	}))
 
+	var got map[string]any
+	if err := c.CompleteWithTool(context.Background(), "", "p", tool, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedSchemaPath == "" {
+		t.Fatal("schema path was not captured")
+	}
+	if _, err := os.Stat(capturedSchemaPath); !os.IsNotExist(err) {
+		t.Errorf("schema tempfile %q must be cleaned up after call (stat err = %v)", capturedSchemaPath, err)
+	}
+}
+
+func TestCompleteWithTool_RecoveryOnDecodeFailure(t *testing.T) {
+	// First call writes prose to the output file (model ignored the
+	// schema, which can happen). Client must retry once with a
+	// recovery prompt and parse the second response.
 	tool := claude.Tool{
 		Name:        "answer",
 		Description: "give answer",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"x":{"type":"integer"}}}`),
 	}
+
+	calls := 0
+	var capturedPrompts []string
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls++
+		capturedPrompts = append(capturedPrompts, args[len(args)-1])
+		path := flagValue(args, "--output-last-message")
+		switch calls {
+		case 1:
+			return writeAndExitCmd(ctx, path, "sure thing! the answer is x=7", "", 0)
+		default:
+			return writeAndExitCmd(ctx, path, `{"x":7}`, "", 0)
+		}
+	}))
 
 	var got struct {
 		X int `json:"x"`
@@ -419,19 +464,13 @@ func TestCompleteWithTool_RecoveryOnProseResult(t *testing.T) {
 	if calls != 2 {
 		t.Fatalf("expected 2 subprocess calls (initial + recovery), got %d", calls)
 	}
-
-	// Recovery prompt must include the prose that failed to parse.
-	recoveryPromptArg := capturedRuns[1][len(capturedRuns[1])-1]
-	if !strings.Contains(recoveryPromptArg, "x=7") {
-		t.Errorf("recovery prompt should include original prose, got %q", recoveryPromptArg)
+	if !strings.Contains(capturedPrompts[1], "x=7") {
+		t.Errorf("recovery prompt should include the original prose, got %q", capturedPrompts[1])
 	}
 }
 
 func TestCompleteWithTools_RoutesToFinalTool(t *testing.T) {
-	envelope := `{"type":"result","is_error":false,"result":"{\"verdict\":\"pass\"}"}`
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return stdoutCmd(ctx, envelope)
-	}))
+	c := New(WithCommandFactory(writingFactory(`{"verdict":"pass"}`, nil)))
 
 	tools := []claude.Tool{
 		{
@@ -458,9 +497,7 @@ func TestCompleteWithTools_RoutesToFinalTool(t *testing.T) {
 }
 
 func TestCompleteWithTools_UnknownFinalToolErrors(t *testing.T) {
-	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return stdoutCmd(ctx, `{"type":"result","is_error":false,"result":"{}"}`)
-	}))
+	c := New(WithCommandFactory(writingFactory(`{}`, nil)))
 
 	tools := []claude.Tool{{Name: "verdict", InputSchema: json.RawMessage(`{}`)}}
 
@@ -474,11 +511,25 @@ func TestCompleteWithTools_UnknownFinalToolErrors(t *testing.T) {
 	}
 }
 
+// --- Compile-time interface check ---
+
+func TestClient_HasCompleterShape(t *testing.T) {
+	// Compile-time guard mirroring the cmd/vairdict completer
+	// interface. If the interface drifts and this package isn't
+	// updated, the build here breaks immediately rather than failing
+	// later at the wiring site.
+	type completerLike interface {
+		CompleteWithSystem(ctx context.Context, system, prompt string, target any) error
+		CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
+		CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, handlers map[string]claude.ToolHandler, target any) error
+		Model() string
+	}
+	var _ completerLike = (*Client)(nil)
+}
+
 // --- Availability + helpers ---
 
 func TestIsAvailable_SmokeTest(t *testing.T) {
-	// Just ensure it doesn't panic and returns a bool — we can't assume
-	// the test host has codex installed or not.
 	_ = IsAvailable()
 }
 
@@ -534,28 +585,37 @@ func TestExtractJSON(t *testing.T) {
 }
 
 func TestBuildArgs_Shape(t *testing.T) {
-	t.Run("base_no_model_no_extra", func(t *testing.T) {
-		args := buildArgs("", nil, "user prompt")
+	t.Run("base_no_model_no_schema_no_extra", func(t *testing.T) {
+		args := buildArgs("", "/tmp/out", "", nil, "user prompt")
 		if args[0] != "exec" {
 			t.Errorf("first arg must be subcommand exec, got %q", args[0])
 		}
 		joined := strings.Join(args, " ")
-		if !strings.Contains(joined, "--json") {
-			t.Errorf("missing --json: %s", joined)
+		if !strings.Contains(joined, "--output-last-message /tmp/out") {
+			t.Errorf("missing --output-last-message: %s", joined)
+		}
+		if strings.Contains(joined, "--json") {
+			t.Errorf("must NOT include --json: %s", joined)
 		}
 		if strings.Contains(joined, "--model") {
 			t.Errorf("must not include --model when empty: %s", joined)
+		}
+		if strings.Contains(joined, "--output-schema") {
+			t.Errorf("must not include --output-schema when empty: %s", joined)
 		}
 		if args[len(args)-1] != "user prompt" {
 			t.Errorf("prompt must be last: %v", args)
 		}
 	})
 
-	t.Run("with_model_and_extra", func(t *testing.T) {
-		args := buildArgs("gpt-5-codex", []string{"--dangerously-bypass-approvals-and-sandbox"}, "p")
+	t.Run("with_model_schema_and_extra", func(t *testing.T) {
+		args := buildArgs("gpt-5-codex", "/tmp/out", "/tmp/schema", []string{"--dangerously-bypass-approvals-and-sandbox"}, "p")
 		joined := strings.Join(args, " ")
 		if !strings.Contains(joined, "--model gpt-5-codex") {
 			t.Errorf("missing --model gpt-5-codex: %s", joined)
+		}
+		if !strings.Contains(joined, "--output-schema /tmp/schema") {
+			t.Errorf("missing --output-schema /tmp/schema: %s", joined)
 		}
 		if !strings.Contains(joined, "--dangerously-bypass-approvals-and-sandbox") {
 			t.Errorf("missing extra arg: %s", joined)
@@ -564,4 +624,19 @@ func TestBuildArgs_Shape(t *testing.T) {
 			t.Errorf("prompt must be last: %v", args)
 		}
 	})
+}
+
+func TestBundlePrompt(t *testing.T) {
+	if got := bundlePrompt("", "user"); got != "user" {
+		t.Errorf("empty system: got %q, want %q", got, "user")
+	}
+	got := bundlePrompt("sys", "user")
+	if !strings.Contains(got, "sys") || !strings.Contains(got, "user") {
+		t.Errorf("bundle missing parts: %q", got)
+	}
+	// No invented [system]/[user] markers — the model would not honor
+	// them. Plain join only.
+	if strings.Contains(got, "[system]") || strings.Contains(got, "[user]") {
+		t.Errorf("bundlePrompt must not invent role markers: %q", got)
+	}
 }

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -14,6 +14,7 @@ Update this file when opening, completing, or blocking an issue.
 
 ## In Progress
 - #91 cmd/interactive: status, notes, pause/continue during execution
+- #126 agents/codex: Codex CLI completer (M6, branch claude/issue-126-tests-first-TBk7B)
 
 ## Blocked
 


### PR DESCRIPTION
Mirrors internal/agents/claudecli's test surface for the new codex
backend: envelope parsing, typed errors, argv shape, system-prompt
bundling into the prompt arg, model flag, tool-use schema injection,
recovery round-trip, and extractJSON edge cases. Implementation lands
in a follow-up so tests are red until then.

Also tracks #126 in plans/PROGRESS.md under In Progress.