### PR TITLE
feat(agents/gemini): add Gemini CLI completer (#127)

### DIFF
--- a/cmd/vairdict/completer.go
+++ b/cmd/vairdict/completer.go
@@ -2,7 +2,7 @@
 // planner and judges (the "completer" roles, distinct from the "coder" role
 // in internal/agents/claudecode which uses tools and edits the filesystem).
 //
-// Four values are accepted in vairdict.yaml under agents.planner /
+// Five values are accepted in vairdict.yaml under agents.planner /
 // agents.judge (and the per-phase overrides agents.plan_judge,
 // agents.code_judge, agents.quality_judge):
 //
@@ -10,12 +10,13 @@
 //	claude-cli  — strict local subprocess (errors if `claude` not on PATH)
 //	claude-api  — strict HTTP API client (errors if no API key configured)
 //	codex       — OpenAI Codex CLI (errors if `codex` not on PATH)
+//	gemini      — Google Gemini CLI (errors if `gemini` not on PATH)
 //
-// The bare value `claude` exists so future families (gemini, …) can
-// follow the same convention: bare = smart default for the family, suffixed
-// = explicit transport. `codex` is single-transport today (no
-// codex-cli/codex-api distinction); when an OpenAI HTTP client lands the
-// same suffix pattern applies.
+// `codex` and `gemini` are single-transport today (no -cli/-api
+// distinction); when their HTTP clients land the same suffix pattern
+// as claude applies. The bare value `claude` exists so each family can
+// follow the same convention: bare = smart default for the family,
+// suffixed = explicit transport.
 package main
 
 import (
@@ -26,6 +27,7 @@ import (
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/agents/claudecli"
 	"github.com/vairdict/vairdict/internal/agents/codex"
+	"github.com/vairdict/vairdict/internal/agents/gemini"
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/state"
 )
@@ -70,6 +72,7 @@ const (
 	backendClaudeCLI backendKind = "claude-cli" // local `claude -p`
 	backendClaudeAPI backendKind = "claude-api" // HTTP API
 	backendCodex     backendKind = "codex"      // OpenAI Codex CLI (`codex exec`)
+	backendGemini    backendKind = "gemini"     // Google Gemini CLI (`gemini -p`)
 )
 
 // backendForRole reads the configured backend string for the given role
@@ -145,8 +148,13 @@ func chooseBackendForRole(roleName, setting string, cliAvailable bool) (backendK
 		// caller errors later if `codex` isn't on PATH (handled in
 		// validateCompleterBackend).
 		return backendCodex, nil
+	case "gemini":
+		// Gemini is single-transport today — no gemini-api fallback
+		// because we don't have a Google HTTP client. Caller errors
+		// later if `gemini` isn't on PATH.
+		return backendGemini, nil
 	default:
-		return "", fmt.Errorf("unknown %s backend %q (want claude|claude-cli|claude-api|codex)", roleName, setting)
+		return "", fmt.Errorf("unknown %s backend %q (want claude|claude-cli|claude-api|codex|gemini)", roleName, setting)
 	}
 }
 
@@ -209,6 +217,18 @@ func resolveCompleter(cfg *config.Config, role completerRole) (completer, backen
 			opts = append(opts, codex.WithModel(model))
 		}
 		return codex.New(opts...), kind, nil
+	case backendGemini:
+		// --yolo lets the subprocess auto-approve tool actions
+		// without interactive prompts, matching the codex
+		// approvals-bypass and claudecli --dangerously-skip-permissions
+		// flags — judges and the planner run unattended.
+		opts := []gemini.Option{
+			gemini.WithExtraArgs("--yolo"),
+		}
+		if model != "" {
+			opts = append(opts, gemini.WithModel(model))
+		}
+		return gemini.New(opts...), kind, nil
 	default:
 		return nil, "", fmt.Errorf("unreachable backend kind: %s", kind)
 	}
@@ -290,8 +310,13 @@ func validateCompleterBackend(roleName, setting string, probes backendProbes) er
 			return fmt.Errorf("%s: codex requires the `codex` binary on PATH", roleName)
 		}
 		return nil
+	case "gemini":
+		if !probes.cliAvailable("gemini") {
+			return fmt.Errorf("%s: gemini requires the `gemini` binary on PATH", roleName)
+		}
+		return nil
 	default:
-		return fmt.Errorf("%s: unknown backend %q (want claude|claude-cli|claude-api|codex)", roleName, setting)
+		return fmt.Errorf("%s: unknown backend %q (want claude|claude-cli|claude-api|codex|gemini)", roleName, setting)
 	}
 }
 

--- a/cmd/vairdict/completer_test.go
+++ b/cmd/vairdict/completer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vairdict/vairdict/internal/agents/claude"
 	"github.com/vairdict/vairdict/internal/agents/claudecli"
 	"github.com/vairdict/vairdict/internal/agents/codex"
+	"github.com/vairdict/vairdict/internal/agents/gemini"
 	"github.com/vairdict/vairdict/internal/config"
 	"github.com/vairdict/vairdict/internal/state"
 )
