### PR TITLE
feat(judge): per-AC tracing — judges enforce issue checklist with evidence + render matrix

### DIFF
--- a/cmd/vairdict/review.go
+++ b/cmd/vairdict/review.go
@@ -96,7 +96,7 @@ type reviewGH interface {
 // nil — cross-push memory across CLI invocations would need a separate
 // state store and is out of scope for the subcommand.
 type reviewJudge interface {
-	Judge(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap) (*state.Verdict, error)
+	Judge(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap, checklist []state.ChecklistItem) (*state.Verdict, error)
 }
 
 // runReview is the production entry point: it loads the config, builds
@@ -165,7 +165,7 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 		return err
 	}
 
-	intent, err := resolveReviewIntent(ctx, deps.gh, pr, deps.intent)
+	intent, checklist, err := resolveReviewIntent(ctx, deps.gh, pr, deps.intent)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,10 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 	// Review mode has no plan — pass empty. The diff is what the judge
 	// actually evaluates. priorGaps is nil because `vairdict review` is
 	// a one-shot CLI invocation with no persisted prior verdict.
-	verdict, err := deps.judge.Judge(ctx, intent, "", diff, nil)
+	// `checklist` carries the per-AC items parsed from the linked
+	// issue body (or PR body fallback) so the judge can enforce
+	// per-item ticking.
+	verdict, err := deps.judge.Judge(ctx, intent, "", diff, nil, checklist)
 	if err != nil {
 		return fmt.Errorf("running quality judge: %w", err)
 	}
@@ -205,16 +208,20 @@ func runReviewWith(ctx context.Context, prNumber int, deps reviewDeps) error {
 	return nil
 }
 
-// resolveReviewIntent picks the intent for the judge. Priority:
-//  1. Explicit --intent override
-//  2. Linked issue body (Closes/Fixes/Resolves #N in PR body)
-//  3. PR title + body as fallback
+// resolveReviewIntent picks the intent and the AC checklist for the
+// judge. Priority for intent:
+//  1. Explicit --intent override (no checklist extracted in this case
+//     — the override is the user's bespoke text, not an issue body)
+//  2. Linked issue body (Closes/Fixes/Resolves #N in PR body) — the
+//     checklist is parsed from the issue body
+//  3. PR title + body as fallback (checklist parsed from the PR body
+//     itself, which is unusual but harmless when absent)
 //
