### PR TITLE
docs: align skillpkg/spm description with implementation + sync M6 progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,25 +142,31 @@ type Gap struct {
 
 ## skillpkg / spm
 
-The ship skill handles lint, format, tests, and build
-in the code phase judge. Do not reimplement this logic
-— call spm instead:
+The code phase judge runs the project's configured
+`commands.build`, `commands.test`, and `commands.lint`
+(from `vairdict.yaml`) plus a formatter selected by
+`conventions.formatter`. Implementation lives in
+`internal/judges/code/judge.go` and shells out via
+`os/exec` directly — there is no spm invocation at
+runtime.
 
-```
-spm exec ship
-```
+The `ship` skill (installable via `spm install ship`)
+is conceptually parallel — same set of quality gates,
+agent-facing — and is what an AI agent uses ad-hoc.
+VAIrdict does not shell out to the skill because spm
+is a package manager, not an executor; it has no
+skill-execution subcommand.
 
-spm must be installed in the environment.
-ship skill must be installed: `spm install ship`
-
-Do NOT add spm dependencies before M2 code phase work.
+If you change the judge's quality-gate set, also
+revisit the ship skill so the agent-facing and
+judge-facing surfaces stay aligned.
 
 ## Not yet integrated
 
-- Slack notifications (M7)
-- Web UI dashboard (M8)
-- Coder environment (M10)
-- skillpkg runtime skill loading (M11)
+- skillpkg runtime skill loading (Milestone 14)
+- Slack notifications (Milestone 23)
+- Web UI dashboard (Web UI section, post-Milestone 18)
+- Coder environment (Milestone 25)
 
 Do not implement these before their milestone.
 

--- a/internal/phases/code/phase.go
+++ b/internal/phases/code/phase.go
@@ -25,7 +25,8 @@ type Coder interface {
 	Run(ctx context.Context, prompt string, workDir string) (state.AgentResult, error)
 }
 
-// Judge is the interface for the code judge (spm exec ship).
+// Judge is the interface for the code judge — runs the project's
+// build/test/lint/format quality gates.
 type Judge interface {
 	Judge(ctx context.Context, workDir string) (*state.Verdict, error)
 }

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -18,7 +18,6 @@ already started — #128, #129, #137 are merged.
 - #88 config/standards: team standards in vairdict.yaml
 
 ## In Progress
-- #136 bug(judge/auto-review): wrong intent on docs/scoping PRs
 
 ## Blocked
 - #130 resolver: extend auto backend resolver — needs #126 + #127
@@ -87,6 +86,7 @@ already started — #128, #129, #137 are merged.
 - #128 config: per-phase backend selection in vairdict.yaml (M6)
 - #129 judge/pluggable: swap judge model in vairdict.yaml (M6)
 - #137 perf/plan: cut multi-loop latency on the plan phase (M6)
+- #136 bug(judge/auto-review): correct intent on docs/scoping PRs (M6)
 
 ---
 
@@ -183,5 +183,5 @@ reviewed by the agent judge, only then created in GitHub.
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
 | M5        | in progress | 16/17       |
-| M6        | in progress | 4/12        |
+| M6        | in progress | 5/16        |
 | M7+       | not started | —           |


### PR DESCRIPTION
## Summary

- CLAUDE.md and `internal/phases/code/phase.go` claimed the code phase judge invokes `spm exec ship` — but that command does not exist (spm is a package manager, not a skill executor). The actual implementation in `internal/judges/code/judge.go` runs `cfg.Commands.Build/Test/Lint` and a formatter via `os/exec`. Docs now describe that reality, with a note that the `ship` skill is the parallel agent-facing surface so changes to one should mirror to the other.
- CLAUDE.md "Not yet integrated" milestone references updated for the ROADMAP renumbering from PR #154 (skillpkg runtime → Milestone 14, Slack → Milestone 23, Coder env → Milestone 25, Web UI dashboard → Web UI section).
- PROGRESS.md M6 denominator: 5/12 → 5/16. Four issues joined the `milestone-6` label since PROGRESS was last numbered: #150, #151, #152 (judge quality additions) and #136 (now closed). #129 also closed on GitHub to match its Done state.

## Test plan

- [ ] CLAUDE.md renders cleanly on GitHub — section structure intact
- [ ] phase.go comment reads sensibly in IDE / godoc
- [ ] PROGRESS.md `M6 5/16` matches `gh issue list --label milestone-6 --state all` (3 closed labelled + 13 open = 16 total; 5 marked Done in PROGRESS includes #129 and #136 which are now closed on GitHub too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)