@@ -39,6 +40,9 @@ func TestChooseBackend(t *testing.T) {
 		// influence codex resolution either way.
 		{"codex no claude cli", "codex", false, backendCodex, false},
 		{"codex with claude cli", "codex", true, backendCodex, false},
+		// Gemini pinned — same explicit-choice semantics as codex.
+		{"gemini no claude cli", "gemini", false, backendGemini, false},
+		{"gemini with claude cli", "gemini", true, backendGemini, false},
 		// Typos surface as a hard error so users don't silently get the
 		// wrong backend.
 		{"unknown value", "openai", true, "", true},
@@ -497,6 +501,100 @@ func TestValidateBackends_CodexAvailable(t *testing.T) {
 	}
 	if err := validateBackends(cfg, probes); err != nil {
 		t.Errorf("codex pinned with binary present should validate, got: %v", err)
+	}
+}
+
+// TestResolveCompleter_GeminiBackend: agents.judge: gemini must
+// construct a gemini.Client (not claude/codex) and route through
+// resolveCompleter without touching the claude API path. AC item from
+// #127: the new client is reachable from the resolver and the
+// configured model flows into it.
+func TestResolveCompleter_GeminiBackend(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "gemini",
+		Judge:   "gemini",
+		Model:   "gemini-2.5-pro",
+	}}
+
+	for _, role := range []completerRole{rolePlanner, rolePlanJudge, roleCodeJudge, roleQualityJudge} {
+		c, kind, err := resolveCompleter(cfg, role)
+		if err != nil {
+			t.Fatalf("resolveCompleter(%s): %v", role, err)
+		}
+		if kind != backendGemini {
+			t.Errorf("%s kind = %q, want %q", role, kind, backendGemini)
+		}
+		gc, ok := c.(*gemini.Client)
+		if !ok {
+			t.Fatalf("expected *gemini.Client for %s, got %T", role, c)
+		}
+		if got := gc.Model(); got != "gemini-2.5-pro" {
+			t.Errorf("%s gemini client model = %q, want gemini-2.5-pro", role, got)
+		}
+	}
+}
+
+// TestValidateBackends_GeminiNeedsBinary: gemini pinned but `gemini`
+// not on PATH must error and name both the role and the missing
+// binary. Mirrors the codex missing-binary check.
+func TestValidateBackends_GeminiNeedsBinary(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "claude",
+		Coder:   "claude-code",
+		Judge:   "claude",
+		// QualityJudge is the explicit pinned slot that should fail.
+		QualityJudge: "gemini",
+	}}
+	probes := backendProbes{
+		// claude available (so coder + smart-default judges validate),
+		// gemini absent.
+		cliAvailable:  func(name string) bool { return name == "claude" },
+		apiKeyPresent: func() bool { return true },
+	}
+	err := validateBackends(cfg, probes)
+	if err == nil {
+		t.Fatal("expected error for missing gemini binary")
+	}
+	if !strings.Contains(err.Error(), "quality_judge") {
+		t.Errorf("error should name the role (quality_judge), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "gemini") {
+		t.Errorf("error should name the missing binary (gemini), got: %v", err)
+	}
+}
+
+// TestValidateBackends_GeminiAvailable: gemini pinned and the binary
+// is on PATH validates without error.
+func TestValidateBackends_GeminiAvailable(t *testing.T) {
+	cfg := &config.Config{Agents: config.AgentsConfig{
+		Planner: "gemini",
+		Coder:   "claude-code",
+		Judge:   "gemini",
+	}}
+	probes := backendProbes{
+		// Both binaries present — claude for the coder, gemini for the
+		// completers.
+		cliAvailable:  func(string) bool { return true },
+		apiKeyPresent: func() bool { return false },
+	}
+	if err := validateBackends(cfg, probes); err != nil {
+		t.Errorf("gemini pinned with binary present should validate, got: %v", err)
+	}
+}
+
+// TestSeedCLISession_NoOpForGeminiClient: gemini has no session-resume
+// concept (the CLI lacks a --resume in our wrapper). seed/capture
+// must be safe no-ops so the orchestrator's existing wiring keeps
+// working unchanged when gemini is the configured completer.
+func TestSeedCLISession_NoOpForGeminiClient(t *testing.T) {
+	geminiClient := gemini.New()
+	task := state.NewTask("t", "i")
+	task.CLISessionIDs = map[string]string{string(rolePlanner): "ignored"}
+	// Must not panic; gemini client doesn't have a session concept.
+	seedCLISession(geminiClient, task, rolePlanner)
+	captureCLISession(geminiClient, task, rolePlanner)
+	if task.CLISessionIDs[string(rolePlanner)] != "ignored" {
+		t.Errorf("gemini client should not affect task session ids, got %v", task.CLISessionIDs)
 	}
 }
 

