### PR TITLE
ci(release): add workflow_dispatch with auto-bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,24 @@ on:
   push:
     tags:
       - "v*"
+  # Manual trigger from the Actions tab. Computes the next tag, pushes it,
+  # then runs GoReleaser in the same job — no chained workflow runs, no PAT.
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump"
+        type: choice
+        required: true
+        default: "patch"
+        options:
+          - patch
+          - minor
+          - major
+          - explicit
+      version:
+        description: "Explicit version (only when bump=explicit, e.g. v1.2.3)"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -12,9 +30,62 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Guard: workflow_dispatch must run from main. Prevents accidentally
+      # cutting a release from a feature branch's HEAD.
+      - name: Reject non-main dispatch
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Release dispatch must run from main (got ${GITHUB_REF})"
+          exit 1
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      # Compute and push the new tag on workflow_dispatch. On a tag push the
+      # tag already exists; this step is skipped and GoReleaser uses GITHUB_REF.
+      - name: Compute and push tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          BUMP="${{ inputs.bump }}"
+          EXPLICIT="${{ inputs.version }}"
+
+          if [ "$BUMP" = "explicit" ]; then
+            if [ -z "$EXPLICIT" ]; then
+              echo "::error::bump=explicit requires the version input"
+              exit 1
+            fi
+            if [[ ! "$EXPLICIT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::version must match v<major>.<minor>.<patch>; got '$EXPLICIT'"
+              exit 1
+            fi
+            NEW="$EXPLICIT"
+          else
+            LATEST=$(git tag --list 'v*' --sort=-v:refname | head -1)
+            LATEST="${LATEST:-v0.0.0}"
+            VER="${LATEST#v}"
+            IFS='.' read -r MAJ MIN PAT <<< "$VER"
+            case "$BUMP" in
+              patch) PAT=$((PAT + 1)) ;;
+              minor) MIN=$((MIN + 1)); PAT=0 ;;
+              major) MAJ=$((MAJ + 1)); MIN=0; PAT=0 ;;
+            esac
+            NEW="v${MAJ}.${MIN}.${PAT}"
+          fi
+
+          if git rev-parse "$NEW" >/dev/null 2>&1; then
+            echo "::error::Tag $NEW already exists"
+            exit 1
+          fi
+
+          echo "Tagging $NEW (bump=$BUMP, latest=${LATEST:-none})"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$NEW" -m "Release $NEW"
+          git push origin "$NEW"
+          # GoReleaser keys off the latest reachable tag (`git describe`),
+          # which now points at the just-created tag on this commit.
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to the existing release workflow so cutting a release no longer requires `git tag vX.Y.Z && git push --tags` from the terminal.

The existing tag-push trigger stays. Both paths converge on the same test + GoReleaser steps.

## Usage after merge

GitHub UI → **Actions → Release → Run workflow**:

| Bump | Behavior | Example |
|---|---|---|
| `patch` *(default)* | latest tag's patch +1 | v0.0.10 → v0.0.11 |
| `minor` | minor +1, patch reset | v0.0.10 → v0.1.0 |
| `major` | major +1, minor + patch reset | v0.0.10 → v1.0.0 |
| `explicit` | reads the `version` input verbatim, validated against `vN.N.N` | manual override |

## Safety

- `workflow_dispatch` from anywhere other than `main` is rejected with a clear `::error::` message
- `bump=explicit` without a `version` input is rejected
- A non-`vN.N.N` explicit version is rejected
- A computed tag that already exists is rejected before any push

## Implementation notes

- Single workflow run does compute + push tag + run GoReleaser. No chained runs, no PAT — the workflow's `GITHUB_TOKEN` (with `contents: write`) handles both the tag push and the release publish.
- Tag is created from the current `main` HEAD; GoReleaser then sees the tag pointing at the same commit it's about to release.
- Bump logic verified locally with the standard cases (`v0.0.10` → `v0.0.11/v0.1.0/v1.0.0`, plus `v1.2.3` and the empty/initial case).

## Test plan

- [ ] Existing manual-tag flow unaffected (push a `vX.Y.Z` tag → release runs as before)
- [ ] After merge: click "Run workflow" with `bump=patch` to ship **v0.0.11**, picks up #146/#153/#156/#143 changes
- [ ] Verify the v0.0.11 release artifacts include the score-removal in `FormatVerdictComment`
- [ ] Subsequent PRs' auto-review comments no longer render `**Score:**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)