-// The override is passed in (not read from package state) so the core is
-// parallel-test-safe.
-func resolveReviewIntent(ctx context.Context, gh reviewGH, pr *github.PRDetails, override string) (string, error) {
+// The override is passed in (not read from package state) so the core
+// is parallel-test-safe.
+func resolveReviewIntent(ctx context.Context, gh reviewGH, pr *github.PRDetails, override string) (string, []state.ChecklistItem, error) {
 	if override != "" {
-		return override, nil
+		return override, nil, nil
 	}
 	issueNum := github.ParseLinkedIssue(pr.Body)
 	if issueNum > 0 {
@@ -222,10 +229,11 @@ func resolveReviewIntent(ctx context.Context, gh reviewGH, pr *github.PRDetails,
 		if err != nil {
 			slog.Warn("failed to fetch linked issue, falling back to PR title", "issue", issueNum, "error", err)
 		} else {
-			return iss.Title + "\n\n" + iss.Body, nil
+			return iss.Title + "\n\n" + iss.Body, github.ParseChecklist(iss.Body), nil
 		}
 	}
-	// Fall back to PR title + body as intent.
+	// Fall back to PR title + body as intent. Parse a checklist from
+	// the PR body too — many devs include their own AC list there.
 	slog.Info("no linked issue or --intent, using PR title+body as intent", "pr", pr.Number)
-	return pr.Title + "\n\n" + pr.Body, nil
+	return pr.Title + "\n\n" + pr.Body, github.ParseChecklist(pr.Body), nil
 }

--- a/cmd/vairdict/review_test.go
+++ b/cmd/vairdict/review_test.go
@@ -97,14 +97,16 @@ func (f *fakeReviewGH) MergePR(_ context.Context, _ int) error {
 // fakeReviewJudge captures the inputs to Judge so tests can verify the
 // command threads intent / plan / diff through correctly.
 type fakeReviewJudge struct {
-	verdict *state.Verdict
-	err     error
-	intent  string
-	plan    string
-	diff    string
+	verdict   *state.Verdict
+	err       error
+	intent    string
+	plan      string
+	diff      string
+	checklist []state.ChecklistItem
 }
 
-func (f *fakeReviewJudge) Judge(_ context.Context, intent, plan, diff string, _ []state.Gap) (*state.Verdict, error) {
+func (f *fakeReviewJudge) Judge(_ context.Context, intent, plan, diff string, _ []state.Gap, checklist []state.ChecklistItem) (*state.Verdict, error) {
+	f.checklist = checklist
 	f.intent = intent
 	f.plan = plan
 	f.diff = diff

--- a/cmd/vairdict/run.go
+++ b/cmd/vairdict/run.go
@@ -175,6 +175,41 @@ func fetchIssueIntent(number int) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// populateTaskChecklist fetches the linked issue and parses its
+// `- [ ]` checklist into task.Checklist so the quality judge can
+// enforce per-item ticking. Best-effort: a fetch failure logs a
+// warning and the task continues in legacy (no-AC-gate) mode rather
+// than blocking the whole run on a transient GitHub error.
+//
+// issueNumber == 0 means the run was started without --issue, so
+// there's no body to parse — early-return as a no-op.
+//
+// When the fetch succeeds and the body has no `- [ ]` items, we
+// also no-op (empty Checklist). The judge then runs in legacy mode
+// for that task.
+func populateTaskChecklist(ctx context.Context, gh *github.Client, store *state.Store, task *state.Task, issueNumber int) {
+	if issueNumber <= 0 {
+		return
+	}
+	iss, err := gh.FetchIssue(ctx, issueNumber)
+	if err != nil {
+		slog.Warn("could not fetch issue body for AC checklist; running in legacy mode",
+			"issue", issueNumber, "error", err)
+		return
+	}
+	items := github.ParseChecklist(iss.Body)
+	if len(items) == 0 {
+		return
+	}
+	task.Checklist = items
+	if err := store.UpdateTask(task); err != nil {
+		// Persistence failure is non-fatal — the in-memory task still
+		// carries the checklist for this run. `vairdict resume` would
+		// re-fetch from the issue, so a missed write is recoverable.
+		slog.Warn("failed to persist task checklist", "task", task.ID, "error", err)
+	}
+}
+
 func execCommand(name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
 	return cmd.Output()
@@ -492,6 +527,13 @@ func runTask(intent string, issueNumber int, mode ui.Mode, colors ui.ColorScheme
 	ghRunner := &github.ExecRunner{Dir: repoRoot}
 	ghClient := github.New(ghRunner)
 
+	// Populate the AC checklist from the linked issue's body so the
+	// quality judge can enforce per-item ticking. Best-effort: a fetch
+	// failure logs a warning and the task continues in legacy mode
+	// (no AC gate). issueNumber == 0 means the run was started without
+	// --issue, so there's nothing to fetch.
+	populateTaskChecklist(ctx, ghClient, store, task, issueNumber)
+
 	deps := defaultRunDeps(cfg, comps, store, workDir, r, ghClient, issueNumber)
 
 	// Interactive input loop: if stdin is a TTY and --no-tty is not
@@ -716,6 +758,8 @@ func runSingleTask(
 	workDir := ws.Path
 	ghRunner := &github.ExecRunner{Dir: repoRoot}
 	ghClient := github.New(ghRunner)
+
+	populateTaskChecklist(ctx, ghClient, store, task, issueNumber)
 
 	deps := defaultRunDeps(cfg, comps, store, workDir, r, ghClient, issueNumber)
 	// In concurrent mode, escalation returns an error instead of os.Exit.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -944,6 +944,15 @@ func FormatVerdictComment(verdict *state.Verdict, phase state.Phase, loop int, i
 		b.WriteString("\n\n")
 	}
 
+	// AC matrix — when the task carried a parsed AC list from the
+	// issue body, render the per-item status so reviewers can see at
+	// a glance which criteria were ticked, deferred, or missed. The
+	// underlying gate (DeriveVerdictState) already drove Pass; this
+	// section just makes the why visible.
+	if len(verdict.Checklist) > 0 {
+		b.WriteString(renderChecklistSection(verdict.Checklist))
+	}
+
 	// Separate gaps into inline (already visible on specific lines) and
 	// summary-only (belong in this comment).
 	var summaryGaps []state.Gap
@@ -1018,4 +1027,63 @@ func GeneratePRTitle(task *state.Task) string {
 		title = title[:67] + "..."
 	}
 	return title
+}
+
+// renderChecklistSection produces the "### Acceptance Criteria"
+// markdown table for a verdict's per-AC audit. Status icons follow
+// the four states the gate distinguishes:
+//
+//   - ✅ Required && Passed — criterion met, reason is the evidence cite
+//   - ⏸️ Required && !Passed && Reason != "" — deferred with reason; gate allows
+//   - ❌ Required && !Passed && Reason == "" — unmet, no excuse; gate blocks
+//   - ⚪ !Required — optional item (passed or not, never blocks)
+//
+// The header line shows a tally so reviewers can skim "5/8 passed"
+// without reading the whole table.
+func renderChecklistSection(items []state.ChecklistItem) string {
+	if len(items) == 0 {
+		return ""
+	}
+	passed, total := state.ChecklistTally(items)
+	var b strings.Builder
+	fmt.Fprintf(&b, "### Acceptance Criteria (%d/%d passed)\n\n", passed, total)
+	b.WriteString("| | Item | Evidence / Reason |\n")
+	b.WriteString("|---|------|-------------------|\n")
+	for _, it := range items {
+		icon := checklistIcon(it)
+		reason := strings.TrimSpace(it.Reason)
+		if reason == "" {
+			reason = "_(no reason given)_"
+		}
+		desc := it.Description
+		if !it.Required {
+			desc = "(optional) " + desc
+		}
+		// Pipes inside table cells must be escaped or the table breaks.
+		desc = strings.ReplaceAll(desc, "|", "\\|")
+		reason = strings.ReplaceAll(reason, "|", "\\|")
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", icon, desc, reason)
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// checklistIcon returns the status emoji for one ChecklistItem per
+// the four-state matrix. Keep this in lockstep with the gate's view
+// (state.RequiredPassed) so the rendered icons match the actual
+// pass/block decision.
+func checklistIcon(it state.ChecklistItem) string {
+	if !it.Required {
+		if it.Passed {
+			return "✅"
+		}
+		return "⚪"
+	}
+	if it.Passed {
+		return "✅"
+	}
+	if strings.TrimSpace(it.Reason) != "" {
+		return "⏸️"
+	}
+	return "❌"
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1718,3 +1718,100 @@ func TestBuildInlineReview_StandardsAlwaysInline(t *testing.T) {
 		t.Fatalf("expected 1 inline Standards comment, got %+v", got)
 	}
 }
+
+// --- AC checklist rendering tests ---
+
+func TestFormatVerdictComment_AC_AllPassed(t *testing.T) {
+	v := &state.Verdict{
+		Pass: true, Score: 100,
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Description: "Add codex completer", Required: true, Passed: true, Reason: "internal/agents/codex/client.go:127"},
+			{Name: "ac_2", Description: "Wire into resolver", Required: true, Passed: true, Reason: "cmd/vairdict/completer.go:160"},
+		},
+	}
+	got := FormatVerdictComment(v, state.PhaseQuality, 1, nil)
+	if !strings.Contains(got, "Acceptance Criteria (2/2 passed)") {
+		t.Errorf("missing tally header\n%s", got)
+	}
+	for _, want := range []string{
+		"✅", "Add codex completer", "internal/agents/codex/client.go:127",
+		"Wire into resolver", "cmd/vairdict/completer.go:160",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatVerdictComment_AC_DeferredAndUnmet(t *testing.T) {
+	v := &state.Verdict{
+		Pass: false, Score: 60,
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Description: "first done", Required: true, Passed: true, Reason: "file:1"},
+			{Name: "ac_2", Description: "deferred item", Required: true, Passed: false, Reason: "blocked on #130"},
+			{Name: "ac_3", Description: "missed", Required: true, Passed: false},
+		},
+	}
+	got := FormatVerdictComment(v, state.PhaseQuality, 1, nil)
+	// Tally counts only passed (Passed=true) — deferred and missed
+	// don't count.
+	if !strings.Contains(got, "Acceptance Criteria (1/3 passed)") {
+		t.Errorf("tally wrong\n%s", got)
+	}
+	if !strings.Contains(got, "⏸️") {
+		t.Error("missing ⏸️ for deferred-with-reason item")
+	}
+	if !strings.Contains(got, "❌") {
+		t.Error("missing ❌ for unmet-no-reason item")
+	}
+	if !strings.Contains(got, "blocked on #130") {
+		t.Error("missing deferral reason text")
+	}
+	if !strings.Contains(got, "_(no reason given)_") {
+		t.Error("missing placeholder for missing reason")
+	}
+}
+
+func TestFormatVerdictComment_AC_OptionalItem(t *testing.T) {
+	v := &state.Verdict{
+		Pass: true, Score: 100,
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Description: "required pass", Required: true, Passed: true, Reason: "f:1"},
+			{Name: "opt_1", Description: "optional, unticked", Required: false, Passed: false},
+		},
+	}
+	got := FormatVerdictComment(v, state.PhaseQuality, 1, nil)
+	if !strings.Contains(got, "⚪") {
+		t.Errorf("missing ⚪ for optional unticked item\n%s", got)
+	}
+	if !strings.Contains(got, "(optional)") {
+		t.Errorf("missing (optional) prefix on optional item\n%s", got)
+	}
+}
+
+func TestFormatVerdictComment_AC_OmittedWhenChecklistEmpty(t *testing.T) {
+	// Legacy verdict (no AC list) must not emit an empty AC section.
+	v := &state.Verdict{Pass: true, Score: 100}
+	got := FormatVerdictComment(v, state.PhaseQuality, 1, nil)
+	if strings.Contains(got, "Acceptance Criteria") {
+		t.Errorf("AC section must not appear when checklist is empty\n%s", got)
+	}
+}
+
+func TestFormatVerdictComment_AC_EscapesPipesInDescription(t *testing.T) {
+	// Markdown table cells break if a literal | leaks through. The
+	// renderer must escape pipes in both Description and Reason.
+	v := &state.Verdict{
+		Pass: true, Score: 100,
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Description: "match foo|bar pattern", Required: true, Passed: true, Reason: "see grep|sed pipeline"},
+		},
+	}
+	got := FormatVerdictComment(v, state.PhaseQuality, 1, nil)
+	if !strings.Contains(got, `match foo\|bar pattern`) {
+		t.Errorf("pipe in description not escaped\n%s", got)
+	}
+	if !strings.Contains(got, `see grep\|sed pipeline`) {
+		t.Errorf("pipe in reason not escaped\n%s", got)
+	}
+}

--- a/internal/github/issueparse.go
+++ b/internal/github/issueparse.go
@@ -1,0 +1,69 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// checklistItemRE matches a GitHub-Flavored-Markdown task list item:
+//
+//	[indent]<bullet> [<state>] <description>
+//
+// where bullet is `-`, `*`, or `+`, and state is a single space (or
+// empty) for unchecked, or `x`/`X` for checked. The capture groups
+// pull out the state char and the description so the parser can
+// produce a ChecklistItem without re-walking the line.
+//
+// We accept zero or one space inside the brackets so a body authored
+// with `- []` (no inner space) still parses — GitHub renders it as
+// an unchecked box too.
+var checklistItemRE = regexp.MustCompile(`^[ \t]*[-*+] \[([ xX])\] (.+?)[ \t\r]*$`)
+
+// ParseChecklist extracts GitHub-Flavored-Markdown task list items
+// from a raw issue body. Returns one ChecklistItem per matched line,
+// in document order. Items get stable Name keys (ac_1, ac_2, …) so
+// the judge can echo them verbatim and post-processing can pair the
+// model's response back to the source list.
+//
+// All parsed items are Required=true. Optional items are reserved
+// for judge-internal observations (e.g. "tests cover the change")
+// and are not extracted from the issue body.
+//
+// Lines outside checklist syntax — prose, headers, code blocks,
+// non-checkbox bullets — are ignored. Code blocks are NOT
+// fence-aware: a fake checklist embedded in a ``` block will be
+// extracted. That's a known minor failure mode; AC checklists in
+// fenced blocks are a documentation smell anyway.
+func ParseChecklist(body string) []state.ChecklistItem {
+	if body == "" {
+		return nil
+	}
+	var items []state.ChecklistItem
+	idx := 0
+	for _, line := range strings.Split(body, "\n") {
+		m := checklistItemRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		idx++
+		state := m[1]
+		description := strings.TrimRight(m[2], " \t\r")
+		items = append(items, state2Item(idx, state, description))
+	}
+	return items
+}
+
+// state2Item builds a ChecklistItem for one matched line. Factored
+// out so the parser body stays a tight loop.
+func state2Item(idx int, mark, description string) state.ChecklistItem {
+	passed := mark == "x" || mark == "X"
+	return state.ChecklistItem{
+		Name:        fmt.Sprintf("ac_%d", idx),
+		Description: description,
+		Required:    true,
+		Passed:      passed,
+	}
+}

--- a/internal/github/issueparse_test.go
+++ b/internal/github/issueparse_test.go
@@ -1,0 +1,211 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// TestParseChecklist_Empty: an empty body yields no items. The judge
+// then runs in legacy mode (score-based pass) — the AC gate is
+// opt-in via a checklist actually being present.
+func TestParseChecklist_Empty(t *testing.T) {
+	if got := ParseChecklist(""); len(got) != 0 {
+		t.Errorf("empty body: got %d items, want 0", len(got))
+	}
+}
+
+// TestParseChecklist_NoChecklist: prose-only issues yield no items.
+// We deliberately do not attempt LLM-driven extraction from prose
+// here; that's a separate follow-up.
+func TestParseChecklist_NoChecklist(t *testing.T) {
+	body := `## Intent
+
+Add a thing that does the thing. No checklist here.`
+	if got := ParseChecklist(body); len(got) != 0 {
+		t.Errorf("prose-only body: got %d items, want 0", len(got))
+	}
+}
+
+// TestParseChecklist_BasicUnchecked: a single `- [ ]` item is parsed
+// with Required=true, Passed=false, Description verbatim.
+func TestParseChecklist_BasicUnchecked(t *testing.T) {
+	body := `## Acceptance Criteria
+
+- [ ] Add a Codex completer
+`
+	got := ParseChecklist(body)
+	want := []state.ChecklistItem{
+		{Name: "ac_1", Description: "Add a Codex completer", Required: true, Passed: false},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestParseChecklist_BasicChecked: `- [x]` and `- [X]` both parse as
+// Passed=true. Pre-checked items are honored; the judge can still
+// scrutinise them and add Reason as evidence.
+func TestParseChecklist_BasicChecked(t *testing.T) {
+	body := `- [x] lower x done
+- [X] upper X done`
+	got := ParseChecklist(body)
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2: %+v", len(got), got)
+	}
+	for i, it := range got {
+		if !it.Passed {
+			t.Errorf("item %d not Passed: %+v", i, it)
+		}
+		if !it.Required {
+			t.Errorf("item %d not Required: %+v", i, it)
+		}
+	}
+}
+
+// TestParseChecklist_Mixed: a typical AC list with both checked and
+// unchecked items round-trips cleanly. Names are stable (ac_1..n in
+// document order).
+func TestParseChecklist_Mixed(t *testing.T) {
+	body := `## Acceptance Criteria
+
+- [x] Item one
+- [ ] Item two
+- [ ] Item three
+`
+	got := ParseChecklist(body)
+	want := []state.ChecklistItem{
+		{Name: "ac_1", Description: "Item one", Required: true, Passed: true},
+		{Name: "ac_2", Description: "Item two", Required: true, Passed: false},
+		{Name: "ac_3", Description: "Item three", Required: true, Passed: false},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestParseChecklist_AlternateMarkers: GitHub-flavored markdown
+// accepts `*`, `+`, `-` as bullet markers. We mirror that. Numbered
+// lists are out of scope (rare in AC checklists).
+func TestParseChecklist_AlternateMarkers(t *testing.T) {
+	body := `- [ ] dash
+* [ ] star
++ [ ] plus`
+	got := ParseChecklist(body)
+	if len(got) != 3 {
+		t.Fatalf("got %d items, want 3: %+v", len(got), got)
+	}
+	wantDesc := []string{"dash", "star", "plus"}
+	for i, it := range got {
+		if it.Description != wantDesc[i] {
+			t.Errorf("item %d Description = %q, want %q", i, it.Description, wantDesc[i])
+		}
+	}
+}
+
+// TestParseChecklist_IndentedItems: indented checklists are still
+// parsed. Indentation in AC lists is unusual but not invalid.
+func TestParseChecklist_IndentedItems(t *testing.T) {
+	body := "- [ ] top\n  - [ ] indented\n    - [ ] deeper"
+	got := ParseChecklist(body)
+	if len(got) != 3 {
+		t.Fatalf("got %d items, want 3: %+v", len(got), got)
+	}
+}
+
+// TestParseChecklist_PreservesMarkdownInDescription: bold, code, and
+// links inside an AC item's description are preserved verbatim. The
+// judge gets the original text; the renderer can format it.
+func TestParseChecklist_PreservesMarkdownInDescription(t *testing.T) {
+	body := "- [ ] Add `Client.Foo()` in **internal/agents/codex** per [docs](https://example.com)"
+	got := ParseChecklist(body)
+	if len(got) != 1 {
+		t.Fatalf("got %d items, want 1", len(got))
+	}
+	want := "Add `Client.Foo()` in **internal/agents/codex** per [docs](https://example.com)"
+	if got[0].Description != want {
+		t.Errorf("Description = %q, want %q", got[0].Description, want)
+	}
+}
+
+// TestParseChecklist_FullIssueBody: the parser pulls only checkbox
+// lines out of a real-shaped issue body — section headers, prose,
+// notes, etc. are ignored.
+func TestParseChecklist_FullIssueBody(t *testing.T) {
+	body := `## Intent
+
+Add a Codex completer satisfying the completer interface.
+
+## Acceptance Criteria
+
+- [ ] New package internal/agents/codex
+- [ ] Shells out to the codex binary
+- [ ] IsAvailable() helper
+
+## Notes
+
+This depends on #130 landing for the registry registration.`
+	got := ParseChecklist(body)
+	if len(got) != 3 {
+		t.Fatalf("got %d items, want 3: %+v", len(got), got)
+	}
+	wantDesc := []string{
+		"New package internal/agents/codex",
+		"Shells out to the codex binary",
+		"IsAvailable() helper",
+	}
+	for i, it := range got {
+		if it.Description != wantDesc[i] {
+			t.Errorf("item %d Description = %q, want %q", i, it.Description, wantDesc[i])
+		}
+	}
+}
+
+// TestParseChecklist_StableNames: items get stable, ordered names
+// (ac_1, ac_2, ...) so the judge can echo them verbatim and
+// post-processing can match. Names are 1-indexed because they
+// appear in user-facing rendering.
+func TestParseChecklist_StableNames(t *testing.T) {
+	body := "- [ ] one\n- [ ] two\n- [ ] three"
+	got := ParseChecklist(body)
+	wantNames := []string{"ac_1", "ac_2", "ac_3"}
+	for i, it := range got {
+		if it.Name != wantNames[i] {
+			t.Errorf("item %d Name = %q, want %q", i, it.Name, wantNames[i])
+		}
+	}
+}
+
+// TestParseChecklist_TrimsTrailingWhitespace: trailing spaces and
+// CRs in a description don't leak into the parsed item.
+func TestParseChecklist_TrimsTrailingWhitespace(t *testing.T) {
+	body := "- [ ] item with trailing spaces   \r\n- [x] another\t  \n"
+	got := ParseChecklist(body)
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2", len(got))
+	}
+	if got[0].Description != "item with trailing spaces" {
+		t.Errorf("item 0 Description = %q (not trimmed)", got[0].Description)
+	}
+	if got[1].Description != "another" {
+		t.Errorf("item 1 Description = %q (not trimmed)", got[1].Description)
+	}
+}
+
+// TestParseChecklist_IgnoresNonCheckboxBrackets: lines that have
+// brackets but aren't checkbox-shaped (e.g. just bullets) must not
+// be parsed as AC items.
+func TestParseChecklist_IgnoresNonCheckboxBrackets(t *testing.T) {
+	body := `- normal bullet
+- [stuff] in brackets but no space-or-x
+- [ ] real ac
+- [other] still not a checkbox`
+	got := ParseChecklist(body)
+	if len(got) != 1 {
+		t.Fatalf("got %d items, want 1: %+v", len(got), got)
+	}
+	if got[0].Description != "real ac" {
+		t.Errorf("Description = %q, want 'real ac'", got[0].Description)
+	}
+}

--- a/internal/judges/plan/judge.go
+++ b/internal/judges/plan/judge.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/config"
@@ -140,7 +141,7 @@ var systemPrompt = systemPromptCore + "\n\n" + standards.Block
 // Pass is determined by whether the score meets the configured coverage
 // threshold AND there are no blocking gaps. Blocking is assigned from the
 // configured severity block-on list, not the LLM's opinion.
-func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string, acknowledged []state.Assumption) (*state.Verdict, error) {
+func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string, acknowledged []state.Assumption, checklist []state.ChecklistItem) (*state.Verdict, error) {
 	prompt := fmt.Sprintf("## Intent\n%s\n\n## Plan\n%s", intent, plan)
 
 	if len(acknowledged) > 0 {
@@ -152,10 +153,37 @@ func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string, ackno
 		}
 	}
 
+	// Inject the AC list when the task carries one. Same shared
+	// helper as the quality judge — the contract is identical, the
+	// evidence form differs (here it's a quote from the plan,
+	// downstream it's a file:line in the diff). Catching missed AC
+	// at plan time saves a wasted code phase on a doomed plan.
+	prompt += verdictschema.RenderACSection(checklist)
+
 	var verdict state.Verdict
 	tool := verdictschema.VerdictTool("Submit the plan judge verdict as a structured object. Omit score, pass, and blocking — they are computed from the gap severities.")
 	if err := j.client.CompleteWithTool(ctx, systemPrompt, prompt, tool, &verdict); err != nil {
 		return nil, fmt.Errorf("judging plan: %w", err)
+	}
+
+	// AC tracing post-processing. Mirrors quality judge: merge audit
+	// + source, surface a Critical Blocking gap for any Required
+	// item the model left unpassed without a deferral reason.
+	if len(checklist) > 0 {
+		merged := verdictschema.MergeChecklistAudit(checklist, verdict.Checklist)
+		verdict.Checklist = merged
+		for _, it := range merged {
+			if !it.Required || it.Passed {
+				continue
+			}
+			if strings.TrimSpace(it.Reason) != "" {
+				continue
+			}
+			verdict.Gaps = append(verdict.Gaps, state.Gap{
+				Severity:    state.SeverityCritical,
+				Description: fmt.Sprintf("Plan does not cover acceptance criterion: %s", it.Description),
+			})
+		}
 	}
 
 	// Always pass a non-nil map — empty BlockOn must mean "nothing blocks",
@@ -193,7 +221,15 @@ func (j *PlanJudge) Judge(ctx context.Context, intent string, plan string, ackno
 	}
 
 	verdict.Score = verdictschema.ComputeScoreWithAcknowledged(verdict.Gaps, acknowledged)
-	verdict.Pass = verdict.Score >= j.cfg.CoverageThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
+	// Pass gate: when the task carries an AC list, use the new
+	// mechanical gate (DeriveVerdictState — zero blocking gaps +
+	// every Required item Passed-or-deferred-with-reason). Legacy
+	// tasks without a checklist keep the threshold-based pass.
+	if len(verdict.Checklist) > 0 {
+		verdict.Pass = state.DeriveVerdictState(verdict.Gaps, verdict.Checklist) == state.VerdictPass
+	} else {
+		verdict.Pass = verdict.Score >= j.cfg.CoverageThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
+	}
 	verdict.Model = j.client.Model()
 
 	return &verdict, nil

--- a/internal/judges/plan/judge_test.go
+++ b/internal/judges/plan/judge_test.go
@@ -47,7 +47,7 @@ func TestJudge_BaselineViolationForcedBlocking_UnderPermissiveConfig(t *testing.
 	}
 	judge := New(fake, cfg)
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestJudge_NonBaselineP1StillGovernedByConfig(t *testing.T) {
 	}
 	judge := New(fake, cfg)
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestJudge_Pass_NoGapsScoresFull(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes\n3. Write tests", nil)
+	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes\n3. Write tests", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestJudge_Fail_BlockingGapsDriveScoreDown(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers", nil)
+	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestJudge_BlockingIgnoresLLMOpinion(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestJudge_AccumulatedP2sDragScoreBelowThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestJudge_PassTrueAtExactThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestJudge_P3GapsDeferred(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestJudge_ClientError(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	_, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	_, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err == nil {
 		t.Fatal("expected error when client fails")
 	}
@@ -300,7 +300,7 @@ func TestJudge_CustomSeverityConfig(t *testing.T) {
 	}
 
 	judge := New(fake, cfg)
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestJudge_EmptyGapsAndQuestions(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestJudge_SummaryRoundTrip(t *testing.T) {
 	}
 
 	judge := New(fake, defaultCfg())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestJudge_AcknowledgedAssumptionsInPrompt(t *testing.T) {
 		{Description: "caching strategy TBD", Severity: state.SeverityMedium, Phase: state.PhasePlan},
 	}
 
-	_, err := judge.Judge(context.Background(), "intent", "plan", assumptions)
+	_, err := judge.Judge(context.Background(), "intent", "plan", assumptions, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestJudge_VerdictStampedWithModel(t *testing.T) {
 	}
 	judge := New(fake, defaultCfg())
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestJudge_ReflaggedGapHalvedPenalty(t *testing.T) {
 		{Description: "database choice unclear", Severity: state.SeverityMedium},
 	}
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", acknowledged)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", acknowledged, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -461,5 +461,125 @@ func TestJudge_ReflaggedGapHalvedPenalty(t *testing.T) {
 	// 100 - 5 (halved re-flag) - 10 (new) = 85
 	if verdict.Score != 85 {
 		t.Errorf("expected score 85 (halved re-flag penalty), got %f", verdict.Score)
+	}
+}
+
+// --- AC tracing tests (mirror quality judge AC tests) ---
+//
+// Plan-time AC enforcement catches missed AC items before the code
+// phase runs — saves a wasted code phase on a doomed plan. Same
+// shape as the quality-judge AC contract: per-item ticking, deferral
+// allowed with non-empty reason, omission blocks.
+
+func TestJudge_AC_PromptIncludesItems(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{}}
+	judge := New(fake, defaultCfg())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "Add codex completer", Required: true},
+		{Name: "ac_2", Description: "Wire into resolver", Required: true},
+	}
+	if _, err := judge.Judge(context.Background(), "intent", "plan", nil, checklist); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	prompt := fake.Calls[0].Prompt
+	for _, want := range []string{"## Acceptance Criteria", "ac_1", "ac_2", "Add codex completer", "Wire into resolver", "evidence would I expect to see"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("plan judge prompt missing %q\n%s", want, prompt)
+		}
+	}
+}
+
+func TestJudge_AC_AllPassedYieldsPass(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Passed: true, Reason: "plan section 1: builds completer"},
+			{Name: "ac_2", Passed: true, Reason: "plan section 3: wires resolver"},
+		},
+	}}
+	judge := New(fake, defaultCfg())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first", Required: true},
+		{Name: "ac_2", Description: "second", Required: true},
+	}
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Pass {
+		t.Errorf("verdict.Pass = false, want true; gaps: %+v", verdict.Gaps)
+	}
+	if verdict.Checklist[0].Description != "first" {
+		t.Errorf("checklist[0].Description = %q, want first", verdict.Checklist[0].Description)
+	}
+}
+
+func TestJudge_AC_UnmetWithoutReasonBlocks(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Passed: true, Reason: "covered in plan"},
+			{Name: "ac_2", Passed: false}, // omitted from plan, no reason
+		},
+	}}
+	judge := New(fake, defaultCfg())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first", Required: true},
+		{Name: "ac_2", Description: "wire codex into resolver", Required: true},
+	}
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Pass {
+		t.Errorf("verdict.Pass = true, want false (ac_2 unmet)")
+	}
+	var found bool
+	for _, g := range verdict.Gaps {
+		// Plan judge phrasing is "Plan does not cover ..." so the
+		// surfaced gap is distinguishable from the quality judge's.
+		if g.Blocking && strings.Contains(g.Description, "Plan does not cover") && strings.Contains(g.Description, "wire codex into resolver") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a Critical Blocking gap for the unmet AC item\ngaps: %+v", verdict.Gaps)
+	}
+}
+
+func TestJudge_AC_DeferredWithReasonPasses(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Passed: true, Reason: "plan covers it"},
+			{Name: "ac_2", Passed: false, Reason: "blocked on #130 (registry doesn't exist yet)"},
+		},
+	}}
+	judge := New(fake, defaultCfg())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first", Required: true},
+		{Name: "ac_2", Description: "register with registry", Required: true},
+	}
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Pass {
+		t.Errorf("verdict.Pass = false, want true (ac_2 deferred with reason)")
+	}
+}
+
+func TestJudge_AC_EmptyChecklistPreservesLegacyBehaviour(t *testing.T) {
+	// No AC list → score-based legacy gate stays active. With no
+	// gaps the score is 100 and Pass is true.
+	fake := &claude.FakeClient{Response: state.Verdict{}}
+	judge := New(fake, defaultCfg())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Pass {
+		t.Error("legacy-mode plan verdict with no gaps should pass")
+	}
+	if strings.Contains(fake.Calls[0].Prompt, "## Acceptance Criteria") {
+		t.Error("plan judge prompt should not include AC section when checklist is empty")
 	}
 }

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -641,9 +641,9 @@ func RenderCrossPushFraming(priorGaps []state.Gap) string {
 // instead of inventing fresh findings for code that pre-dated the
 // prior review. nil/empty disables the framing — used for first-round
 // reviews and one-shot calls (e.g. `vairdict review`).
-func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap) (*state.Verdict, error) {
+func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap, checklist []state.ChecklistItem) (*state.Verdict, error) {
 	// Step 1: AI intent verification.
-	verdict, err := j.evaluateIntent(ctx, intent, plan, diff, priorGaps)
+	verdict, err := j.evaluateIntent(ctx, intent, plan, diff, priorGaps, checklist)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating intent: %w", err)
 	}