--- a/internal/agents/gemini/client.go
+++ b/internal/agents/gemini/client.go
@@ -1,0 +1,432 @@
+// Package gemini implements a Completer that shells out to Google's
+// Gemini CLI (`gemini -p ...`) instead of calling an Anthropic HTTP
+// API.
+//
+// This is the third completer family for VAIrdict — joining
+// claude-{cli,api} and codex. Lets users with the Gemini CLI installed
+// run vairdict end-to-end without Anthropic or OpenAI credentials.
+//
+// Wire shape (verified against github.com/google-gemini/gemini-cli
+// headless mode docs):
+//
+//	gemini --output-format json [-m <model>] [<extras>...] -p <prompt>
+//
+// Output is a single JSON object on stdout (the "envelope"):
+//
+//	{"response": "<final agent text>", "stats": {...}, "error": null}
+//
+// We use `--output-format json` and NOT `--output-format stream-json`:
+// the streaming form emits JSONL telemetry events, not a single
+// structured result. Same reasoning as why codex avoids `--json`.
+//
+// Tool use: Gemini's CLI currently has no native `--output-schema`
+// flag (tracked at google-gemini/gemini-cli#5021). The tool's
+// InputSchema is therefore injected into the system prompt, and a
+// single recovery round-trip mirrors codex when the model returns
+// prose anyway.
+//
+// The Client is safe to share across goroutines. Each
+// CompleteWithSystem call spawns a fresh `gemini` subprocess and
+// blocks until it finishes.
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/vairdict/vairdict/internal/agents/claude"
+)
+
+// NotInstalledError is returned when the `gemini` binary cannot be
+// found on PATH. Callers can use errors.As to surface a friendlier
+// install-me message.
+type NotInstalledError struct {
+	Err error
+}
+
+func (e *NotInstalledError) Error() string {
+	return fmt.Sprintf("gemini CLI not installed: %v", e.Err)
+}
+
+func (e *NotInstalledError) Unwrap() error { return e.Err }
+
+// ParseError is returned when gemini's stdout could not be decoded
+// into the envelope, the envelope reported an error, or the response
+// text could not be decoded into the caller's target. Raw carries the
+// original (possibly truncated) content so operators can see what
+// gemini actually said.
+type ParseError struct {
+	Raw string
+	Err error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("gemini cli parse error: %v (raw: %.200s)", e.Err, e.Raw)
+}
+
+func (e *ParseError) Unwrap() error { return e.Err }
+
+// ExitError is returned when `gemini` exits with a non-zero status.
+type ExitError struct {
+	ExitCode int
+	Stderr   string
+	Err      error
+}
+
+func (e *ExitError) Error() string {
+	stderr := strings.TrimRight(e.Stderr, "\n")
+	if stderr == "" {
+		return fmt.Sprintf("gemini cli exited with status %d", e.ExitCode)
+	}
+	return fmt.Sprintf("gemini cli exited with status %d: %s", e.ExitCode, stderr)
+}
+
+func (e *ExitError) Unwrap() error { return e.Err }
+
+// CommandFactory constructs exec.Cmd instances. The production default
+// is exec.CommandContext; tests inject a factory that returns a fake
+// binary.
+type CommandFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+// Client is a Completer backed by the Gemini CLI.
+type Client struct {
+	timeout    time.Duration
+	cmdFactory CommandFactory
+	extraArgs  []string
+	model      string
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithTimeout caps how long a single Gemini CLI call may run.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) { c.timeout = d }
+}
+
+// WithCommandFactory overrides how subprocesses are constructed. Tests
+// use this to intercept exec without touching the real `gemini` binary.
+func WithCommandFactory(f CommandFactory) Option {
+	return func(c *Client) { c.cmdFactory = f }
+}
+
+// WithExtraArgs appends additional flags after the core flags and
+// before `-p <prompt>`. Useful for `--yolo`, sandbox toggles, etc.
+// Core flags (`--output-format json`, `-p`) are always set.
+func WithExtraArgs(args ...string) Option {
+	return func(c *Client) { c.extraArgs = append(c.extraArgs, args...) }
+}
+
+// WithModel pins the Gemini CLI subprocess to a specific model via
+// the `-m` flag. Empty string is a no-op.
+func WithModel(model string) Option {
+	return func(c *Client) { c.model = model }
+}
+
+// New constructs a Client with the given options.
+func New(opts ...Option) *Client {
+	c := &Client{
+		timeout:    5 * time.Minute,
+		cmdFactory: exec.CommandContext,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// IsAvailable reports whether the `gemini` binary is on PATH.
+func IsAvailable() bool {
+	_, err := exec.LookPath("gemini")
+	return err == nil
+}
+
+// Model returns the model the client is pinned to via WithModel.
+func (c *Client) Model() string { return c.model }
+
+// Complete is a convenience wrapper for CompleteWithSystem with an
+// empty system prompt.
+func (c *Client) Complete(ctx context.Context, prompt string, target any) error {
+	return c.CompleteWithSystem(ctx, "", prompt, target)
+}
+
+// CompleteWithSystem runs `gemini` and unmarshals the envelope's
+// `.response` field into target. The system prompt is bundled into
+// the `-p` arg; gemini-cli's non-interactive mode has no separate
+// system-prompt flag.
+func (c *Client) CompleteWithSystem(ctx context.Context, system, prompt string, target any) error {
+	return c.run(ctx, system, prompt, target)
+}
+
+// CompleteWithTool injects the tool's InputSchema into the system
+// prompt (gemini-cli has no native --output-schema; tracked at
+// google-gemini/gemini-cli#5021) and unmarshals the response into
+// target. On parse failure the client makes a single recovery call
+// asking the model to reformat the original prose as JSON.
+func (c *Client) CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error {
+	systemWithSchema := bundleSchema(system, tool)
+
+	err := c.run(ctx, systemWithSchema, prompt, target)
+	if err == nil {
+		return nil
+	}
+
+	parseErr, ok := err.(*ParseError)
+	if !ok || parseErr.Raw == "" {
+		return err
+	}
+
+	slog.Info("gemini cli tool call failed, attempting recovery", "original_err", err)
+
+	recoveryPrompt := fmt.Sprintf(
+		"The following text was supposed to be a JSON object conforming to this schema:\n%s\n\n"+
+			"But it was returned as prose. Extract the information and return ONLY the JSON object. "+
+			"No markdown, no explanation, no fences — just the JSON.\n\n"+
+			"Original text:\n%s",
+		string(tool.InputSchema), truncate(parseErr.Raw, 4000),
+	)
+	return c.run(ctx, "", recoveryPrompt, target)
+}
+
+// CompleteWithTools falls back to single-turn CompleteWithTool using
+// only the final tool. The CLI backend cannot do multi-turn tool use,
+// so auxiliary tools like check_path are silently unavailable.
+func (c *Client) CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, _ map[string]claude.ToolHandler, target any) error {
+	for _, t := range tools {
+		if t.Name == finalTool {
+			return c.CompleteWithTool(ctx, system, prompt, t, target)
+		}
+	}
+	return fmt.Errorf("final tool %q not found in tools list", finalTool)
+}
+
+// run is the core invocation path. Spawns gemini, reads stdout,
+// decodes the envelope, extracts JSON from the .response field, and
+// unmarshals into target.
+func (c *Client) run(ctx context.Context, system, prompt string, target any) error {
+	stdout, err := c.runOnce(ctx, system, prompt)
+	if err != nil {
+		return err
+	}
+
+	if len(bytes.TrimSpace(stdout)) == 0 {
+		return &ParseError{Raw: "", Err: fmt.Errorf("gemini wrote empty stdout")}
+	}
+
+	var envelope struct {
+		Response string          `json:"response"`
+		Error    json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(stdout, &envelope); err != nil {
+		return &ParseError{Raw: string(stdout), Err: fmt.Errorf("decoding envelope: %w", err)}
+	}
+
+	if hasEnvelopeError(envelope.Error) {
+		return &ParseError{
+			Raw: string(stdout),
+			Err: fmt.Errorf("gemini reported error: %s", string(envelope.Error)),
+		}
+	}
+
+	if envelope.Response == "" {
+		return &ParseError{Raw: string(stdout), Err: fmt.Errorf("envelope has empty .response")}
+	}
+
+	cleaned := extractJSON(envelope.Response)
+	if err := json.Unmarshal([]byte(cleaned), target); err != nil {
+		slog.Debug("gemini cli parse failed",
+			"err", err,
+			"raw_len", len(envelope.Response),
+			"cleaned_len", len(cleaned),
+			"raw_head", truncate(envelope.Response, 500),
+			"cleaned_head", truncate(cleaned, 500),
+		)
+		return &ParseError{Raw: envelope.Response, Err: fmt.Errorf("decoding response into target: %w", err)}
+	}
+	return nil
+}
+
+// runOnce executes a single gemini subprocess. Returns typed errors
+// (NotInstalledError, ExitError) on failure. Returns the captured
+// stdout on success.
+func (c *Client) runOnce(ctx context.Context, system, prompt string) ([]byte, error) {
+	start := time.Now()
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	bundled := bundlePrompt(system, prompt)
+	args := buildArgs(c.model, c.extraArgs, bundled)
+	cmd := c.cmdFactory(ctx, "gemini", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	slog.Debug("running gemini cli", "args", args, "timeout", c.timeout)
+
+	if err := cmd.Run(); err != nil {
+		if execErr, ok := err.(*exec.Error); ok {
+			return nil, &NotInstalledError{Err: execErr}
+		}
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("gemini cli cancelled: %w", ctx.Err())
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, &ExitError{
+				ExitCode: exitErr.ExitCode(),
+				Stderr:   stderr.String(),
+				Err:      err,
+			}
+		}
+		return nil, fmt.Errorf("running gemini cli: %w", err)
+	}
+
+	slog.Debug("gemini cli completed", "duration", time.Since(start))
+	return stdout.Bytes(), nil
+}
+
+// hasEnvelopeError reports whether the envelope's `.error` field is
+// present and non-null. The field is JSON-typed (could be null or a
+// string), so a raw-message check is more robust than coercing to a
+// concrete type.
+func hasEnvelopeError(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	return !bytes.Equal(trimmed, []byte("null"))
+}
+
+// bundlePrompt prepends the system prompt to the user prompt with a
+// blank-line separator. No role markers — gemini has no convention for
+// parsing them, and inventing `[system]/[user]` would be cargo-culting
+// from chat formats the model wasn't trained to honor.
+func bundlePrompt(system, prompt string) string {
+	if system == "" {
+		return prompt
+	}
+	return system + "\n\n" + prompt
+}
+
+// bundleSchema appends a "respond with JSON conforming to this schema"
+// instruction (carrying the tool's InputSchema verbatim) to the
+// caller's system prompt. Used by CompleteWithTool because gemini-cli
+// has no native schema-enforcement flag.
+func bundleSchema(system string, tool claude.Tool) string {
+	schemaBlock := fmt.Sprintf(
+		"Respond with a single JSON object conforming to this schema:\n%s\n"+
+			"Return ONLY the JSON object — no markdown fences, no prose, no commentary.",
+		string(tool.InputSchema),
+	)
+	if system == "" {
+		return schemaBlock
+	}
+	return system + "\n\n" + schemaBlock
+}
+
+// buildArgs returns the argv after the binary name for one `gemini`
+// invocation. Pulled out as a free function so it's trivially
+// unit-testable.
+//
+// model is optional ("" omits -m). extras and prompt are appended
+// last so the prompt always lands as the final positional value
+// (after `-p`).
+func buildArgs(model string, extra []string, prompt string) []string {
+	args := make([]string, 0, 6+len(extra))
+	args = append(args, "--output-format", "json")
+	if model != "" {
+		args = append(args, "-m", model)
+	}
+	args = append(args, extra...)
+	args = append(args, "-p", prompt)
+	return args
+}
+
+// truncate returns the first n characters of s.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// extractJSON pulls a JSON object out of gemini's `.response` text,
+// tolerating prose preambles and markdown fences. The CLI has no
+// native schema enforcement (tracked at google-gemini/gemini-cli#5021)
+// so models commonly wrap output in ```json fences or ramble before
+// emitting the object.
+func extractJSON(text string) string {
+	if obj := extractBraceObject(text); obj != "" {
+		return obj
+	}
+	if fenced := extractFencedBlock(text); fenced != "" {
+		return fenced
+	}
+	return strings.TrimSpace(text)
+}
+
+// extractFencedBlock returns the content between the first pair of ```
+// fences, or empty string if no complete pair is found.
+func extractFencedBlock(text string) string {
+	const fence = "```"
+	open := strings.Index(text, fence)
+	if open == -1 {
+		return ""
+	}
+	bodyStart := open + len(fence)
+	if nl := strings.IndexByte(text[bodyStart:], '\n'); nl != -1 {
+		bodyStart += nl + 1
+	}
+	end := strings.Index(text[bodyStart:], fence)
+	if end == -1 {
+		return ""
+	}
+	return text[bodyStart : bodyStart+end]
+}
+
+// extractBraceObject scans for the first `{` and walks forward
+// counting braces (respecting JSON string literals) until it finds the
+// matching closing `}`.
+func extractBraceObject(text string) string {
+	start := strings.IndexByte(text, '{')
+	if start == -1 {
+		return ""
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(text); i++ {
+		c := text[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch c {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return text[start : i+1]
+			}
+		}
+	}
+	return ""
+}

--- a/internal/agents/gemini/client_test.go
+++ b/internal/agents/gemini/client_test.go
@@ -1,0 +1,643 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vairdict/vairdict/internal/agents/claude"
+)
+
+// --- Test helpers ---
+
+// fakeCmd builds an exec.Cmd that runs `sh -c script` via the given ctx
+// so each test can script stdout/stderr/exit-code precisely without
+// touching the real gemini binary.
+func fakeCmd(ctx context.Context, script string) *exec.Cmd {
+	return exec.CommandContext(ctx, "sh", "-c", script)
+}
+
+// flagValue returns the value following the named flag in args, or ""
+// if the flag is not present or has no value following it.
+func flagValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// envelopeOut wraps the given response text in the JSON envelope
+// gemini-cli emits under `--output-format json`:
+//
+//	{"response": "<text>", "stats": {...}, "error": null}
+//
+// Used by writingFactory to build realistic stdout.
+func envelopeOut(response string) string {
+	out, _ := json.Marshal(map[string]any{
+		"response": response,
+		"stats":    map[string]any{"session": map[string]any{"duration": 1}},
+		"error":    nil,
+	})
+	return string(out)
+}
+
+// stdoutCmd returns a sh -c command that prints content to stdout,
+// stderr to stderr, and exits with the given code. Used by the fake
+// command factory to simulate the gemini binary's output.
+func stdoutCmd(ctx context.Context, stdout, stderr string, exit int) *exec.Cmd {
+	script := `printf '%s' "$FAKE_STDOUT"; if [ -n "$FAKE_STDERR" ]; then printf '%s' "$FAKE_STDERR" >&2; fi; exit ${FAKE_EXIT:-0}`
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"FAKE_STDOUT="+stdout,
+		"FAKE_STDERR="+stderr,
+		"FAKE_EXIT="+itoa(exit),
+	)
+	return cmd
+}
+
+// writingFactory returns a CommandFactory that captures argv into
+// captured (if non-nil) and emits an envelope wrapping responseText on
+// stdout.
+func writingFactory(responseText string, captured *[][]string) CommandFactory {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if captured != nil {
+			*captured = append(*captured, append([]string{name}, args...))
+		}
+		return stdoutCmd(ctx, envelopeOut(responseText), "", 0)
+	}
+}
+
+// rawFactory returns a CommandFactory that captures argv and emits
+// rawStdout verbatim (no envelope wrapping) — used to test malformed
+// envelope handling.
+func rawFactory(rawStdout string, captured *[][]string) CommandFactory {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if captured != nil {
+			*captured = append(*captured, append([]string{name}, args...))
+		}
+		return stdoutCmd(ctx, rawStdout, "", 0)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}
+
+// --- Core CompleteWithSystem behaviour ---
+
+func TestCompleteWithSystem_HappyPath(t *testing.T) {
+	c := New(WithCommandFactory(writingFactory(`{"answer":42,"label":"ok"}`, nil)))
+
+	var got struct {
+		Answer int    `json:"answer"`
+		Label  string `json:"label"`
+	}
+	if err := c.CompleteWithSystem(context.Background(), "sys", "hi", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Answer != 42 || got.Label != "ok" {
+		t.Errorf("got %+v, want {42 ok}", got)
+	}
+}
+
+func TestCompleteWithSystem_FencedResult(t *testing.T) {
+	// gemini-cli has no native schema enforcement, so models commonly
+	// wrap output in ```json … ``` fences. extractJSON must tolerate.
+	c := New(WithCommandFactory(writingFactory("```json\n{\"x\":1}\n```", nil)))
+
+	var got struct {
+		X int `json:"x"`
+	}
+	if err := c.Complete(context.Background(), "hi", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.X != 1 {
+		t.Errorf("got %+v, want {1}", got)
+	}
+}
+
+func TestCompleteWithSystem_EmptyStdout(t *testing.T) {
+	c := New(WithCommandFactory(rawFactory("", nil)))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestCompleteWithSystem_EnvelopeNotJSON(t *testing.T) {
+	// stdout is non-JSON garbage — envelope decode fails. Raw is
+	// preserved so operators can see what gemini said.
+	c := New(WithCommandFactory(rawFactory("oops this is not json at all", nil)))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(parseErr.Raw, "oops") {
+		t.Errorf("raw should preserve stdout, got %q", parseErr.Raw)
+	}
+}
+
+func TestCompleteWithSystem_EnvelopeError(t *testing.T) {
+	// envelope's `.error` field is non-null — surface as ParseError
+	// carrying gemini's error message so operators can see it.
+	raw := `{"response":"","error":"rate limited","stats":{}}`
+	c := New(WithCommandFactory(rawFactory(raw, nil)))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(parseErr.Error(), "rate limited") {
+		t.Errorf("error message should include gemini's error, got %q", parseErr.Error())
+	}
+}
+
+func TestCompleteWithSystem_EnvelopeEmptyResponse(t *testing.T) {
+	raw := `{"response":"","error":null,"stats":{}}`
+	c := New(WithCommandFactory(rawFactory(raw, nil)))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError for empty .response, got %T: %v", err, err)
+	}
+}
+
+func TestCompleteWithSystem_TargetDecodeFailure(t *testing.T) {
+	// .response is a JSON string but not an object — decoding into a
+	// struct target should surface as ParseError with the response
+	// text preserved as Raw.
+	c := New(WithCommandFactory(writingFactory(`"a string"`, nil)))
+
+	var got struct{ X int }
+	err := c.Complete(context.Background(), "hi", &got)
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("expected ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(parseErr.Raw, "a string") {
+		t.Errorf("expected raw to preserve response text, got %q", parseErr.Raw)
+	}
+}
+
+func TestCompleteWithSystem_NonZeroExit(t *testing.T) {
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeCmd(ctx, "echo 'boom' >&2; exit 2")
+	}))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+	if exitErr.ExitCode != 2 {
+		t.Errorf("exit code = %d, want 2", exitErr.ExitCode)
+	}
+	if !strings.Contains(exitErr.Stderr, "boom") {
+		t.Errorf("stderr = %q, want to contain 'boom'", exitErr.Stderr)
+	}
+}
+
+func TestCompleteWithSystem_NotInstalled(t *testing.T) {
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "nonexistent-binary-xyz-12345")
+	}))
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	var ni *NotInstalledError
+	if !errors.As(err, &ni) {
+		t.Fatalf("expected NotInstalledError, got %T: %v", err, err)
+	}
+}
+
+func TestCompleteWithSystem_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return fakeCmd(ctx, "exec sleep 1")
+	}))
+
+	var got map[string]any
+	err := c.CompleteWithSystem(ctx, "", "hi", &got)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+	if !strings.Contains(err.Error(), "cancelled") && !strings.Contains(err.Error(), "context") {
+		t.Errorf("expected cancellation error, got %v", err)
+	}
+}
+
+func TestCompleteWithSystem_Timeout(t *testing.T) {
+	c := New(
+		WithTimeout(50*time.Millisecond),
+		WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			return fakeCmd(ctx, "exec sleep 5")
+		}),
+	)
+
+	var got map[string]any
+	err := c.Complete(context.Background(), "hi", &got)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+// --- Argv shape (verified against google-gemini/gemini-cli headless mode) ---
+
+func TestCompleteWithSystem_ArgvShape(t *testing.T) {
+	// Production argv shape against the real gemini binary:
+	//   gemini --output-format json [-m M] [extras...] -p <prompt>
+	// We deliberately do NOT use --output-format stream-json: that
+	// emits JSONL telemetry events not a single result, mirroring why
+	// codex avoids --json.
+	var captured [][]string
+	c := New(
+		WithExtraArgs("--yolo"),
+		WithCommandFactory(writingFactory(`{}`, &captured)),
+	)
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "you are a judge", "do the thing", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 invocation, got %d", len(captured))
+	}
+	run := captured[0]
+	if run[0] != "gemini" {
+		t.Errorf("binary = %q, want gemini", run[0])
+	}
+	joined := strings.Join(run, " ")
+	if !strings.Contains(joined, "--output-format json") {
+		t.Errorf("argv must contain --output-format json: %s", joined)
+	}
+	if strings.Contains(joined, "stream-json") {
+		t.Errorf("argv must NOT contain stream-json (it streams JSONL events, not structured output): %s", joined)
+	}
+	if !strings.Contains(joined, "--yolo") {
+		t.Errorf("argv missing extra arg: %s", joined)
+	}
+	// Prompt is passed via -p; the prompt text is the last arg and
+	// contains both system + user prompt (bundled, no markers).
+	promptVal := flagValue(run[1:], "-p")
+	if promptVal == "" {
+		t.Errorf("-p has no value: %v", run)
+	}
+	if !strings.Contains(promptVal, "you are a judge") {
+		t.Errorf("-p arg %q must contain system prompt", promptVal)
+	}
+	if !strings.Contains(promptVal, "do the thing") {
+		t.Errorf("-p arg %q must contain user prompt", promptVal)
+	}
+}
+
+func TestCompleteWithSystem_WithModelAddsFlag(t *testing.T) {
+	var captured [][]string
+	c := New(
+		WithModel("gemini-2.5-pro"),
+		WithCommandFactory(writingFactory(`{}`, &captured)),
+	)
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "", "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Model() != "gemini-2.5-pro" {
+		t.Errorf("client Model() = %q, want gemini-2.5-pro", c.Model())
+	}
+	joined := strings.Join(captured[0], " ")
+	if !strings.Contains(joined, "-m gemini-2.5-pro") {
+		t.Errorf("captured args missing -m gemini-2.5-pro: %v", captured[0])
+	}
+}
+
+func TestCompleteWithSystem_NoModelSkipsFlag(t *testing.T) {
+	var captured [][]string
+	c := New(WithCommandFactory(writingFactory(`{}`, &captured)))
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "", "p", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, a := range captured[0] {
+		if a == "-m" {
+			t.Errorf("client without WithModel must not add -m flag: %v", captured[0])
+		}
+	}
+}
+
+func TestCompleteWithSystem_NoSystemPromptKeepsPromptClean(t *testing.T) {
+	// When system is empty, the -p arg is the user prompt verbatim.
+	var captured [][]string
+	c := New(WithCommandFactory(writingFactory(`{}`, &captured)))
+
+	var got map[string]any
+	if err := c.CompleteWithSystem(context.Background(), "", "just the prompt", &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	promptVal := flagValue(captured[0][1:], "-p")
+	if promptVal != "just the prompt" {
+		t.Errorf("expected -p value to equal user prompt verbatim when system empty, got %q", promptVal)
+	}
+}
+
+// --- Tool use (schema injected into system prompt — no native flag) ---
+
+func TestCompleteWithTool_SchemaInjectedIntoPrompt(t *testing.T) {
+	// CompleteWithTool must (a) inject the tool's InputSchema into the
+	// system prompt (no native --output-schema in gemini-cli — tracked
+	// at google-gemini/gemini-cli#5021) and (b) parse the .response
+	// field into the target.
+	var captured [][]string
+
+	schemaJSON := `{"type":"object","properties":{"verdict":{"type":"string"},"score":{"type":"number"}},"required":["verdict","score"]}`
+	tool := claude.Tool{
+		Name:        "verdict",
+		Description: "judge verdict",
+		InputSchema: json.RawMessage(schemaJSON),
+	}
+
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		captured = append(captured, append([]string{name}, args...))
+		return stdoutCmd(ctx, envelopeOut(`{"verdict":"pass","score":0.9}`), "", 0)
+	}))
+
+	var got struct {
+		Verdict string  `json:"verdict"`
+		Score   float64 `json:"score"`
+	}
+	if err := c.CompleteWithTool(context.Background(), "you are a judge", "judge it", tool, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Verdict != "pass" || got.Score != 0.9 {
+		t.Errorf("got %+v, want {pass 0.9}", got)
+	}
+	promptVal := flagValue(captured[0][1:], "-p")
+	if !strings.Contains(promptVal, schemaJSON) {
+		t.Errorf("-p value must contain InputSchema verbatim, got %q", promptVal)
+	}
+	if !strings.Contains(promptVal, "you are a judge") {
+		t.Errorf("-p value must still contain caller's system prompt, got %q", promptVal)
+	}
+}
+
+func TestCompleteWithTool_RecoveryOnDecodeFailure(t *testing.T) {
+	// First call returns prose (model ignored the schema-in-prompt
+	// guidance, which can happen). Client must retry once with a
+	// recovery prompt and parse the second response.
+	tool := claude.Tool{
+		Name:        "answer",
+		Description: "give answer",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"x":{"type":"integer"}}}`),
+	}
+
+	calls := 0
+	var capturedPrompts []string
+	c := New(WithCommandFactory(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls++
+		capturedPrompts = append(capturedPrompts, flagValue(args, "-p"))
+		switch calls {
+		case 1:
+			return stdoutCmd(ctx, envelopeOut("sure thing! the answer is x=7"), "", 0)
+		default:
+			return stdoutCmd(ctx, envelopeOut(`{"x":7}`), "", 0)
+		}
+	}))
+
+	var got struct {
+		X int `json:"x"`
+	}
+	if err := c.CompleteWithTool(context.Background(), "", "what is x?", tool, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.X != 7 {
+		t.Errorf("got %+v, want {7}", got)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 subprocess calls (initial + recovery), got %d", calls)
+	}
+	if !strings.Contains(capturedPrompts[1], "x=7") {
+		t.Errorf("recovery prompt should include the original prose, got %q", capturedPrompts[1])
+	}
+}
+
+func TestCompleteWithTools_RoutesToFinalTool(t *testing.T) {
+	c := New(WithCommandFactory(writingFactory(`{"verdict":"pass"}`, nil)))
+
+	tools := []claude.Tool{
+		{
+			Name:        "check_path",
+			Description: "auxiliary",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		{
+			Name:        "verdict",
+			Description: "final",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"verdict":{"type":"string"}}}`),
+		},
+	}
+
+	var got struct {
+		Verdict string `json:"verdict"`
+	}
+	if err := c.CompleteWithTools(context.Background(), "", "p", tools, "verdict", nil, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Verdict != "pass" {
+		t.Errorf("got %+v, want {pass}", got)
+	}
+}
+
+func TestCompleteWithTools_UnknownFinalToolErrors(t *testing.T) {
+	c := New(WithCommandFactory(writingFactory(`{}`, nil)))
+
+	tools := []claude.Tool{{Name: "verdict", InputSchema: json.RawMessage(`{}`)}}
+
+	var got map[string]any
+	err := c.CompleteWithTools(context.Background(), "", "p", tools, "missing_tool", nil, &got)
+	if err == nil {
+		t.Fatalf("expected error for unknown final tool")
+	}
+	if !strings.Contains(err.Error(), "missing_tool") {
+		t.Errorf("error should name the missing tool, got %v", err)
+	}
+}
+
+// --- Compile-time interface check ---
+
+func TestClient_HasCompleterShape(t *testing.T) {
+	// Compile-time guard mirroring the cmd/vairdict completer
+	// interface. If the interface drifts and this package isn't
+	// updated, the build here breaks immediately rather than failing
+	// later at the wiring site.
+	type completerLike interface {
+		CompleteWithSystem(ctx context.Context, system, prompt string, target any) error
+		CompleteWithTool(ctx context.Context, system, prompt string, tool claude.Tool, target any) error
+		CompleteWithTools(ctx context.Context, system, prompt string, tools []claude.Tool, finalTool string, handlers map[string]claude.ToolHandler, target any) error
+		Model() string
+	}
+	var _ completerLike = (*Client)(nil)
+}
+
+// --- Availability + helpers ---
+
+func TestIsAvailable_SmokeTest(t *testing.T) {
+	_ = IsAvailable()
+}
+
+func TestExtractJSON(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"bare", `{"x":1}`, `{"x":1}`},
+		{"fenced_json", "```json\n{\"x\":1}\n```", `{"x":1}`},
+		{"fenced_plain", "```\n{\"x\":2}\n```", `{"x":2}`},
+		{"padded", "   {\"x\":3}   ", `{"x":3}`},
+		{
+			"preamble_then_fence",
+			"Here is the answer.\n\n```json\n{\"x\":4}\n```",
+			`{"x":4}`,
+		},
+		{
+			"prose_then_bare_object",
+			"Here is the result: {\"x\":6} done.",
+			`{"x":6}`,
+		},
+		{
+			"string_with_braces",
+			`{"msg":"a{b}c","n":7}`,
+			`{"msg":"a{b}c","n":7}`,
+		},
+		{
+			"escaped_quote_in_string",
+			`{"msg":"he said \"hi\"","n":8}`,
+			`{"msg":"he said \"hi\"","n":8}`,
+		},
+		{
+			"nested_object",
+			`prefix {"a":{"b":{"c":9}}} suffix`,
+			`{"a":{"b":{"c":9}}}`,
+		},
+		{
+			// Brace matching ignores braces and fences inside string
+			// literals — same regression coverage as codex/claudecli.
+			"fenced_with_embedded_fence_in_string",
+			"```json\n{\"requirements\":\"see ```html\\nfoo\\n``` for an example\",\"n\":10}\n```",
+			"{\"requirements\":\"see ```html\\nfoo\\n``` for an example\",\"n\":10}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractJSON(tc.in)
+			if got != tc.want {
+				t.Errorf("extractJSON(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildArgs_Shape(t *testing.T) {
+	t.Run("base_no_model_no_extra", func(t *testing.T) {
+		args := buildArgs("", nil, "user prompt")
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "--output-format json") {
+			t.Errorf("missing --output-format json: %s", joined)
+		}
+		if strings.Contains(joined, "stream-json") {
+			t.Errorf("must NOT include stream-json: %s", joined)
+		}
+		if strings.Contains(joined, "-m") {
+			t.Errorf("must not include -m when model empty: %s", joined)
+		}
+		// Prompt is the last arg, via -p.
+		if args[len(args)-2] != "-p" {
+			t.Errorf("second-to-last arg must be -p, got %q (args=%v)", args[len(args)-2], args)
+		}
+		if args[len(args)-1] != "user prompt" {
+			t.Errorf("prompt must be last arg, got %q (args=%v)", args[len(args)-1], args)
+		}
+	})
+
+	t.Run("with_model_and_extra", func(t *testing.T) {
+		args := buildArgs("gemini-2.5-pro", []string{"--yolo"}, "p")
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "-m gemini-2.5-pro") {
+			t.Errorf("missing -m gemini-2.5-pro: %s", joined)
+		}
+		if !strings.Contains(joined, "--yolo") {
+			t.Errorf("missing extra arg: %s", joined)
+		}
+		if args[len(args)-1] != "p" {
+			t.Errorf("prompt must be last arg, got %q (args=%v)", args[len(args)-1], args)
+		}
+	})
+}
+
+func TestBundlePrompt(t *testing.T) {
+	if got := bundlePrompt("", "user"); got != "user" {
+		t.Errorf("empty system: got %q, want %q", got, "user")
+	}
+	got := bundlePrompt("sys", "user")
+	if !strings.Contains(got, "sys") || !strings.Contains(got, "user") {
+		t.Errorf("bundle missing parts: %q", got)
+	}
+	if strings.Contains(got, "[system]") || strings.Contains(got, "[user]") {
+		t.Errorf("bundlePrompt must not invent role markers: %q", got)
+	}
+}
+
+func TestBundleSchema(t *testing.T) {
+	tool := claude.Tool{
+		Name:        "x",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"y":{"type":"integer"}}}`),
+	}
+	// Empty system: schema-only output.
+	got := bundleSchema("", tool)
+	if !strings.Contains(got, `"type":"object"`) {
+		t.Errorf("bundleSchema must inline the InputSchema, got %q", got)
+	}
+	// With system: caller's system prompt is preserved alongside schema.
+	got = bundleSchema("you are a judge", tool)
+	if !strings.Contains(got, "you are a judge") {
+		t.Errorf("bundleSchema must preserve caller system prompt, got %q", got)
+	}
+	if !strings.Contains(got, `"type":"object"`) {
+		t.Errorf("bundleSchema must inline the InputSchema, got %q", got)
+	}
+}

--- a/plans/PROGRESS.md
+++ b/plans/PROGRESS.md
@@ -13,10 +13,10 @@ real SQLite contention bug along the way. M6 work continues.
 ---
 
 ## Ready to Start
-- #127 agents/gemini: Gemini CLI completer
 - #88 config/standards: team standards in vairdict.yaml
 
 ## In Progress
+- #127 agents/gemini: Gemini CLI completer
 
 ## Blocked
 - #130 resolver: extend auto backend resolver — needs #126 + #127


### PR DESCRIPTION
## Summary

Closes #127. Adds `gemini` as a third completer family alongside `claude-{cli,api}` and `codex`, letting users with Google's Gemini CLI installed run the planner and judges without Anthropic credentials.

- New `internal/agents/gemini` package mirroring the codex client shape: `Client`, `New`, `IsAvailable`, `Model`, `Complete*`, typed errors (`NotInstalledError`, `ParseError`, `ExitError`), and options (`WithTimeout`, `WithCommandFactory`, `WithExtraArgs`, `WithModel`).
- Subprocess invokes `gemini --output-format json [-m MODEL] [extras...] -p <prompt>`. Stdout envelope (`{"response": "...", "stats": {...}, "error": null}`) is decoded, `.response` is JSON-extracted, then unmarshalled into the caller's target.
- Tool use injects `tool.InputSchema` into the system prompt because gemini-cli has no native `--output-schema` flag (tracked at google-gemini/gemini-cli#5021). Single-recovery round-trip on parse failure, matching codex.
- Resolver wiring in `cmd/vairdict/completer.go`: `agents.planner: gemini` / `agents.judge: gemini` (and per-phase overrides) construct the new client; `validateBackends` errors when `gemini` isn't on PATH.

### Deferred AC bullet

The AC includes *"Registers with the backend registry from #130 in an `init()`"*, but #130 explicitly depends on #127 (per `plans/PROGRESS.md` and #130's own description: *"In practice this likely lands as one PR that introduces the registry and migrates all five existing/new families to it"*). Matching the codex precedent (switch-statement resolver entries); #130 will migrate codex and gemini onto the registry in one go.

## Test plan

- [x] Unit tests for the gemini package — fake subprocess via `CommandFactory`, no real binary in CI. Covers happy path, envelope decode failures, envelope `error` field, empty/missing response, tool-use schema injection, parse-recovery round-trip, argv shape, model flag wiring, context cancellation, timeout, NotInstalled/Exit errors, `extractJSON` table, compile-time interface guard.
- [x] Resolver tests in `cmd/vairdict/completer_test.go` — `chooseBackend` accepts `gemini`, `resolveCompleter` constructs `*gemini.Client` for every completer role with model plumbing intact, `validateBackends` errors when the binary is missing and passes when present, `seedCLISession`/`captureCLISession` are no-ops for gemini.
- [x] `make test` — every package green.
- [x] `make lint` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)