### PR TITLE
docs(progress): M5 final count is 18/18, not 17/17

### DIFF
--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -182,6 +182,6 @@ reviewed by the agent judge, only then created in GitHub.
 | M2        | done        | 6/6         |
 | M3        | done        | 15/15       |
 | M4        | done        | 8/8         |
-| M5        | done        | 17/17       |
+| M5        | done        | 18/18       |
 | M6        | in progress | 5/16        |
 | M7+       | not started | —           |


### PR DESCRIPTION
## Summary

Closes the M5 bookkeeping. After closing #86 (state/rewind-context — shipped via #119 but the issue wasn't auto-closed), GitHub shows **18 closed, 0 open** `milestone-5` labeled issues. PROGRESS.md was at 17/17; bumps to 18/18.

## Test plan

- [x] `gh issue list --label milestone-5 --state open --json number` returns `[]`
- [x] M5 row now reads `done | 18/18` and matches GitHub state exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)