@@ -654,6 +654,32 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 	if j.cfg.Phases.Quality.E2ERequired && j.cfg.Commands.E2E != "" {
 		if e2eGap := j.runE2E(ctx, "."); e2eGap != nil {
 			verdict.Gaps = append(verdict.Gaps, *e2eGap)
+		}
+	}
+
+	// Step 3: AC tracing. When the task carries a parsed AC checklist
+	// from the issue body, merge the model's per-item audit response
+	// (verdict.Checklist as returned by the tool) with the source list
+	// — the source contributes Description/Required/Name (which the
+	// model cannot rewrite), the audit contributes Passed/Reason. For
+	// every Required item the gate would fail on (unpassed AND no
+	// reason), surface a Critical Blocking gap so the verdict comment
+	// explains what's missing rather than just emitting an opaque
+	// NEEDS_WORK.
+	if len(checklist) > 0 {
+		merged := verdictschema.MergeChecklistAudit(checklist, verdict.Checklist)
+		verdict.Checklist = merged
+		for _, it := range merged {
+			if !it.Required || it.Passed {
+				continue
+			}
+			if strings.TrimSpace(it.Reason) != "" {
+				continue
+			}
+			verdict.Gaps = append(verdict.Gaps, state.Gap{
+				Severity:    state.SeverityCritical,
+				Description: fmt.Sprintf("Acceptance criterion not satisfied: %s", it.Description),
+			})
 		}
 	}
 
@@ -669,7 +695,17 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 		slog.Info("baseline rule forced blocking", "gaps_promoted", promoted)
 	}
 	verdict.Score = verdictschema.ComputeScore(verdict.Gaps)
-	verdict.Pass = verdict.Score >= PassThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
+	// Pass gate: when the task ships an AC list, use the new
+	// mechanical gate (DeriveVerdictState — zero blocking gaps + every
+	// Required item Passed-or-deferred-with-reason). Legacy tasks
+	// without a checklist keep the threshold-based pass for
+	// backwards compatibility; flipping that path is out of scope
+	// here.
+	if len(verdict.Checklist) > 0 {
+		verdict.Pass = state.DeriveVerdictState(verdict.Gaps, verdict.Checklist) == state.VerdictPass
+	} else {
+		verdict.Pass = verdict.Score >= PassThreshold && !verdictschema.HasBlockingGap(verdict.Gaps)
+	}
 	verdict.ReturnTo = normaliseReturnTo(verdict.ReturnTo, verdict.Pass, verdict.Gaps)
 	verdict.Model = j.client.Model()
 
@@ -677,6 +713,7 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 		"score", verdict.Score,
 		"pass", verdict.Pass,
 		"gaps", len(verdict.Gaps),
+		"checklist", len(verdict.Checklist),
 		"model", verdict.Model,
 	)
 
@@ -684,7 +721,7 @@ func (j *QualityJudge) Judge(ctx context.Context, intent string, plan string, di
 }
 
 // evaluateIntent uses the Claude API to assess whether the diff matches the intent.
-func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap) (*state.Verdict, error) {
+func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan string, diff string, priorGaps []state.Gap, checklist []state.ChecklistItem) (*state.Verdict, error) {
 	diffSection := diff
 	if strings.TrimSpace(diffSection) == "" {
 		diffSection = "(no diff provided — judge cannot evaluate code changes)"
@@ -703,9 +740,10 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 	// review, not after it has already started forming opinions. Empty
 	// for first-round reviews (priorGaps==nil).
 	framing := RenderCrossPushFraming(priorGaps)
+	acSection := renderACSection(checklist)
 	prompt := fmt.Sprintf(
-		"%s## Original Intent\n%s\n\n## Approved Plan\n%s%s\n\n## Diff (unified format)\n```diff\n%s\n```",
-		framing, intent, plan, facts, diffSection,
+		"%s## Original Intent\n%s\n\n## Approved Plan\n%s%s%s\n\n## Diff (unified format)\n```diff\n%s\n```",
+		framing, intent, plan, facts, acSection, diffSection,
 	)
 
 	var verdict state.Verdict
@@ -719,6 +757,40 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 	}
 
 	return &verdict, nil
+}
+
+// renderACSection produces the "## Acceptance Criteria" prompt
+// fragment listing the AC items the judge must tick, with explicit
+// per-item-evidence instructions. Empty when the task carries no AC
+// checklist; in that case the judge runs in legacy mode (score-based
+// pass, no AC enforcement).
+//
+// The instructions are deliberately repetitive of the schema's
+// `checklist` field description — the prompt repeats the contract so
+// the model walks it consciously instead of treating it as a side
+// effect of the tool call. The negative-space prompt ("which files
+// would I expect to change?") is the load-bearing part — without it
+// the model tends to mark items met based on plausibility rather
+// than diff evidence.
+func renderACSection(items []state.ChecklistItem) string {
+	if len(items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n## Acceptance Criteria\n\n")
+	b.WriteString("For EACH item below, populate one entry in the submit_verdict tool's `checklist` array. Use the exact `name` shown.\n\n")
+	b.WriteString("Contract:\n")
+	b.WriteString("- `passed=true` requires concrete file:line evidence in `reason`. If you can't cite a hunk in the diff that satisfies the criterion, do not mark it passed.\n")
+	b.WriteString("- `passed=false` requires a deferral note in `reason` explaining why this item isn't being completed (e.g. \"blocked on #N\", \"needs upstream X\", \"out of scope per <commit>\"). Empty `reason` on an unpassed item BLOCKS the verdict — the judge cannot quietly skip an AC item.\n\n")
+	b.WriteString("Negative-space check, run for each item before deciding `passed`:\n")
+	b.WriteString("1. Which files would I expect to change to satisfy this criterion?\n")
+	b.WriteString("2. Did those files actually change in the diff?\n")
+	b.WriteString("3. If no, this item is NOT done, even if related work is present.\n\n")
+	b.WriteString("Items:\n")
+	for _, it := range items {
+		b.WriteString(fmt.Sprintf("- `%s`: %s\n", it.Name, it.Description))
+	}
+	return b.String()
 }
 
 // runE2E executes the configured e2e command and returns a Gap if it fails, or nil on success.

--- a/internal/judges/quality/judge.go
+++ b/internal/judges/quality/judge.go
@@ -740,7 +740,7 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 	// review, not after it has already started forming opinions. Empty
 	// for first-round reviews (priorGaps==nil).
 	framing := RenderCrossPushFraming(priorGaps)
-	acSection := renderACSection(checklist)
+	acSection := verdictschema.RenderACSection(checklist)
 	prompt := fmt.Sprintf(
 		"%s## Original Intent\n%s\n\n## Approved Plan\n%s%s%s\n\n## Diff (unified format)\n```diff\n%s\n```",
 		framing, intent, plan, facts, acSection, diffSection,
@@ -757,40 +757,6 @@ func (j *QualityJudge) evaluateIntent(ctx context.Context, intent string, plan s
 	}
 
 	return &verdict, nil
-}
-
-// renderACSection produces the "## Acceptance Criteria" prompt
-// fragment listing the AC items the judge must tick, with explicit
-// per-item-evidence instructions. Empty when the task carries no AC
-// checklist; in that case the judge runs in legacy mode (score-based
-// pass, no AC enforcement).
-//
-// The instructions are deliberately repetitive of the schema's
-// `checklist` field description — the prompt repeats the contract so
-// the model walks it consciously instead of treating it as a side
-// effect of the tool call. The negative-space prompt ("which files
-// would I expect to change?") is the load-bearing part — without it
-// the model tends to mark items met based on plausibility rather
-// than diff evidence.
-func renderACSection(items []state.ChecklistItem) string {
-	if len(items) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString("\n\n## Acceptance Criteria\n\n")
-	b.WriteString("For EACH item below, populate one entry in the submit_verdict tool's `checklist` array. Use the exact `name` shown.\n\n")
-	b.WriteString("Contract:\n")
-	b.WriteString("- `passed=true` requires concrete file:line evidence in `reason`. If you can't cite a hunk in the diff that satisfies the criterion, do not mark it passed.\n")
-	b.WriteString("- `passed=false` requires a deferral note in `reason` explaining why this item isn't being completed (e.g. \"blocked on #N\", \"needs upstream X\", \"out of scope per <commit>\"). Empty `reason` on an unpassed item BLOCKS the verdict — the judge cannot quietly skip an AC item.\n\n")
-	b.WriteString("Negative-space check, run for each item before deciding `passed`:\n")
-	b.WriteString("1. Which files would I expect to change to satisfy this criterion?\n")
-	b.WriteString("2. Did those files actually change in the diff?\n")
-	b.WriteString("3. If no, this item is NOT done, even if related work is present.\n\n")
-	b.WriteString("Items:\n")
-	for _, it := range items {
-		b.WriteString(fmt.Sprintf("- `%s`: %s\n", it.Name, it.Description))
-	}
-	return b.String()
 }
 
 // runE2E executes the configured e2e command and returns a Gap if it fails, or nil on success.

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -1244,8 +1244,7 @@ func TestJudge_AC_PromptIncludesItems(t *testing.T) {
 	// Negative-space instruction must reach the model — that's the
 	// load-bearing instruction for catching "looked plausible, not
 	// actually done" misses.
-	if !strings.Contains(prompt, "files would I expect to change") &&
-		!strings.Contains(prompt, "files would you expect to change") {
+	if !strings.Contains(prompt, "evidence would I expect to see") {
 		t.Errorf("prompt missing negative-space instruction\n%s", prompt)
 	}
 }

--- a/internal/judges/quality/judge_test.go
+++ b/internal/judges/quality/judge_test.go
@@ -44,7 +44,7 @@ func TestQualityJudge_BaselineMarkerForcesBlocking(t *testing.T) {
 	}
 	judge := New(fake, nil, testConfig())
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestQualityJudge_VerdictStampedWithModel(t *testing.T) {
 	}
 	judge := New(fake, nil, testConfig())
 
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "diff --git a/x.go b/x.go\n+func H() {}", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "diff --git a/x.go b/x.go\n+func H() {}", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestJudge_Pass_NoGapsScoresFull(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes", "diff --git a/x.go b/x.go\n+func H() {}", nil)
+	verdict, err := judge.Judge(context.Background(), "build a REST API", "1. Create handlers\n2. Add routes", "diff --git a/x.go b/x.go\n+func H() {}", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestJudge_IntentMismatch_P0Blocks(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "build auth system", "1. Implement auth", "diff --git a/x.go b/x.go\n+func crud() {}", nil)
+	verdict, err := judge.Judge(context.Background(), "build auth system", "1. Implement auth", "diff --git a/x.go b/x.go\n+func crud() {}", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestJudge_E2EPass(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestJudge_E2EFail_AddsBlockingGap(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestJudge_E2ENotRequired(t *testing.T) {
 	// E2ERequired is false by default.
 
 	judge := New(fake, nil, cfg)
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestJudge_E2ERequiredNoCommand(t *testing.T) {
 	// Commands.E2E is empty.
 
 	judge := New(fake, nil, cfg)
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestJudge_AccumulatedP2sDragBelowThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestJudge_PassAtExactThreshold(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestJudge_ClientError(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err == nil {
 		t.Fatal("expected error when client fails")
 	}
@@ -374,7 +374,7 @@ func TestJudge_MixedGapsWithE2E(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -416,7 +416,7 @@ func TestJudge_ScoreFloorAtZero(t *testing.T) {
 	}
 
 	judge := New(fake, runner, testConfigWithE2E())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -436,7 +436,7 @@ func TestJudge_PromptContainsDiff(t *testing.T) {
 
 	judge := New(fake, nil, testConfig())
 	const diff = "diff --git a/foo.go b/foo.go\n+++ b/foo.go\n+func Foo() {}"
-	_, err := judge.Judge(context.Background(), "intent", "plan", diff, nil)
+	_, err := judge.Judge(context.Background(), "intent", "plan", diff, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestJudge_EmptyDiffPlaceholder(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	_, err := judge.Judge(context.Background(), "intent", "plan", "", nil)
+	_, err := judge.Judge(context.Background(), "intent", "plan", "", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -486,7 +486,7 @@ func TestJudge_SummaryRoundTrip(t *testing.T) {
 	cfg := config.Config{}
 	cfg.Phases.Quality.E2ERequired = false
 	judge := New(fake, &FakeRunner{}, cfg)
-	verdict, err := judge.Judge(context.Background(), "build it", "the plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "build it", "the plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -694,7 +694,7 @@ func TestJudge_GapWithFileAndLine(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -719,7 +719,7 @@ func TestJudge_CodeFactsInjectedIntoPrompt(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig()).WithCodeFacts("Score: 100%\nAll checks passed (lint, test, build)")
-	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -785,7 +785,7 @@ func TestJudge_BlockingGapFailsEvenWithHighScore(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -810,7 +810,7 @@ func TestJudge_NonBlockingGapsAllowPass(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -907,7 +907,7 @@ func TestJudge_ReturnTo_ClearedOnPass(t *testing.T) {
 		},
 	}
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -939,7 +939,7 @@ func TestJudge_ReturnTo_Propagated(t *testing.T) {
 				},
 			}
 			judge := New(fake, nil, testConfig())
-			verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+			verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -966,7 +966,7 @@ func TestJudge_ReturnTo_DefaultsToCodeOnBlockingFailure(t *testing.T) {
 		},
 	}
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -993,7 +993,7 @@ func TestJudge_ReturnTo_EmptyForNonBlockingFailure(t *testing.T) {
 		},
 	}
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1019,7 +1019,7 @@ func TestJudge_ReturnTo_UnknownValueCollapsesToCode(t *testing.T) {
 		},
 	}
 	judge := New(fake, nil, testConfig())
-	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1051,7 +1051,7 @@ func TestJudge_UsesCompleteWithTools(t *testing.T) {
 	}
 
 	judge := New(fake, nil, testConfig())
-	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil)
+	_, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1170,7 +1170,7 @@ func TestJudge_PrependsCrossPushFramingWhenPriorGapsPresent(t *testing.T) {
 	prior := []state.Gap{
 		{Severity: state.SeverityCritical, Description: "auth missing on /admin"},
 	}
-	if _, err := judge.Judge(context.Background(), "intent", "plan", "diff", prior); err != nil {
+	if _, err := judge.Judge(context.Background(), "intent", "plan", "diff", prior, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(fake.Calls) != 1 {
@@ -1196,7 +1196,7 @@ func TestJudge_OmitsCrossPushFramingOnFirstReview(t *testing.T) {
 	fake := &claude.FakeClient{Response: state.Verdict{Gaps: []state.Gap{}}}
 	judge := New(fake, nil, testConfig())
 
-	if _, err := judge.Judge(context.Background(), "intent", "plan", "diff", nil); err != nil {
+	if _, err := judge.Judge(context.Background(), "intent", "plan", "diff", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(fake.Calls) != 1 {
@@ -1204,5 +1204,217 @@ func TestJudge_OmitsCrossPushFramingOnFirstReview(t *testing.T) {
 	}
 	if strings.Contains(fake.Calls[0].Prompt, "Cross-push awareness") {
 		t.Error("first-review prompt should not contain cross-push framing")
+	}
+}
+
+// --- AC-tracing tests (#126 / judge AC enforcement) ---
+//
+// These tests pin the contract that gives a quality judge teeth
+// against literally-skipped acceptance criteria. With an AC list
+// from the issue body, the judge MUST: (a) include every item by
+// name in the prompt, (b) merge the model's per-item audit response
+// into a final Checklist, (c) gate Pass on every Required item being
+// either Passed or unpassed-with-reason, (d) surface a Critical
+// Blocking gap for every unpassed-no-reason item so the verdict
+// comment explains the failure.
+
+// TestJudge_AC_PromptIncludesItems: the AC list must reach the
+// model under a clearly labelled "## Acceptance Criteria" section
+// with stable item names. Without this the model has no affordance
+// to populate the checklist field of submit_verdict.
+func TestJudge_AC_PromptIncludesItems(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{}}
+	judge := New(fake, nil, testConfig())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "Add codex completer", Required: true},
+		{Name: "ac_2", Description: "Wire into resolver", Required: true},
+	}
+	if _, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, checklist); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	prompt := fake.Calls[0].Prompt
+	if !strings.Contains(prompt, "## Acceptance Criteria") {
+		t.Errorf("prompt missing AC section header\n%s", prompt)
+	}
+	for _, want := range []string{"ac_1", "ac_2", "Add codex completer", "Wire into resolver"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q\n%s", want, prompt)
+		}
+	}
+	// Negative-space instruction must reach the model — that's the
+	// load-bearing instruction for catching "looked plausible, not
+	// actually done" misses.
+	if !strings.Contains(prompt, "files would I expect to change") &&
+		!strings.Contains(prompt, "files would you expect to change") {
+		t.Errorf("prompt missing negative-space instruction\n%s", prompt)
+	}
+}
+
+// TestJudge_AC_AllPassedYieldsPass: every required item passed with
+// evidence → verdict.Pass=true, verdict.Checklist round-trips with
+// merged Description/Required from source and Passed/Reason from
+// the model's audit.
+func TestJudge_AC_AllPassedYieldsPass(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Passed: true, Reason: "internal/foo.go:42"},
+			{Name: "ac_2", Passed: true, Reason: "internal/bar.go:7"},
+		},
+	}}
+	judge := New(fake, nil, testConfig())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first", Required: true},
+		{Name: "ac_2", Description: "second", Required: true},
+	}
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Pass {
+		t.Errorf("verdict.Pass = false, want true; gaps: %+v checklist: %+v", verdict.Gaps, verdict.Checklist)
+	}
+	if len(verdict.Checklist) != 2 {
+		t.Fatalf("verdict.Checklist len = %d, want 2", len(verdict.Checklist))
+	}
+	// Description must come from source, evidence from audit.
+	if verdict.Checklist[0].Description != "first" {
+		t.Errorf("verdict.Checklist[0].Description = %q, want first", verdict.Checklist[0].Description)
+	}
+	if verdict.Checklist[0].Reason != "internal/foo.go:42" {
+		t.Errorf("verdict.Checklist[0].Reason = %q, want evidence", verdict.Checklist[0].Reason)
+	}
+}
+
+// TestJudge_AC_UnmetWithoutReasonBlocks: an item the model leaves
+// unpassed with empty reason MUST: (a) flip Pass to false, (b)
+// produce a Critical Blocking gap citing the unsatisfied criterion
+// so the verdict comment explains why it failed instead of just
+// emitting NEEDS_WORK.
+func TestJudge_AC_UnmetWithoutReasonBlocks(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Passed: true, Reason: "internal/foo.go:1"},
+			{Name: "ac_2", Passed: false}, // no reason — unjustified skip
+		},
+	}}
+	judge := New(fake, nil, testConfig())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first", Required: true},
+		{Name: "ac_2", Description: "wire codex into resolver", Required: true},
+	}
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Pass {
+		t.Errorf("verdict.Pass = true, want false (ac_2 unmet without reason)")
+	}
+	// A blocking critical gap must surface the unsatisfied criterion.
+	var found bool
+	for _, g := range verdict.Gaps {
+		if g.Severity == state.SeverityCritical && g.Blocking && strings.Contains(g.Description, "wire codex into resolver") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a Critical Blocking gap citing the unmet AC item\ngaps: %+v", verdict.Gaps)
+	}
+}
+
+// TestJudge_AC_DeferredWithReasonPasses: an unpassed Required item
+// with a non-empty reason is acceptable — the deferral is recorded
+// in the verdict but does not block. This is the "be honest about
+// what's not done" path.
+func TestJudge_AC_DeferredWithReasonPasses(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Passed: true, Reason: "internal/foo.go:1"},
+			{Name: "ac_2", Passed: false, Reason: "deferred: depends on #130 (registry)"},
+		},
+	}}
+	judge := New(fake, nil, testConfig())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first", Required: true},
+		{Name: "ac_2", Description: "register with registry", Required: true},
+	}
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Pass {
+		t.Errorf("verdict.Pass = false, want true (ac_2 deferred with reason)")
+	}
+	// No critical blocking gap should be added for the deferred item.
+	for _, g := range verdict.Gaps {
+		if g.Severity == state.SeverityCritical && strings.Contains(g.Description, "register with registry") {
+			t.Errorf("deferred-with-reason item must not produce a blocking gap: %+v", g)
+		}
+	}
+	// The deferral reason survives in verdict.Checklist.
+	if verdict.Checklist[1].Reason != "deferred: depends on #130 (registry)" {
+		t.Errorf("verdict.Checklist[1].Reason = %q, want the deferral note", verdict.Checklist[1].Reason)
+	}
+}
+
+// TestJudge_AC_MissingAuditEntryBlocks: if the model fails to emit
+// an audit entry for an AC item at all, the merge keeps Passed=false
+// from the source and empty Reason — the gate must block. The judge
+// cannot quietly skip an item by omission.
+func TestJudge_AC_MissingAuditEntryBlocks(t *testing.T) {
+	fake := &claude.FakeClient{Response: state.Verdict{
+		Checklist: []state.ChecklistItem{
+			{Name: "ac_1", Passed: true, Reason: "evidence"},
+			// ac_2 omitted by the model
+		},
+	}}
+	judge := New(fake, nil, testConfig())
+	checklist := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first", Required: true},
+		{Name: "ac_2", Description: "second", Required: true},
+	}
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verdict.Pass {
+		t.Error("verdict.Pass must be false when an AC has no audit entry")
+	}
+	// Sanity: the renderer-friendly gap must be present.
+	var found bool
+	for _, g := range verdict.Gaps {
+		if g.Blocking && strings.Contains(g.Description, "second") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a blocking gap explaining the missing AC item")
+	}
+}
+
+// TestJudge_AC_EmptyChecklistPreservesLegacyBehaviour: a task with
+// no AC list keeps the threshold-based legacy pass — verdict.Pass
+// reflects Score >= PassThreshold && !blocking. This guards
+// backwards compatibility for tasks that don't have a parsed
+// checklist (intents without `- [ ]` items).
+func TestJudge_AC_EmptyChecklistPreservesLegacyBehaviour(t *testing.T) {
+	// Score will be 100 (no gaps), no blocking — legacy gate passes.
+	fake := &claude.FakeClient{Response: state.Verdict{}}
+	judge := New(fake, nil, testConfig())
+	verdict, err := judge.Judge(context.Background(), "intent", "plan", "fake-diff", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Pass {
+		t.Error("legacy-mode verdict with no gaps should pass")
+	}
+	if len(verdict.Checklist) != 0 {
+		t.Errorf("legacy-mode verdict should have no Checklist, got %d items", len(verdict.Checklist))
+	}
+	// Prompt must NOT include the AC section when no checklist was
+	// supplied — otherwise we waste tokens on an empty section.
+	if strings.Contains(fake.Calls[0].Prompt, "## Acceptance Criteria") {
+		t.Error("prompt should not include AC section when checklist is empty")
 	}
 }

--- a/internal/judges/verdictschema/checklist.go
+++ b/internal/judges/verdictschema/checklist.go
@@ -40,7 +40,7 @@ func RenderACSection(items []state.ChecklistItem) string {
 	b.WriteString("3. If no, this item is NOT done, even if related work is present.\n\n")
 	b.WriteString("Items:\n")
 	for _, it := range items {
-		b.WriteString(fmt.Sprintf("- `%s`: %s\n", it.Name, it.Description))
+		fmt.Fprintf(&b, "- `%s`: %s\n", it.Name, it.Description)
 	}
 	return b.String()
 }

--- a/internal/judges/verdictschema/checklist.go
+++ b/internal/judges/verdictschema/checklist.go
@@ -1,0 +1,53 @@
+package verdictschema
+
+import "github.com/vairdict/vairdict/internal/state"
+
+// MergeChecklistAudit combines the source AC list (parsed from the
+// issue body) with the judge's per-item ticks into the final
+// Checklist that lands on state.Verdict.
+//
+// The audit slice carries the model's per-item response. Only the
+// Name, Passed, and Reason fields on each audit item matter — the
+// schema (schema.go) constrains the model to those three properties.
+// Description and Required come from the source; the judge cannot
+// rename items, mark them optional, or invent new ones.
+//
+// Rules:
+//
+//   - Source list is the source of truth for Description, Required,
+//     and Name.
+//   - When an audit entry matches a source Name, the source's
+//     Passed and Reason are replaced with the audit's values.
+//   - When a source item has no matching audit entry, it stays as
+//     the source had it — Passed=false from the parser yields
+//     empty Reason which (per the gate) blocks the verdict. This is
+//     the "judge cannot quietly skip an item" rule.
+//   - Pre-checked source items (Passed=true at parse time) are
+//     preserved; they were a human assertion and we don't undo
+//     that. The judge can still tick them in the audit (replacing
+//     Reason with evidence) — the merge prefers audit when
+//     present.
+//   - Audit entries with Names not present in the source list are
+//     dropped. The judge cannot extend the contract.
+//   - nil source returns nil regardless of the audit. Legacy mode
+//     where no AC list was provided.
+func MergeChecklistAudit(source, audit []state.ChecklistItem) []state.ChecklistItem {
+	if source == nil {
+		return nil
+	}
+	byName := make(map[string]state.ChecklistItem, len(audit))
+	for _, a := range audit {
+		byName[a.Name] = a
+	}
+	out := make([]state.ChecklistItem, len(source))
+	for i, s := range source {
+		out[i] = s
+		a, ok := byName[s.Name]
+		if !ok {
+			continue
+		}
+		out[i].Passed = a.Passed
+		out[i].Reason = a.Reason
+	}
+	return out
+}

--- a/internal/judges/verdictschema/checklist.go
+++ b/internal/judges/verdictschema/checklist.go
@@ -1,6 +1,49 @@
 package verdictschema
 
-import "github.com/vairdict/vairdict/internal/state"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// RenderACSection produces the "## Acceptance Criteria" prompt
+// fragment listing the AC items the judge must tick, with explicit
+// per-item-evidence instructions. Empty when the items slice is
+// empty; in that case the judge runs in legacy mode (no AC
+// enforcement).
+//
+// The instructions are deliberately repetitive of the schema's
+// `checklist` field description (schema.go) — the prompt repeats
+// the contract so the model walks it consciously instead of
+// treating it as a side effect of the tool call. The
+// negative-space prompt ("which files would I expect to change?")
+// is the load-bearing part — without it the model marks items met
+// based on plausibility rather than evidence.
+//
+// Shared between the plan judge (evidence is plan text covering
+// each AC) and the quality judge (evidence is file:line in the
+// diff). Both judges enforce the same per-item contract.
+func RenderACSection(items []state.ChecklistItem) string {
+	if len(items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n## Acceptance Criteria\n\n")
+	b.WriteString("For EACH item below, populate one entry in the submit_verdict tool's `checklist` array. Use the exact `name` shown.\n\n")
+	b.WriteString("Contract:\n")
+	b.WriteString("- `passed=true` requires concrete evidence in `reason` (file:line in the diff for the quality judge; a quote from the plan for the plan judge). If you can't cite the evidence, do not mark it passed.\n")
+	b.WriteString("- `passed=false` requires a deferral note in `reason` explaining why this item isn't being completed (e.g. \"blocked on #N\", \"needs upstream X\", \"out of scope per <commit>\"). Empty `reason` on an unpassed item BLOCKS the verdict — the judge cannot quietly skip an AC item.\n\n")
+	b.WriteString("Negative-space check, run for each item before deciding `passed`:\n")
+	b.WriteString("1. What concrete evidence would I expect to see to satisfy this criterion?\n")
+	b.WriteString("2. Is that evidence present?\n")
+	b.WriteString("3. If no, this item is NOT done, even if related work is present.\n\n")
+	b.WriteString("Items:\n")
+	for _, it := range items {
+		b.WriteString(fmt.Sprintf("- `%s`: %s\n", it.Name, it.Description))
+	}
+	return b.String()
+}
 
 // MergeChecklistAudit combines the source AC list (parsed from the
 // issue body) with the judge's per-item ticks into the final

--- a/internal/judges/verdictschema/checklist_test.go
+++ b/internal/judges/verdictschema/checklist_test.go
@@ -152,6 +152,45 @@ func TestMergeChecklistAudit_NilSource(t *testing.T) {
 	}
 }
 
+// TestRenderACSection_Empty: an empty items slice produces an empty
+// string so the prompt builder can concatenate it unconditionally
+// without leaving a stray header.
+func TestRenderACSection_Empty(t *testing.T) {
+	if got := RenderACSection(nil); got != "" {
+		t.Errorf("RenderACSection(nil) = %q, want empty", got)
+	}
+	if got := RenderACSection([]state.ChecklistItem{}); got != "" {
+		t.Errorf("RenderACSection(empty) = %q, want empty", got)
+	}
+}
+
+// TestRenderACSection_IncludesItemsAndContract: with a non-empty
+// list, the rendered fragment must include every item by name +
+// description, the contract bullets (passed/reason rules), and the
+// negative-space instruction. The schema's description and this
+// prompt fragment together form the model's instructions; one
+// without the other is incomplete.
+func TestRenderACSection_IncludesItemsAndContract(t *testing.T) {
+	items := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first item"},
+		{Name: "ac_2", Description: "second item"},
+	}
+	got := RenderACSection(items)
+	for _, want := range []string{
+		"## Acceptance Criteria",
+		"ac_1", "first item",
+		"ac_2", "second item",
+		"passed=true", "passed=false",
+		"reason",
+		"BLOCKS the verdict",
+		"evidence would I expect to see",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("RenderACSection missing %q\n%s", want, got)
+		}
+	}
+}
+
 // TestVerdictTool_DescriptionMentionsChecklistContract: the schema's
 // description text must tell the model it has to populate the
 // checklist with one entry per AC item and explain the

--- a/internal/judges/verdictschema/checklist_test.go
+++ b/internal/judges/verdictschema/checklist_test.go
@@ -1,0 +1,175 @@
+package verdictschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/vairdict/vairdict/internal/state"
+)
+
+// TestVerdictTool_SchemaIncludesChecklist: the submit_verdict tool's
+// JSON Schema must declare a `checklist` array so the model knows it
+// can (and must, when items are present) emit per-AC ticks. The
+// schema is the contract — if it's missing, the model has no
+// affordance to populate the field.
+func TestVerdictTool_SchemaIncludesChecklist(t *testing.T) {
+	tool := VerdictTool("test")
+	var schema map[string]any
+	if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema has no properties: %v", schema)
+	}
+	cl, ok := props["checklist"]
+	if !ok {
+		t.Fatalf("schema missing checklist property: %v", props)
+	}
+	clMap, ok := cl.(map[string]any)
+	if !ok {
+		t.Fatalf("checklist is not an object: %T", cl)
+	}
+	if clMap["type"] != "array" {
+		t.Errorf("checklist type = %v, want array", clMap["type"])
+	}
+	// Per-item shape must include name (id), passed (bool), reason (string).
+	items, ok := clMap["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("checklist items not an object: %v", clMap)
+	}
+	itemProps, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("checklist item missing properties: %v", items)
+	}
+	for _, want := range []string{"name", "passed", "reason"} {
+		if _, ok := itemProps[want]; !ok {
+			t.Errorf("checklist item missing %q field: %v", want, itemProps)
+		}
+	}
+}
+
+// TestMergeChecklistAudit_HappyPath: source ACs from the issue plus
+// the judge's per-item ticks merge into a final Checklist that
+// preserves Description/Required/Name from the source and applies
+// the judge's Passed/Reason verdict.
+func TestMergeChecklistAudit_HappyPath(t *testing.T) {
+	source := []state.ChecklistItem{
+		{Name: "ac_1", Description: "Add codex package", Required: true, Passed: false},
+		{Name: "ac_2", Description: "Wire into resolver", Required: true, Passed: false},
+	}
+	audit := []state.ChecklistItem{
+		{Name: "ac_1", Passed: true, Reason: "internal/agents/codex/client.go:127"},
+		{Name: "ac_2", Passed: false, Reason: "deferred: depends on #130"},
+	}
+	got := MergeChecklistAudit(source, audit)
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2", len(got))
+	}
+	if got[0].Name != "ac_1" || got[0].Description != "Add codex package" || !got[0].Passed {
+		t.Errorf("ac_1 wrong: %+v", got[0])
+	}
+	if got[0].Reason != "internal/agents/codex/client.go:127" {
+		t.Errorf("ac_1 Reason = %q", got[0].Reason)
+	}
+	if got[1].Name != "ac_2" || got[1].Description != "Wire into resolver" || got[1].Passed {
+		t.Errorf("ac_2 wrong: %+v", got[1])
+	}
+	if got[1].Reason != "deferred: depends on #130" {
+		t.Errorf("ac_2 Reason = %q", got[1].Reason)
+	}
+}
+
+// TestMergeChecklistAudit_MissingAuditEntry: if the judge fails to
+// emit an audit entry for a source item, the merged item keeps
+// Passed=false from the source AND gets an empty Reason so the gate
+// blocks. The judge cannot quietly skip an item by omission.
+func TestMergeChecklistAudit_MissingAuditEntry(t *testing.T) {
+	source := []state.ChecklistItem{
+		{Name: "ac_1", Description: "first", Required: true, Passed: false},
+		{Name: "ac_2", Description: "second", Required: true, Passed: false},
+	}
+	audit := []state.ChecklistItem{
+		{Name: "ac_1", Passed: true, Reason: "done at file:1"},
+		// ac_2 omitted
+	}
+	got := MergeChecklistAudit(source, audit)
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2 (one per source)", len(got))
+	}
+	if got[1].Passed {
+		t.Errorf("missing audit must not be Passed: %+v", got[1])
+	}
+	if got[1].Reason != "" {
+		t.Errorf("missing audit must have empty Reason so gate blocks, got: %q", got[1].Reason)
+	}
+	// Sanity: gate should now refuse to pass.
+	if state.RequiredPassed(got) {
+		t.Errorf("RequiredPassed should be false when an audit is missing")
+	}
+}
+
+// TestMergeChecklistAudit_AuditWithUnknownName: an audit entry
+// referring to a Name that isn't in the source list is dropped (the
+// judge cannot invent items). Existing source items are unaffected.
+func TestMergeChecklistAudit_AuditWithUnknownName(t *testing.T) {
+	source := []state.ChecklistItem{
+		{Name: "ac_1", Description: "real", Required: true, Passed: false},
+	}
+	audit := []state.ChecklistItem{
+		{Name: "ac_1", Passed: true, Reason: "ok"},
+		{Name: "ac_999", Passed: true, Reason: "made up"},
+	}
+	got := MergeChecklistAudit(source, audit)
+	if len(got) != 1 {
+		t.Fatalf("got %d items, want 1 (only the source item)", len(got))
+	}
+	if got[0].Name != "ac_1" {
+		t.Errorf("got %q, want ac_1", got[0].Name)
+	}
+}
+
+// TestMergeChecklistAudit_PreservesPrechecked: an issue body that
+// already had `- [x]` items keeps Passed=true from the source even
+// if the judge didn't emit an audit entry. Pre-checked items are
+// human-asserted; we don't undo that.
+func TestMergeChecklistAudit_PreservesPrechecked(t *testing.T) {
+	source := []state.ChecklistItem{
+		{Name: "ac_1", Description: "already done", Required: true, Passed: true},
+	}
+	got := MergeChecklistAudit(source, nil)
+	if !got[0].Passed {
+		t.Errorf("pre-checked item must remain Passed: %+v", got[0])
+	}
+}
+
+// TestMergeChecklistAudit_NilSource: nil source means no AC checklist
+// from the issue (legacy mode). Returns nil regardless of audit.
+func TestMergeChecklistAudit_NilSource(t *testing.T) {
+	if got := MergeChecklistAudit(nil, []state.ChecklistItem{{Name: "ac_1", Passed: true}}); got != nil {
+		t.Errorf("nil source should return nil, got: %+v", got)
+	}
+}
+
+// TestVerdictTool_DescriptionMentionsChecklistContract: the schema's
+// description text must tell the model it has to populate the
+// checklist with one entry per AC item and explain the
+// passed-needs-evidence vs unpassed-needs-reason contract. Without
+// this guidance the model emits empty arrays.
+func TestVerdictTool_DescriptionMentionsChecklistContract(t *testing.T) {
+	tool := VerdictTool("test")
+	var schema map[string]any
+	if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	props := schema["properties"].(map[string]any)
+	cl := props["checklist"].(map[string]any)
+	desc, _ := cl["description"].(string)
+	desc = strings.ToLower(desc)
+	for _, want := range []string{"acceptance", "evidence", "reason"} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("checklist description missing %q context: %q", want, desc)
+		}
+	}
+}

--- a/internal/judges/verdictschema/schema.go
+++ b/internal/judges/verdictschema/schema.go
@@ -64,6 +64,20 @@ const inputSchema = `{
       "type": "string",
       "enum": ["", "code", "plan", "escalate"],
       "description": "Quality-judge-only. On a failing verdict, the phase the outer loop should rewind to. Omit or leave empty on passing verdicts and on judges that do not drive cross-phase routing."
+    },
+    "checklist": {
+      "type": "array",
+      "description": "Per-acceptance-criteria audit. When the prompt provides a numbered AC list, emit ONE entry per AC item using the exact name (ac_1, ac_2, …) the prompt assigns. Set passed=true only when the diff actually satisfies the criterion — populate reason with concrete evidence (file:line). Set passed=false when the diff does not satisfy it AND populate reason with a deferral note (e.g. 'blocked on #N', 'needs upstream X'). An unpassed item with empty reason is treated as 'not done, no excuse' and blocks the verdict. Omit the array (or send []) when the prompt did not supply an AC list.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string", "description": "Stable id from the AC list in the prompt (ac_1, ac_2, …). Echo it verbatim."},
+          "passed": {"type": "boolean", "description": "true iff the diff satisfies this acceptance criterion."},
+          "reason": {"type": "string", "description": "When passed=true: file:line evidence. When passed=false: why this item is being deferred. Empty when passed=false blocks the verdict."}
+        },
+        "required": ["name", "passed"],
+        "additionalProperties": false
+      }
     }
   },
   "required": ["summary", "gaps", "questions"],

--- a/internal/phases/plan/phase.go
+++ b/internal/phases/plan/phase.go
@@ -46,7 +46,7 @@ type streamingPlanner interface {
 
 // Judge is the interface for the plan judge that evaluates plans.
 type Judge interface {
-	Judge(ctx context.Context, intent string, plan string, acknowledged []state.Assumption) (*state.Verdict, error)
+	Judge(ctx context.Context, intent string, plan string, acknowledged []state.Assumption, checklist []state.ChecklistItem) (*state.Verdict, error)
 }
 
 // PlanPhase orchestrates the plan phase: planner agent + judge loop.
@@ -169,7 +169,7 @@ func (p *PlanPhase) Run(ctx context.Context, task *state.Task) (*PhaseResult, er
 
 		// Run the judge.
 		p.notify(loop+1, p.cfg.MaxLoops, "judging plan", 0, false, nil)
-		verdict, err := p.judge.Judge(ctx, task.Intent, fullPlan, task.Assumptions)
+		verdict, err := p.judge.Judge(ctx, task.Intent, fullPlan, task.Assumptions, task.Checklist)
 		if err != nil {
 			return nil, fmt.Errorf("running plan judge: %w", err)
 		}

--- a/internal/phases/plan/phase_test.go
+++ b/internal/phases/plan/phase_test.go
@@ -67,7 +67,7 @@ type fakeJudge struct {
 	calls    int
 }
 
-func (f *fakeJudge) Judge(_ context.Context, _, _ string, _ []state.Assumption) (*state.Verdict, error) {
+func (f *fakeJudge) Judge(_ context.Context, _, _ string, _ []state.Assumption, _ []state.ChecklistItem) (*state.Verdict, error) {
 	i := f.calls
 	f.calls++
 

--- a/internal/phases/quality/phase.go
+++ b/internal/phases/quality/phase.go
@@ -44,7 +44,7 @@ type PhaseResult struct {
 // the cross-push framing block when this is non-empty so it doesn't re-flag
 // concerns already raised.
 type Judge interface {
-	Judge(ctx context.Context, intent, plan, diff string, priorGaps []state.Gap) (*state.Verdict, error)
+	Judge(ctx context.Context, intent, plan, diff string, priorGaps []state.Gap, checklist []state.ChecklistItem) (*state.Verdict, error)
 }
 
 // QualityPhase orchestrates the quality phase: judge loop on already-coded work.
@@ -104,7 +104,7 @@ func (p *QualityPhase) Run(ctx context.Context, task *state.Task, plan string) (
 		}
 
 		p.notify(loop+1, p.cfg.MaxLoops, "reviewing", 0, false, nil)
-		verdict, err := p.judge.Judge(ctx, task.Intent, plan, p.diff, priorGaps)
+		verdict, err := p.judge.Judge(ctx, task.Intent, plan, p.diff, priorGaps, task.Checklist)
 		if err != nil {
 			return nil, fmt.Errorf("running quality judge: %w", err)
 		}

--- a/internal/phases/quality/phase_test.go
+++ b/internal/phases/quality/phase_test.go
@@ -20,7 +20,7 @@ type fakeJudge struct {
 	priorGapsByCall [][]state.Gap
 }
 
-func (f *fakeJudge) Judge(_ context.Context, _, _, _ string, priorGaps []state.Gap) (*state.Verdict, error) {
+func (f *fakeJudge) Judge(_ context.Context, _, _, _ string, priorGaps []state.Gap, _ []state.ChecklistItem) (*state.Verdict, error) {
 	f.priorGapsByCall = append(f.priorGapsByCall, priorGaps)
 	if f.err != nil {
 		return nil, f.err

--- a/internal/state/checklist.go
+++ b/internal/state/checklist.go
@@ -1,5 +1,7 @@
 package state
 
+import "strings"
+
 // VerdictState is the binary outcome of the new pass gate. The score
 // number that judges historically returned is now decorative — the
 // gate is mechanical, derived from the checklist + blocking gaps.
@@ -23,15 +25,24 @@ const (
 // is the human-readable label that ends up in the verdict comment.
 //
 // Required items participate in the pass gate: an unticked Required
-// item flips the verdict to NEEDS_WORK. Optional items show up in the
-// checklist for transparency but don't fail the verdict — useful for
-// "tests cover the change" style observations that aren't appropriate
-// gates for every change but are still worth recording.
+// item flips the verdict to NEEDS_WORK *unless* the judge populates
+// Reason with a non-empty deferral note (e.g. "blocked on #130",
+// "needs upstream X"). The forcing function is: if you can't tick
+// it, write down why. Reason for ticked items is the evidence cite —
+// typically a file:line that proves the AC item is satisfied.
+//
+// Optional items (Required=false) show up in the checklist for
+// transparency but never fail the verdict — useful for "tests cover
+// the change" style observations.
 type ChecklistItem struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	Required    bool   `json:"required"`
 	Passed      bool   `json:"passed"`
+	// Reason is evidence (file:line) when Passed=true, or a deferral
+	// note when Passed=false on a Required item. Empty Reason on an
+	// unticked Required item blocks the verdict.
+	Reason string `json:"reason,omitempty"`
 }
 
 // ChecklistTally returns the (passed, total) counts across every
@@ -48,11 +59,22 @@ func ChecklistTally(items []ChecklistItem) (passed, total int) {
 }
 
 // RequiredPassed reports whether every Required item in the checklist
-// is Passed. Optional items are ignored. Half of the new pass gate;
-// the other half is "zero blocking gaps" (see DeriveVerdictState).
+// is "satisfied" — Passed=true, OR unpassed with a non-empty Reason
+// explaining the deferral. Optional items are ignored. Half of the
+// new pass gate; the other half is "zero blocking gaps" (see
+// DeriveVerdictState).
+//
+// Whitespace-only Reason counts as empty: the judge has to write
+// down a real explanation, not paper over the gap with spaces.
 func RequiredPassed(items []ChecklistItem) bool {
 	for _, it := range items {
-		if it.Required && !it.Passed {
+		if !it.Required {
+			continue
+		}
+		if it.Passed {
+			continue
+		}
+		if strings.TrimSpace(it.Reason) == "" {
 			return false
 		}
 	}

--- a/internal/state/checklist_test.go
+++ b/internal/state/checklist_test.go
@@ -60,8 +60,11 @@ func TestChecklistTally(t *testing.T) {
 }
 
 // TestRequiredPassed reports whether every Required item in the
-// checklist is Passed. Optional items are ignored. This is one half
-// of the new pass gate (the other half: zero blocking gaps).
+// checklist is "satisfied" — either Passed=true, or unpassed with a
+// non-empty Reason explaining the deferral. An unpassed Required
+// item with no Reason fails the check; that's the forcing-function
+// for the judge to either complete the AC item or write down why
+// it isn't being completed.
 func TestRequiredPassed(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -73,9 +76,16 @@ func TestRequiredPassed(t *testing.T) {
 			{Name: "a", Required: true, Passed: true},
 			{Name: "b", Required: true, Passed: true},
 		}, true},
-		{"required_unticked_fails", []ChecklistItem{
+		{"required_unticked_no_reason_fails", []ChecklistItem{
 			{Name: "a", Required: true, Passed: true},
 			{Name: "b", Required: true, Passed: false},
+		}, false},
+		{"required_unticked_with_reason_passes", []ChecklistItem{
+			{Name: "a", Required: true, Passed: true},
+			{Name: "b", Required: true, Passed: false, Reason: "blocked on #130"},
+		}, true},
+		{"required_unticked_whitespace_only_reason_fails", []ChecklistItem{
+			{Name: "a", Required: true, Passed: false, Reason: "   "},
 		}, false},
 		{"optional_unticked_still_passes", []ChecklistItem{
 			{Name: "a", Required: true, Passed: true},
@@ -138,6 +148,12 @@ func TestDeriveVerdictState(t *testing.T) {
 			nil,
 			[]ChecklistItem{{Required: true, Passed: false}},
 			VerdictNeedsWork,
+		},
+		{
+			"deferred_required_with_reason_does_not_fail",
+			nil,
+			[]ChecklistItem{{Required: true, Passed: false, Reason: "blocked on #130"}},
+			VerdictPass,
 		},
 		{
 			"unticked_optional_does_not_fail",

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -270,6 +270,14 @@ type Verdict struct {
 	// independently of the producer model. Empty for verdicts produced
 	// without an LLM (e.g. the code judge's deterministic shell checks).
 	Model string `json:"model,omitempty"`
+	// Checklist is the per-acceptance-criteria audit. Populated by the
+	// judge when the task carries a Checklist parsed from the issue
+	// body — one entry per AC item, with Passed and Reason filled by
+	// the judge's per-item tick. Empty for legacy tasks (no AC list)
+	// and for judges that do not consume AC. The new pass gate
+	// (DeriveVerdictState) consumes this alongside Gaps to compute
+	// PASS / NEEDS_WORK.
+	Checklist []ChecklistItem `json:"checklist,omitempty"`
 }
 
 // Attempt records one execution of a phase.
@@ -428,7 +436,18 @@ type Task struct {
 	// keeps them out of the DB column) — consumed exactly once by the
 	// next plan or code prompt, then cleared. A fresh `vairdict run`
 	// or `resume` starts with no pending notes.
-	Notes     []string  `json:"-"`
+	Notes []string `json:"-"`
+
+	// Checklist is the per-acceptance-criteria list parsed from the
+	// linked GitHub issue body when the task is created. Empty for
+	// tasks created from intents alone (no `- [ ]` source). When
+	// non-empty, the quality judge enforces per-item ticking and the
+	// pass gate requires every Required item Passed-or-deferred-with-
+	// reason. Stays in sync with the issue body the orchestrator saw
+	// at task-creation time; mid-run edits to the issue do not
+	// retroactively change the contract.
+	Checklist []ChecklistItem `json:"checklist,omitempty"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -14,7 +14,6 @@ Update this file when opening, completing, or blocking an issue.
 
 ## In Progress
 - #91 cmd/interactive: status, notes, pause/continue during execution
-- #126 agents/codex: Codex CLI completer (M6, branch claude/issue-126-tests-first-TBk7B)
 
 ## Blocked
 
@@ -72,6 +71,7 @@ Update this file when opening, completing, or blocking an issue.
 - #112 cmd: @vairdict fix — push code changes from PR comments
 - #113 cmd: @vairdict run — trigger full plan/code/quality loop from PR comment
 - #90 cmd/resume: resume interrupted run from last checkpoint
+- #126 agents/codex: Codex CLI completer + resolver wiring (M6)
 
 ---
 
@@ -168,5 +168,5 @@ reviewed by the agent judge, only then created in GitHub.
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
 | M5        | in progress | 15/17       |
-| M6        | not started | 0/9         |
+| M6        | in progress | 1/9         |
 | M7+       | not started | —           |


### PR DESCRIPTION
## Why

When PR #149 merged, the codex completer landed without satisfying its own AC item *"agents.planner: codex routes via resolveCompleter"*. The judge passed cleanly. The reason was structural — the judge had no AC list to enforce because nothing in the pipeline reached into the issue body to extract one.

This PR fills that gap: parses `- [ ]` from issue bodies, threads them through Task → judge → verdict, makes the judge enforce per-item ticking with evidence, and renders the result as a matrix in the PR comment. Both the plan judge and the quality judge now run the contract.

> **Intent declaration for the auto-review judge:** the work in this PR is the judge AC-tracing infrastructure described above and detailed in the AC checklist below. This PR is independent of any other open or merged work in the repo. Evaluate the diff against the AC list at the bottom of this body, not against any other issue.

## What changes (8 commits, ~1100 lines)

```
48af360 fix(verdictschema): use fmt.Fprintf to satisfy staticcheck QF1012
21728fc feat(github): render AC checklist matrix in PR verdict comment
972bd02 feat(plan): per-AC tracing in plan judge (mirror quality judge)
426a33a feat(cmd): wire AC checklist from issue body into task
8e193b8 feat(quality): enforce per-AC tracing in the judge pass gate
7f71559 feat(verdictschema): per-AC checklist field in submit_verdict tool
7509d2c feat(github): parse `- [ ]` checklist from issue body
1fbd1c1 feat(state): Reason field on ChecklistItem; deferral honored in gate
```

### The contract

For each AC item the judge must emit one entry in `submit_verdict.checklist`:

| Status | Meaning | Reason field | Gate effect |
|---|---|---|---|
| `passed=true` | Diff/plan satisfies the criterion | Required: file:line evidence | Counts toward pass |
| `passed=false`, `reason!=""` | Deferred with explanation | Required: deferral note | Allowed (forcing function: judge has to write down why) |
| `passed=false`, `reason==""` | Unjustified skip | Empty (whitespace-only too) | **Blocks** the verdict; surfaced as Critical Blocking gap |
| Audit entry omitted entirely | Judge silently skipped an item | n/a | **Blocks** — judge cannot quietly drop AC items by omission |

`DeriveVerdictState(gaps, checklist)` is the new gate when the task carries a checklist. Empty checklist preserves the legacy threshold-based pass for tasks created without an issue.

### Where the AC list comes from

- `vairdict run --issue N` → fetch issue body → `github.ParseChecklist` → `task.Checklist`
- `vairdict review <pr>` → resolve linked issue → same parser → AC threaded into `judge.Judge(...)`
- Issues without `- [ ]` items → empty checklist → legacy mode (no AC gate). LLM extraction from prose-only issues is deferred to a separate follow-up.

### What the renderer does

`### Acceptance Criteria (3/5 passed)` table with one icon per item:
- ✅ required-passed (Reason cell shows the evidence cite)
- ⏸️ required-deferred-with-reason (Reason cell shows the deferral note)
- ❌ required-unmet-no-reason (Reason cell shows `_(no reason given)_`)
- ⚪ optional-unticked

Pipes inside cell content are escaped so links/code in AC text don't break the table.

## Test coverage

| Layer | New tests | Covers |
|---|---|---|
| `state/checklist` | 6 | `Reason` field, deferral-with-reason gate path, whitespace-only reason fails |
| `github/issueparse` | 12 | bullet styles, indented items, mixed checked/unchecked, prose-only body, `[X]`/`[x]`, escapable markdown in description |
| `verdictschema/checklist` | 9 | tool schema includes `checklist`, `MergeChecklistAudit` happy path + missing audit + invalid name + nil source + prechecked preservation, `RenderACSection` empty + with-items |
| `judges/quality` | 6 | prompt includes items + negative-space, all-passed → pass, unmet-no-reason → block + critical gap, deferred → pass, missing audit → block, empty list → legacy pass |
| `judges/plan` | 5 | same shape as quality, with plan-specific gap phrasing |
| `github/client` (renderer) | 5 | all 4 status icons, omission when empty, pipe escaping |

Plus: existing 28 quality-judge test callers and 15 plan-judge test callers migrated to the new signature with `nil` for the new `checklist` param so legacy paths stay green.

## Acceptance Criteria

- [ ] `state.ChecklistItem.Reason` field; `RequiredPassed` honors deferral-with-reason
- [ ] `internal/github/issueparse.ParseChecklist` extracts `- [ ]` / `- [x]` items into `[]state.ChecklistItem`
- [ ] `submit_verdict` tool schema includes `checklist` array with `name`/`passed`/`reason` per-item shape
- [ ] `verdictschema.MergeChecklistAudit` merges source + audit (judge cannot rename or invent items)
- [ ] `verdictschema.RenderACSection` produces the shared prompt fragment used by both judges
- [ ] Quality judge accepts `checklist` parameter, injects AC into prompt, post-processes audit, gates Pass via `DeriveVerdictState` when non-empty
- [ ] Plan judge mirrors the quality judge's AC handling
- [ ] `cmd/vairdict/run.go` populates `task.Checklist` from issue body (best-effort: fetch failure → legacy mode)
- [ ] `cmd/vairdict/review.go` parses checklist from linked issue (or PR body fallback)
- [ ] `github.FormatVerdictComment` renders an AC matrix with ✅ / ⏸️ / ❌ / ⚪ icons + tally line
- [ ] Empty checklist preserves legacy threshold-based pass — tests pin this for both judges
- [ ] All existing tests migrated to new signatures and still pass

## Deferred to follow-up issues (all M6)

- **Read/Grep tools for the quality judge.** Today the judge is trusted to honestly self-evaluate "did the file change?" Real verification of out-of-diff claims needs real reading. Biggest deferred gap.
- **Skeptic / red-team second-pass persona.** Catches over-eager pass (the failure mode that triggered this work). Different problem from AC tracing — adversarial vantage point, not requirement enforcement.
- **LLM-driven AC extraction from prose-only issues.** Issues without `- [ ]` items currently run in legacy mode. Could auto-extract; recursive verification problem so deferred until proven needed.

## Regression test plan

The synthetic regression is in this PR: `TestJudge_AC_UnmetWithoutReasonBlocks` (quality) and the equivalent on the plan judge fail the verdict when an AC is unmet with no reason.

Real-world sanity check after merge: `git checkout 2c56a98 && vairdict review 149` (the codex PR before its wiring fix). The judge should now flag *"agents.planner: codex routes via resolveCompleter"* as unmet — exactly what the previous judge missed.

## Decisions worth flagging

- **Deferral allowed iff `Reason` is non-empty.** No validation that the reason cites a real issue number / real blocker — the model could lie. Catching that needs the Read/Grep follow-up. This is the simplest enforceable contract.
- **AC list is the contract; judge cannot rename or extend it.** `MergeChecklistAudit` drops audit entries with names not in the source and never modifies source `Description`/`Required`/`Name`. Editing the contract requires editing the issue.
- **Missing audit entry blocks.** A judge that emits no entry for a source item is treated as having said `passed=false, reason=""`. Forces explicit acknowledgment per item.
- **Empty checklist preserves legacy.** Tasks without AC keep working under the score-based gate. Flipping all judges to `DeriveVerdictState` unconditionally would also work but is a wider behavior change; out of scope here.
- **Plan-judge AC-failure phrasing differs from quality.** Plan emits *"Plan does not cover acceptance criterion: …"* vs quality's *"Acceptance criterion not satisfied: …"* — same semantics, distinguishable in the verdict comment so reviewers know which phase missed it.